### PR TITLE
hold back more data like poolhashrate and clean non used data / Add range option for hashrate chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ https://github.com/warioishere/blitzpool-message-encryptor-for-TG
 - Integrated `blockTemplateInterval` configuration
 - Hashrate corrections and updated statistics endpoints
 - Extended `/api/info/chart` endpoint with a `range` query supporting `1d`, `1m`, `6m` and `12m`
-- Statistics are retained for up to one year by aggregating old entries
-- Detailed worker statistics are pruned after 14 days to save disk space
+- Statistics are retained for up to one year by aggregating old pool hashrate
+- Worker totals are kept for six months while session details are pruned after one day
 - Example: `GET /api/info/chart?range=6m` returns six months of pool hashrate data (defaults to `1d`)
 - Telegram bot subscriptions managed via a custom ORM
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ https://github.com/warioishere/blitzpool-message-encryptor-for-TG
 - Hashrate corrections and updated statistics endpoints
 - Extended `/api/info/chart` endpoint with a `range` query supporting `1d`, `1m`, `6m` and `12m`
 - Statistics are retained for up to one year to enable long-range charts
+- Example: `GET /api/info/chart?range=6m` returns six months of pool hashrate data (defaults to `1d`)
 - Telegram bot subscriptions managed via a custom ORM
 
 #### Blitzpool-UI

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ https://github.com/warioishere/blitzpool-message-encryptor-for-TG
 - Integrated `blockTemplateInterval` configuration
 - Hashrate corrections and updated statistics endpoints
 - Extended `/api/info/chart` endpoint with a `range` query supporting `1d`, `1m`, `6m` and `12m`
-- Statistics are retained for up to one year to enable long-range charts
+- Statistics are retained for up to one year by aggregating old entries
+- Detailed worker statistics are pruned after 14 days to save disk space
 - Example: `GET /api/info/chart?range=6m` returns six months of pool hashrate data (defaults to `1d`)
 - Telegram bot subscriptions managed via a custom ORM
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ https://github.com/warioishere/blitzpool-message-encryptor-for-TG
 #### 🛠️ Extra Services
 - Integrated `blockTemplateInterval` configuration
 - Hashrate corrections and updated statistics endpoints
+- Extended `/api/info/chart` endpoint with a `range` query supporting `1d`, `1m`, `6m` and `12m`
+- Statistics are retained for up to one year to enable long-range charts
 - Telegram bot subscriptions managed via a custom ORM
 
 #### Blitzpool-UI

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -38,19 +38,36 @@ export class ClientStatisticsService {
     }
 
     public async deleteOldStatistics() {
-        const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+        const oneYearAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
 
         return await this.clientStatisticsRepository
             .createQueryBuilder()
             .delete()
             .from(ClientStatisticsEntity)
-            .where('time < :time', { time: oneDayAgo.getTime() })
+            .where('time < :time', { time: oneYearAgo.getTime() })
             .execute();
     }
 
-    public async getChartDataForSite() {
+    public async getChartDataForSite(range: '1d' | '1m' | '6m' | '12m' = '1d') {
 
-        var yesterday = new Date(new Date().getTime() - (24 * 60 * 60 * 1000));
+        let diffDays = 1;
+
+        switch (range) {
+            case '1m':
+                diffDays = 30;
+                break;
+            case '6m':
+                diffDays = 180;
+                break;
+            case '12m':
+                diffDays = 365;
+                break;
+            default:
+                diffDays = 1;
+        }
+
+        const since = new Date(Date.now() - diffDays * 24 * 60 * 60 * 1000);
+        const limit = diffDays * 144;
 
         const query = `
             SELECT
@@ -59,12 +76,12 @@ export class ClientStatisticsService {
             FROM
                 client_statistics_entity AS entry
             WHERE
-                entry.time > ${yesterday.getTime()}
+                entry.time > ${since.getTime()}
             GROUP BY
                 time
             ORDER BY
                 time
-            LIMIT 144;
+            LIMIT ${limit};
 
     `;
 

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -39,10 +39,11 @@ export class ClientStatisticsService {
 
     public async deleteOldStatistics() {
         const now = Date.now();
-        const detailCutoff = new Date(now - 14 * 24 * 60 * 60 * 1000);
+        const detailCutoff = new Date(now - 1 * 24 * 60 * 60 * 1000);
+        const halfYearCutoff = new Date(now - 180 * 24 * 60 * 60 * 1000);
         const yearCutoff = new Date(now - 365 * 24 * 60 * 60 * 1000);
 
-        // Aggregate old statistics so that only pool hashrate is retained
+        // Aggregate old statistics so that only pool hashrate and worker totals are retained
         await this.clientStatisticsRepository.query(`
             INSERT INTO client_statistics_entity (
                 address,
@@ -64,20 +65,51 @@ export class ClientStatisticsService {
                 datetime('now'),
                 datetime('now')
             FROM client_statistics_entity
-            WHERE time < ${detailCutoff.getTime()} AND time >= ${yearCutoff.getTime()} AND NOT (address = 'POOL' AND clientName = 'POOL' AND sessionId = 'POOL')
+            WHERE time < ${detailCutoff.getTime()} AND NOT (address = 'POOL' AND clientName = 'POOL' AND sessionId = 'POOL') AND sessionId != 'AGG'
             GROUP BY time;
         `);
 
-        // Delete detailed records older than two weeks
         await this.clientStatisticsRepository.query(`
-            DELETE FROM client_statistics_entity
-            WHERE time < ${detailCutoff.getTime()} AND NOT (address = 'POOL' AND clientName = 'POOL' AND sessionId = 'POOL');
+            INSERT INTO client_statistics_entity (
+                address,
+                clientName,
+                sessionId,
+                time,
+                shares,
+                acceptedCount,
+                "createdAt",
+                "updatedAt"
+            )
+            SELECT
+                address,
+                clientName,
+                'AGG',
+                ${detailCutoff.getTime()},
+                SUM(shares),
+                SUM(acceptedCount),
+                datetime('now'),
+                datetime('now')
+            FROM client_statistics_entity
+            WHERE time < ${detailCutoff.getTime()} AND NOT (sessionId = 'AGG' OR (address = 'POOL' AND clientName = 'POOL' AND sessionId = 'POOL'))
+            GROUP BY address, clientName;
         `);
 
-        // Remove aggregated data older than one year
+        // Delete detailed records older than one day
         await this.clientStatisticsRepository.query(`
             DELETE FROM client_statistics_entity
-            WHERE time < ${yearCutoff.getTime()};
+            WHERE time < ${detailCutoff.getTime()} AND NOT (sessionId = 'AGG' OR (address = 'POOL' AND clientName = 'POOL' AND sessionId = 'POOL'));
+        `);
+
+        // Remove worker aggregates older than six months
+        await this.clientStatisticsRepository.query(`
+            DELETE FROM client_statistics_entity
+            WHERE time < ${halfYearCutoff.getTime()} AND sessionId = 'AGG';
+        `);
+
+        // Remove pool aggregates older than one year
+        await this.clientStatisticsRepository.query(`
+            DELETE FROM client_statistics_entity
+            WHERE time < ${yearCutoff.getTime()} AND address = 'POOL' AND clientName = 'POOL' AND sessionId = 'POOL';
         `);
     }
 
@@ -109,7 +141,7 @@ export class ClientStatisticsService {
             FROM
                 client_statistics_entity AS entry
             WHERE
-                entry.time > ${since.getTime()}
+                entry.time > ${since.getTime()} AND entry.sessionId != 'AGG'
             GROUP BY
                 time
             ORDER BY

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -38,14 +38,47 @@ export class ClientStatisticsService {
     }
 
     public async deleteOldStatistics() {
-        const oneYearAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
+        const now = Date.now();
+        const detailCutoff = new Date(now - 14 * 24 * 60 * 60 * 1000);
+        const yearCutoff = new Date(now - 365 * 24 * 60 * 60 * 1000);
 
-        return await this.clientStatisticsRepository
-            .createQueryBuilder()
-            .delete()
-            .from(ClientStatisticsEntity)
-            .where('time < :time', { time: oneYearAgo.getTime() })
-            .execute();
+        // Aggregate old statistics so that only pool hashrate is retained
+        await this.clientStatisticsRepository.query(`
+            INSERT INTO client_statistics_entity (
+                address,
+                clientName,
+                sessionId,
+                time,
+                shares,
+                acceptedCount,
+                "createdAt",
+                "updatedAt"
+            )
+            SELECT
+                'POOL',
+                'POOL',
+                'POOL',
+                time,
+                SUM(shares),
+                SUM(acceptedCount),
+                datetime('now'),
+                datetime('now')
+            FROM client_statistics_entity
+            WHERE time < ${detailCutoff.getTime()} AND time >= ${yearCutoff.getTime()} AND NOT (address = 'POOL' AND clientName = 'POOL' AND sessionId = 'POOL')
+            GROUP BY time;
+        `);
+
+        // Delete detailed records older than two weeks
+        await this.clientStatisticsRepository.query(`
+            DELETE FROM client_statistics_entity
+            WHERE time < ${detailCutoff.getTime()} AND NOT (address = 'POOL' AND clientName = 'POOL' AND sessionId = 'POOL');
+        `);
+
+        // Remove aggregated data older than one year
+        await this.clientStatisticsRepository.query(`
+            DELETE FROM client_statistics_entity
+            WHERE time < ${yearCutoff.getTime()};
+        `);
     }
 
     public async getChartDataForSite(range: '1d' | '1m' | '6m' | '12m' = '1d') {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,5 +1,5 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Controller, Get, Inject } from '@nestjs/common';
+import { Controller, Get, Inject, Query } from '@nestjs/common';
 import { Cache } from 'cache-manager';
 import { firstValueFrom } from 'rxjs';
 
@@ -91,17 +91,17 @@ export class AppController {
   }
 
   @Get('info/chart')
-  public async infoChart() {
+  public async infoChart(@Query('range') range: '1d' | '1m' | '6m' | '12m' = '1d') {
 
 
-    const CACHE_KEY = 'SITE_HASHRATE_GRAPH';
+    const CACHE_KEY = `SITE_HASHRATE_GRAPH_${range}`;
     const cachedResult = await this.cacheManager.get(CACHE_KEY);
 
     if (cachedResult != null) {
       return cachedResult;
     }
 
-    const chartData = await this.clientStatisticsService.getChartDataForSite();
+    const chartData = await this.clientStatisticsService.getChartDataForSite(range);
 
     //10 min
     await this.cacheManager.set(CACHE_KEY, chartData, 10 * 60 * 1000);

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -55,8 +55,8 @@ export class AppService implements OnModuleInit {
     private async deleteOldStatistics() {
         console.log('Deleting statistics');
 
-        const deletedStatistics = await this.clientStatisticsService.deleteOldStatistics();
-        console.log(`Deleted ${deletedStatistics.affected} old statistics`);
+        await this.clientStatisticsService.deleteOldStatistics();
+        console.log('Deleted old statistics');
         const deletedClients = await this.clientService.deleteOldClients();
         console.log(`Deleted ${deletedClients.affected} old clients`);
 


### PR DESCRIPTION
## Summary
- allow query `range` on `/api/info/chart` for more than 24h of data
- implement range logic in `ClientStatisticsService`
- document new API option in README
- keep statistics for one year to enable long-range charts
