### PR TITLE
Fix best diff persistence across restarts

### DIFF
--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -451,13 +451,18 @@ export class StratumV1Client {
             if (this.creatingEntity == null) {
                 this.creatingEntity = new Promise(async (resolve, reject) => {
                     try {
+                        const addressSettings = await this.addressSettingsService.getSettings(
+                            this.clientAuthorization.address,
+                            true,
+                        );
+
                         this.entity = await this.clientService.insert({
                             sessionId: this.extraNonceAndSessionId,
                             address: this.clientAuthorization.address,
                             clientName: this.clientAuthorization.worker,
                             userAgent: this.clientSubscription.userAgent,
                             startTime: new Date(),
-                            bestDifficulty: 0
+                            bestDifficulty: addressSettings?.bestDifficulty ?? 0,
                         });
                     } catch (e) {
                         reject(e);


### PR DESCRIPTION
## Summary
- preserve best difficulty when a client reconnects by initializing it from the address settings
