### PR TITLE
Add share rate series for 7-day chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ https://github.com/warioishere/blitzpool-message-encryptor-for-TG
 #### 🛠️ Extra Services
 - Integrated `blockTemplateInterval` configuration
 - Hashrate corrections and updated statistics endpoints
-- Extended `/api/info/chart` endpoint with a `range` query supporting `1d`, `1m`, `6m` and `12m`
+- Extended `/api/info/chart` endpoint with a `range` query supporting `1d`, `7d`, `1m`, `6m` and `12m`
 - Statistics are retained for up to one year by aggregating old pool hashrate
 - Worker totals are kept for six months while session details are pruned after one day
 - Example: `GET /api/info/chart?range=6m` returns six months of pool hashrate data (defaults to `1d`)
 - Telegram bot subscriptions managed via a custom ORM
+- `GET /api/info/share-rate?minutes=10080` yields a 7-day series of pool share rate values
 
 #### Blitzpool-UI
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ https://github.com/warioishere/blitzpool-message-encryptor-for-TG
 - Worker totals are kept for six months while session details are pruned after one day
 - Example: `GET /api/info/chart?range=6m` returns six months of pool hashrate data (defaults to `1d`)
 - Telegram bot subscriptions managed via a custom ORM
-- `GET /api/info/share-rate` returns a 7‑day series of pool share rates sampled every 5 minutes
+- `GET /api/info/share-rate` returns a 7‑day series of pool share rates (shares per second) sampled every 5 minutes
 
 #### Blitzpool-UI
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ https://github.com/warioishere/blitzpool-message-encryptor-for-TG
 - Worker totals are kept for six months while session details are pruned after one day
 - Example: `GET /api/info/chart?range=6m` returns six months of pool hashrate data (defaults to `1d`)
 - Telegram bot subscriptions managed via a custom ORM
-- `GET /api/info/share-rate?minutes=10080` yields a 7-day series of pool share rate values
+- `GET /api/info/share-rate` returns a 7‑day series of pool share rates sampled every 5 minutes
 
 #### Blitzpool-UI
 

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -392,7 +392,7 @@ export class ClientStatisticsService {
 
         return result.map(res => ({
             label: new Date(res.label).toISOString(),
-            data: Math.floor((parseFloat(res.shares) * 4294967296) / 600)
+            data: Math.floor(parseFloat(res.shares) / 300)
         })).slice(0, result.length - 1);
     }
 }

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -132,7 +132,7 @@ export class ClientStatisticsService {
         }
 
         const since = new Date(Date.now() - diffDays * 24 * 60 * 60 * 1000);
-        const limit = diffDays * 144;
+        const limit = diffDays * 288;
 
         const query = `
             SELECT
@@ -198,7 +198,7 @@ export class ClientStatisticsService {
                     time
                 ORDER BY
                     time
-                LIMIT 144;
+                LIMIT 288;
 
         `;
 
@@ -250,7 +250,7 @@ export class ClientStatisticsService {
                 time
             ORDER BY
                 time
-            LIMIT 144;
+            LIMIT 288;
         `;
 
         const result = await this.clientStatisticsRepository.query(query, [address, clientName]);
@@ -321,7 +321,7 @@ export class ClientStatisticsService {
                 time
             ORDER BY
                 time
-            LIMIT 144;
+            LIMIT 288;
         `;
 
         const result = await this.clientStatisticsRepository.query(query, [address, clientName, sessionId]);
@@ -371,7 +371,7 @@ export class ClientStatisticsService {
 
     public async getShareRateSeriesForSite(minutes: number): Promise<{ label: string, data: number }[]> {
         const since = new Date(Date.now() - minutes * 60 * 1000);
-        const limit = Math.floor(minutes / 10);
+        const limit = Math.floor(minutes / 5);
 
         const query = `
             SELECT

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -368,4 +368,31 @@ export class ClientStatisticsService {
         const totalShares = result?.total ? parseFloat(result.total) : 0;
         return totalShares / (minutes * 60);
     }
+
+    public async getShareRateSeriesForSite(minutes: number): Promise<{ label: string, data: number }[]> {
+        const since = new Date(Date.now() - minutes * 60 * 1000);
+        const limit = Math.floor(minutes / 10);
+
+        const query = `
+            SELECT
+                time AS label,
+                SUM(shares) AS shares
+            FROM
+                client_statistics_entity AS entry
+            WHERE
+                entry.time > ${since.getTime()} AND entry.sessionId != 'AGG'
+            GROUP BY
+                time
+            ORDER BY
+                time
+            LIMIT ${limit};
+        `;
+
+        const result: any[] = await this.clientStatisticsRepository.query(query);
+
+        return result.map(res => ({
+            label: new Date(res.label).toISOString(),
+            data: Math.floor((parseFloat(res.shares) * 4294967296) / 600)
+        })).slice(0, result.length - 1);
+    }
 }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -112,30 +112,16 @@ export class AppController {
   }
 
   @Get('info/share-rate')
-  public async shareRate(@Query('minutes') minutes = '10') {
-    const interval = parseInt(minutes, 10);
-    if (interval > 1440) {
-      const CACHE_KEY = `SITE_SHARE_RATE_SERIES_${interval}`;
-      const cachedResult = await this.cacheManager.get(CACHE_KEY);
-      if (cachedResult != null) {
-        return cachedResult;
-      }
-      const series = await this.clientStatisticsService.getShareRateSeriesForSite(interval);
-      await this.cacheManager.set(CACHE_KEY, series, 10 * 60 * 1000);
-      return series;
-    }
-
-    const CACHE_KEY = `SITE_SHARE_RATE_${interval}`;
+  public async shareRate() {
+    const interval = 7 * 24 * 60;
+    const CACHE_KEY = `SITE_SHARE_RATE_SERIES_${interval}`;
     const cachedResult = await this.cacheManager.get(CACHE_KEY);
     if (cachedResult != null) {
       return cachedResult;
     }
-
-    const rate = await this.clientStatisticsService.getShareRateForSite(interval || 10);
-    const data = { sharesPerSecond: Math.floor(rate) };
-    // 1 min
-    await this.cacheManager.set(CACHE_KEY, data, 1 * 60 * 1000);
-    return data;
+    const series = await this.clientStatisticsService.getShareRateSeriesForSite(interval);
+    await this.cacheManager.set(CACHE_KEY, series, 10 * 60 * 1000);
+    return series;
   }
 
 }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -112,8 +112,8 @@ export class AppController {
   }
 
   @Get('info/share-rate')
-  public async shareRate() {
-    const interval = 7 * 24 * 60;
+  public async shareRate(@Query('minutes') minutes = '10080') {
+    const interval = parseInt(minutes, 10) || (7 * 24 * 60);
     const CACHE_KEY = `SITE_SHARE_RATE_SERIES_${interval}`;
     const cachedResult = await this.cacheManager.get(CACHE_KEY);
     if (cachedResult != null) {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -114,6 +114,17 @@ export class AppController {
   @Get('info/share-rate')
   public async shareRate(@Query('minutes') minutes = '10') {
     const interval = parseInt(minutes, 10);
+    if (interval > 1440) {
+      const CACHE_KEY = `SITE_SHARE_RATE_SERIES_${interval}`;
+      const cachedResult = await this.cacheManager.get(CACHE_KEY);
+      if (cachedResult != null) {
+        return cachedResult;
+      }
+      const series = await this.clientStatisticsService.getShareRateSeriesForSite(interval);
+      await this.cacheManager.set(CACHE_KEY, series, 10 * 60 * 1000);
+      return series;
+    }
+
     const CACHE_KEY = `SITE_SHARE_RATE_${interval}`;
     const cachedResult = await this.cacheManager.get(CACHE_KEY);
     if (cachedResult != null) {
@@ -121,7 +132,7 @@ export class AppController {
     }
 
     const rate = await this.clientStatisticsService.getShareRateForSite(interval || 10);
-    const data = { sharesPerSecond: rate };
+    const data = { sharesPerSecond: Math.floor(rate) };
     // 1 min
     await this.cacheManager.set(CACHE_KEY, data, 1 * 60 * 1000);
     return data;

--- a/src/models/StratumV1ClientStatistics.ts
+++ b/src/models/StratumV1ClientStatistics.ts
@@ -33,8 +33,8 @@ export class StratumV1ClientStatistics {
     // awhile with saveShares()
     public async addShares(client: ClientEntity, targetDifficulty: number) {
 
-        // 10 min
-        var coeff = 1000 * 60 * 10;
+        // 5 min
+        var coeff = 1000 * 60 * 5;
         var date = new Date();
         var timeSlot = new Date(Math.floor(date.getTime() / coeff) * coeff).getTime();
 


### PR DESCRIPTION
## Summary
- allow `/api/info/share-rate` to return a historical series when the interval is larger than one day
- document new share-rate series endpoint
