### PR TITLE
Update statistics retention logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ https://github.com/warioishere/blitzpool-message-encryptor-for-TG
 #### 🛠️ Extra Services
 - Integrated `blockTemplateInterval` configuration
 - Hashrate corrections and updated statistics endpoints
-- Extended `/api/info/chart` endpoint with a `range` query supporting `1d`, `1m`, `6m` and `12m`
-- Statistics are retained for up to one year by aggregating old pool hashrate
-- Worker totals are kept for six months while session details are pruned after one day
-- Example: `GET /api/info/chart?range=6m` returns six months of pool hashrate data (defaults to `1d`)
+- Extended `/api/info/chart` endpoint with a `range` query supporting `1d` and `1m`
+- Pool hashrate statistics are kept for one month
+- Worker shares and total shares per address are kept for six months while session details are pruned after one day
+- Example: `GET /api/info/chart?range=1m` returns one month of pool hashrate data (defaults to `1d`)
 - Telegram bot subscriptions managed via a custom ORM
 
 #### Blitzpool-UI

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -41,7 +41,7 @@ export class ClientStatisticsService {
         const now = Date.now();
         const detailCutoff = new Date(now - 1 * 24 * 60 * 60 * 1000);
         const halfYearCutoff = new Date(now - 180 * 24 * 60 * 60 * 1000);
-        const yearCutoff = new Date(now - 365 * 24 * 60 * 60 * 1000);
+        const monthCutoff = new Date(now - 30 * 24 * 60 * 60 * 1000);
 
         // Aggregate old statistics so that only pool hashrate and worker totals are retained
         await this.clientStatisticsRepository.query(`
@@ -106,26 +106,20 @@ export class ClientStatisticsService {
             WHERE time < ${halfYearCutoff.getTime()} AND sessionId = 'AGG';
         `);
 
-        // Remove pool aggregates older than one year
+        // Remove pool aggregates older than one month
         await this.clientStatisticsRepository.query(`
             DELETE FROM client_statistics_entity
-            WHERE time < ${yearCutoff.getTime()} AND address = 'POOL' AND clientName = 'POOL' AND sessionId = 'POOL';
+            WHERE time < ${monthCutoff.getTime()} AND address = 'POOL' AND clientName = 'POOL' AND sessionId = 'POOL';
         `);
     }
 
-    public async getChartDataForSite(range: '1d' | '1m' | '6m' | '12m' = '1d') {
+    public async getChartDataForSite(range: '1d' | '1m' = '1d') {
 
         let diffDays = 1;
 
         switch (range) {
             case '1m':
                 diffDays = 30;
-                break;
-            case '6m':
-                diffDays = 180;
-                break;
-            case '12m':
-                diffDays = 365;
                 break;
             default:
                 diffDays = 1;

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -91,7 +91,7 @@ export class AppController {
   }
 
   @Get('info/chart')
-  public async infoChart(@Query('range') range: '1d' | '1m' | '6m' | '12m' = '1d') {
+  public async infoChart(@Query('range') range: '1d' | '1m' = '1d') {
 
 
     const CACHE_KEY = `SITE_HASHRATE_GRAPH_${range}`;


### PR DESCRIPTION
## Summary
- shorten storage of pool hashrate to 1 month
- keep worker shares & address totals for 6 months
- adjust `/api/info/chart` to only support `1d` and `1m`
- document new retention policy
