### PR TITLE
Add rejected share tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,6 @@ POOL_IDENTIFIER="Public-Pool"
 
 # Optional block template refresh interval (ms)
 #BLOCK_TEMPLATE_INTERVAL=30000
+
+# Ignore share statistics before this UNIX timestamp in milliseconds (values below 1e12 are treated as seconds)
+#SHARE_STATS_RESET_AFTER=

--- a/README.md
+++ b/README.md
@@ -49,10 +49,13 @@ https://github.com/warioishere/blitzpool-message-encryptor-for-TG
 - Integrated `blockTemplateInterval` configuration
 - Hashrate corrections and updated statistics endpoints
 - Extended `/api/info/chart` endpoint with a `range` query supporting `1d` and `1m`
+- `/api/client/:address/chart` now accepts a `range` query (`1d`, `3d`, `7d`) for up to one week of address hashrate data
 - Pool hashrate statistics are kept for one month
 - Worker shares and total shares per address are kept for six months while session details are pruned after one day
 - Example: `GET /api/info/chart?range=1m` returns one month of pool hashrate data (defaults to `1d`)
 - Telegram bot subscriptions managed via a custom ORM
+- New `/api/info/shares` endpoint returns pool-wide accepted and rejected share totals for 1d, 14d, 1m and since the last block. Counts represent the sum of difficulty‑1 shares.
+- Optional `SHARE_STATS_RESET_AFTER` environment variable allows ignoring statistics before a given UNIX timestamp **in milliseconds** without deleting data (values below `1e12` are treated as seconds)
 
 #### Blitzpool-UI
 
@@ -64,6 +67,16 @@ Blitzpool UI has additional Features to show
 
 - total Shares per address
 - total shares per Worker
+
+### Database Migrations
+
+Run pending TypeORM migrations whenever the database schema changes. After pulling updates, execute:
+
+```bash
+npm run migration:run
+```
+
+The server will also attempt to apply migrations automatically when it starts.
 
 ---
 💬 Contact

--- a/full-setup/blitzpool-example.env
+++ b/full-setup/blitzpool-example.env
@@ -31,3 +31,6 @@ NETWORK=mainnet
 
 API_SECURE=false
 POOL_IDENTIFIER="blitzpool"
+
+# Ignore share statistics before this UNIX timestamp in milliseconds (values below 1e12 are treated as seconds)
+#SHARE_STATS_RESET_AFTER=

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "migration:run": "typeorm-ts-node-commonjs -d src/data-source.ts migration:run"
   },
   "dependencies": {
     "@nestjs/axios": "^3.0.0",

--- a/src/ORM/blocks/blocks.service.ts
+++ b/src/ORM/blocks/blocks.service.ts
@@ -46,4 +46,12 @@ export class BlocksService {
             }
         });
     }
+
+    public async getLatestBlockTime(): Promise<Date | null> {
+        const latest = await this.blocksRepository
+            .createQueryBuilder('block')
+            .orderBy('block.createdAt', 'DESC')
+            .getOne();
+        return latest?.createdAt || null;
+    }
 }

--- a/src/ORM/client-statistics/client-statistics.entity.ts
+++ b/src/ORM/client-statistics/client-statistics.entity.ts
@@ -28,8 +28,11 @@ export class ClientStatisticsEntity extends TrackedEntity {
     @Column({ type: 'real' })
     shares: number;
 
-    @Column({ default: 0, type: 'integer' })
+    @Column({ default: 0, type: 'real' })
     acceptedCount: number;
+
+    @Column({ default: 0, type: 'real' })
+    rejectedCount: number;
 
 
 }

--- a/src/ORM/client-statistics/client-statistics.module.ts
+++ b/src/ORM/client-statistics/client-statistics.module.ts
@@ -1,5 +1,6 @@
 import { Global, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
 
 import { ClientStatisticsEntity } from './client-statistics.entity';
 import { ClientStatisticsService } from './client-statistics.service';
@@ -7,7 +8,7 @@ import { ClientStatisticsService } from './client-statistics.service';
 
 @Global()
 @Module({
-    imports: [TypeOrmModule.forFeature([ClientStatisticsEntity])],
+    imports: [TypeOrmModule.forFeature([ClientStatisticsEntity]), ConfigModule],
     providers: [ClientStatisticsService],
     exports: [TypeOrmModule, ClientStatisticsService],
 })

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
 import { Repository } from 'typeorm';
 
 import { ClientStatisticsEntity } from './client-statistics.entity';
@@ -7,14 +8,19 @@ import { ClientStatisticsEntity } from './client-statistics.entity';
 
 @Injectable()
 export class ClientStatisticsService {
+    private readonly resetAfter: number;
 
     constructor(
-
-
         @InjectRepository(ClientStatisticsEntity)
         private clientStatisticsRepository: Repository<ClientStatisticsEntity>,
+        configService: ConfigService,
     ) {
-
+        const value = configService.get<string>('SHARE_STATS_RESET_AFTER');
+        let parsed = value ? parseInt(value, 10) : 0;
+        if (parsed && parsed < 1e12) {
+            parsed *= 1000; // allow specifying timestamp in seconds
+        }
+        this.resetAfter = parsed;
     }
 
     public async update(clientStatistic: Partial<ClientStatisticsEntity>) {
@@ -28,6 +34,7 @@ export class ClientStatisticsService {
             {
                 shares: clientStatistic.shares,
                 acceptedCount: clientStatistic.acceptedCount,
+                rejectedCount: clientStatistic.rejectedCount,
                 updatedAt: new Date()
             });
 
@@ -52,6 +59,7 @@ export class ClientStatisticsService {
                 time,
                 shares,
                 acceptedCount,
+                rejectedCount,
                 "createdAt",
                 "updatedAt"
             )
@@ -62,6 +70,7 @@ export class ClientStatisticsService {
                 time,
                 SUM(shares),
                 SUM(acceptedCount),
+                SUM(rejectedCount),
                 datetime('now'),
                 datetime('now')
             FROM client_statistics_entity
@@ -77,6 +86,7 @@ export class ClientStatisticsService {
                 time,
                 shares,
                 acceptedCount,
+                rejectedCount,
                 "createdAt",
                 "updatedAt"
             )
@@ -87,6 +97,7 @@ export class ClientStatisticsService {
                 ${detailCutoff.getTime()},
                 SUM(shares),
                 SUM(acceptedCount),
+                SUM(rejectedCount),
                 datetime('now'),
                 datetime('now')
             FROM client_statistics_entity
@@ -176,9 +187,25 @@ export class ClientStatisticsService {
 
     // }
 
-    public async getChartDataForAddress(address: string) {
+    public async getChartDataForAddress(
+        address: string,
+        range: '1d' | '3d' | '7d' = '1d',
+    ) {
 
-        var yesterday = new Date(new Date().getTime() - (24 * 60 * 60 * 1000));
+        let diffDays = 1;
+        switch (range) {
+            case '3d':
+                diffDays = 3;
+                break;
+            case '7d':
+                diffDays = 7;
+                break;
+            default:
+                diffDays = 1;
+        }
+
+        const since = new Date(Date.now() - diffDays * 24 * 60 * 60 * 1000);
+        const limit = diffDays * 144;
 
         const query = `
                 SELECT
@@ -187,21 +214,23 @@ export class ClientStatisticsService {
                 FROM
                     client_statistics_entity AS entry
                 WHERE
-                    entry.address = ? AND entry.time > ${yesterday.getTime()}
+                    entry.address = ? AND entry.time > ${since.getTime()}
                 GROUP BY
                     time
                 ORDER BY
                     time
-                LIMIT 144;
+                LIMIT ${limit};
 
         `;
 
         const result = await this.clientStatisticsRepository.query(query, [address]);
 
-        return result.map(res => {
-            res.label = new Date(res.label).toISOString();
-            return res;
-        }).slice(0, result.length - 1);
+        return result
+            .map(res => {
+                res.label = new Date(res.label).toISOString();
+                return res;
+            })
+            .slice(0, result.length - 1);
 
 
     }
@@ -349,5 +378,63 @@ export class ClientStatisticsService {
 
     public async deleteAll() {
         return await this.clientStatisticsRepository.delete({})
+    }
+
+    private effectiveSince(date: Date): number {
+        const t = date.getTime();
+        return this.resetAfter && this.resetAfter > t ? this.resetAfter : t;
+    }
+
+    private async getTotalsSince(date: Date): Promise<Array<{ address: string, accepted: number, rejected: number }>> {
+        const since = this.effectiveSince(date);
+        const results = await this.clientStatisticsRepository
+            .createQueryBuilder('entry')
+            .select('entry.address', 'address')
+            .addSelect('SUM(entry.acceptedCount)', 'accepted')
+            .addSelect('SUM(entry.rejectedCount)', 'rejected')
+            .where('entry.time >= :since', { since })
+            .andWhere("NOT (entry.address = 'POOL' AND entry.clientName = 'POOL' AND entry.sessionId = 'POOL')")
+            .groupBy('entry.address')
+            .getRawMany();
+        return results.map(r => ({
+            address: r.address,
+            accepted: parseFloat(r.accepted || 0),
+            rejected: parseFloat(r.rejected || 0)
+        }));
+    }
+
+    public async getTotalsLastDays(days: number): Promise<Array<{ address: string, accepted: number, rejected: number }>> {
+        const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+        return this.getTotalsSince(since);
+    }
+
+    public async getTotalsSinceLastBlock(lastBlockTime: Date | null): Promise<Array<{ address: string, accepted: number, rejected: number }>> {
+        const since = lastBlockTime || new Date(0);
+        return this.getTotalsSince(since);
+    }
+
+    private async getPoolTotalsSince(date: Date): Promise<{ accepted: number; rejected: number }> {
+        const since = this.effectiveSince(date);
+        const result = await this.clientStatisticsRepository
+            .createQueryBuilder('entry')
+            .select('SUM(entry.acceptedCount)', 'accepted')
+            .addSelect('SUM(entry.rejectedCount)', 'rejected')
+            .where('entry.time >= :since', { since })
+            .andWhere("NOT (entry.address = 'POOL' AND entry.clientName = 'POOL' AND entry.sessionId = 'POOL')")
+            .getRawOne();
+        return {
+            accepted: parseFloat(result?.accepted || 0),
+            rejected: parseFloat(result?.rejected || 0)
+        };
+    }
+
+    public async getPoolTotalsLastDays(days: number): Promise<{ accepted: number; rejected: number }> {
+        const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+        return this.getPoolTotalsSince(since);
+    }
+
+    public async getPoolTotalsSinceLastBlock(lastBlockTime: Date | null): Promise<{ accepted: number; rejected: number }> {
+        const since = lastBlockTime || new Date(0);
+        return this.getPoolTotalsSince(since);
     }
 }

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -1,0 +1,70 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CacheModule } from '@nestjs/cache-manager';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+
+import { AppController } from './app.controller';
+import { ClientStatisticsModule } from './ORM/client-statistics/client-statistics.module';
+import { ClientStatisticsService } from './ORM/client-statistics/client-statistics.service';
+import { BlocksModule } from './ORM/blocks/blocks.module';
+import { BlocksService } from './ORM/blocks/blocks.service';
+import { ClientService } from './ORM/client/client.service';
+import { BitcoinRpcService } from './services/bitcoin-rpc.service';
+import { AddressSettingsService } from './ORM/address-settings/address-settings.service';
+
+describe('AppController infoShares', () => {
+  let controller: AppController;
+  let stats: ClientStatisticsService;
+  let blocks: BlocksService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        CacheModule.register(),
+        ConfigModule.forRoot(),
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          synchronize: true,
+          autoLoadEntities: true,
+          logging: false
+        }),
+        ClientStatisticsModule,
+        BlocksModule
+      ],
+      controllers: [AppController],
+      providers: [
+        { provide: ClientService, useValue: {} },
+        { provide: BitcoinRpcService, useValue: { newBlock$: { subscribe: () => ({}) } } },
+        { provide: AddressSettingsService, useValue: {} }
+      ]
+    }).compile();
+
+    controller = module.get<AppController>(AppController);
+    stats = module.get<ClientStatisticsService>(ClientStatisticsService);
+    blocks = module.get<BlocksService>(BlocksService);
+  });
+
+  it('returns aggregated share totals', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-01-01T00:00:00Z'));
+    await blocks.save({ height: 1, minerAddress: 'addr1', worker: 'w1', sessionId: 's1', blockData: '00' });
+
+    jest.setSystemTime(new Date('2023-01-01T12:00:00Z'));
+    const time = Math.floor(Date.now() / 600000) * 600000;
+    await stats.insert({ time, shares: 0, acceptedCount: 3, rejectedCount: 1, address: 'addr1', clientName: 'w1', sessionId: 'AGG' });
+    await stats.insert({ time, shares: 0, acceptedCount: 5, rejectedCount: 2, address: 'POOL', clientName: 'POOL', sessionId: 'POOL' });
+
+    const result: any = await controller.infoShares();
+    expect(result).toEqual({
+      accepted1d: 3,
+      rejected1d: 1,
+      accepted14d: 3,
+      rejected14d: 1,
+      accepted30d: 3,
+      rejected30d: 1,
+      acceptedSinceBlock: 0,
+      rejectedSinceBlock: 0
+    });
+    jest.useRealTimers();
+  });
+});

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -108,7 +108,40 @@ export class AppController {
 
     return chartData;
 
+  }
+
+  @Get('info/shares')
+  public async infoShares() {
+    const CACHE_KEY = 'SHARE_INFO';
+    const cached = await this.cacheManager.get(CACHE_KEY);
+    if (cached != null) {
+      return cached;
+    }
+
+    const lastBlockTime = await this.blocksService.getLatestBlockTime();
+
+    const [totals1d, totals14d, totals30d, totalsSinceBlock] = await Promise.all([
+      this.clientStatisticsService.getPoolTotalsLastDays(1),
+      this.clientStatisticsService.getPoolTotalsLastDays(14),
+      this.clientStatisticsService.getPoolTotalsLastDays(30),
+      this.clientStatisticsService.getPoolTotalsSinceLastBlock(lastBlockTime)
+    ]);
+
+    const result = {
+      accepted1d: totals1d.accepted,
+      rejected1d: totals1d.rejected,
+      accepted14d: totals14d.accepted,
+      rejected14d: totals14d.rejected,
+      accepted30d: totals30d.accepted,
+      rejected30d: totals30d.rejected,
+      acceptedSinceBlock: totalsSinceBlock.accepted,
+      rejectedSinceBlock: totalsSinceBlock.rejected
+    };
+
+    await this.cacheManager.set(CACHE_KEY, result, 60 * 1000);
+    return result;
 
   }
 
 }
+

--- a/src/controllers/client/client.controller.spec.ts
+++ b/src/controllers/client/client.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
 
 import { AddressSettingsModule } from '../../ORM/address-settings/address-settings.module';
 import { ClientStatisticsModule } from '../../ORM/client-statistics/client-statistics.module';
@@ -15,6 +16,7 @@ describe('ClientController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [
+        ConfigModule.forRoot(),
         TypeOrmModule.forRoot({
           type: 'sqlite',
           database: ':memory:',

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, NotFoundException, Param } from '@nestjs/common';
+import { Controller, Get, NotFoundException, Param, Query } from '@nestjs/common';
 
 import { AddressSettingsService } from '../../ORM/address-settings/address-settings.service';
 import { ClientStatisticsService } from '../../ORM/client-statistics/client-statistics.service';
@@ -41,8 +41,11 @@ export class ClientController {
     }
 
     @Get(':address/chart')
-    async getClientInfoChart(@Param('address') address: string) {
-        const chartData = await this.clientStatisticsService.getChartDataForAddress(address);
+    async getClientInfoChart(
+        @Param('address') address: string,
+        @Query('range') range: '1d' | '3d' | '7d' = '1d'
+    ) {
+        const chartData = await this.clientStatisticsService.getChartDataForAddress(address, range);
         return chartData;
     }
 

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -1,0 +1,12 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+
+export const AppDataSource = new DataSource({
+    type: 'sqlite',
+    database: './DB/public-pool.sqlite',
+    entities: ['src/**/*.entity.ts'],
+    migrations: ['src/migrations/*.ts'],
+    synchronize: false,
+});
+
+export default AppDataSource;

--- a/src/migrations/1720986000000-AddRejectedCount.ts
+++ b/src/migrations/1720986000000-AddRejectedCount.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRejectedCount1720986000000 implements MigrationInterface {
+  name = 'AddRejectedCount1720986000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "client_statistics_entity" ADD COLUMN "rejectedCount" REAL NOT NULL DEFAULT 0`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "client_statistics_entity" DROP COLUMN "rejectedCount"`
+    );
+  }
+}
+

--- a/src/models/ClientStatisticsPersistence.spec.ts
+++ b/src/models/ClientStatisticsPersistence.spec.ts
@@ -1,0 +1,197 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { ConfigModule } from '@nestjs/config';
+
+import { ClientModule } from '../ORM/client/client.module';
+import { ClientService } from '../ORM/client/client.service';
+import { ClientEntity } from '../ORM/client/client.entity';
+import { ClientStatisticsModule } from '../ORM/client-statistics/client-statistics.module';
+import { ClientStatisticsService } from '../ORM/client-statistics/client-statistics.service';
+import { ClientStatisticsEntity } from '../ORM/client-statistics/client-statistics.entity';
+
+describe('Client statistics persistence', () => {
+  let clientService: ClientService;
+  let statsService: ClientStatisticsService;
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot(),
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          synchronize: true,
+          autoLoadEntities: true,
+          logging: false
+        }),
+        ClientModule,
+        ClientStatisticsModule
+      ]
+    }).compile();
+
+    clientService = module.get<ClientService>(ClientService);
+    statsService = module.get<ClientStatisticsService>(ClientStatisticsService);
+    dataSource = module.get<DataSource>(DataSource);
+  });
+
+  it('retains statistics after client removal', async () => {
+    const now = new Date();
+    const client = await clientService.insert({
+      sessionId: 's1',
+      address: 'addr',
+      clientName: 'worker',
+      userAgent: 'ua',
+      startTime: now,
+      firstSeen: now,
+      bestDifficulty: 0
+    });
+    await clientService.insertClients();
+
+    const time = Math.floor(Date.now() / 600000) * 600000;
+    await statsService.insert({
+      time,
+      shares: 0,
+      acceptedCount: 8,
+      rejectedCount: 0,
+      address: client.address,
+      clientName: client.clientName,
+      sessionId: client.sessionId
+    });
+
+    await statsService.insert({
+      time,
+      shares: 0,
+      acceptedCount: 100,
+      rejectedCount: 50,
+      address: 'POOL',
+      clientName: 'POOL',
+      sessionId: 'POOL'
+    });
+
+    await statsService.insert({
+      time,
+      shares: 0,
+      acceptedCount: 4,
+      rejectedCount: 2,
+      address: client.address,
+      clientName: client.clientName,
+      sessionId: 'AGG'
+    });
+
+    await clientService.delete(client.sessionId);
+
+    await dataSource.getRepository(ClientEntity).update(
+      { sessionId: client.sessionId },
+      { deletedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000) }
+    );
+    await clientService.deleteOldClients();
+
+    const repo = dataSource.getRepository(ClientStatisticsEntity);
+    expect(await repo.count()).toBe(3);
+    const totals = await statsService.getTotalsLastDays(1);
+    expect(totals).toEqual([{ address: 'addr', accepted: 12, rejected: 2 }]);
+  });
+
+  it('resets stats using seconds timestamp', async () => {
+    process.env.SHARE_STATS_RESET_AFTER = '1700000000';
+
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot(),
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          synchronize: true,
+          autoLoadEntities: true,
+          logging: false
+        }),
+        ClientStatisticsModule
+      ]
+    }).compile();
+
+    const service = module.get<ClientStatisticsService>(ClientStatisticsService);
+
+    const before = new Date('2023-11-14T21:13:20Z').getTime();
+    const after = new Date('2023-11-14T23:13:20Z').getTime();
+
+    await service.insert({
+      time: before,
+      shares: 0,
+      acceptedCount: 1,
+      rejectedCount: 0,
+      address: 'addr',
+      clientName: 'worker',
+      sessionId: 's1'
+    });
+
+    await service.insert({
+      time: after,
+      shares: 0,
+      acceptedCount: 2,
+      rejectedCount: 1,
+      address: 'addr',
+      clientName: 'worker',
+      sessionId: 's2'
+    });
+
+    jest.useFakeTimers().setSystemTime(new Date('2023-11-15T02:13:20Z'));
+    const totals = await service.getTotalsLastDays(1);
+    jest.useRealTimers();
+
+    expect(totals).toEqual([{ address: 'addr', accepted: 2, rejected: 1 }]);
+
+    delete process.env.SHARE_STATS_RESET_AFTER;
+  });
+
+  it('flushes statistics on client destroy', async () => {
+    const now = new Date();
+    const client = await clientService.insert({
+      sessionId: 's2',
+      address: 'addr',
+      clientName: 'worker',
+      userAgent: 'ua',
+      startTime: now,
+      firstSeen: now,
+      bestDifficulty: 0
+    });
+    await clientService.insertClients();
+
+    const socket = {
+      destroyed: false,
+      writableEnded: false,
+      on: jest.fn(),
+      write: jest.fn(),
+      end: jest.fn()
+    } as unknown as import('net').Socket;
+
+    const empty: any = {};
+    const configService = { get: (k: string) => (k === 'NETWORK' ? 'testnet' : null) } as any;
+    const stratumClient = new (require('./StratumV1Client').StratumV1Client)(
+      socket,
+      empty,
+      empty,
+      clientService,
+      statsService,
+      empty,
+      empty,
+      configService,
+      empty,
+      empty
+    );
+
+    (stratumClient as any).entity = client;
+    (stratumClient as any).statistics = new (require('./StratumV1ClientStatistics').StratumV1ClientStatistics)(statsService);
+
+    await (stratumClient as any).statistics.addRejectedShare(client, 1);
+    await (stratumClient as any).statistics.addRejectedShare(client, 1);
+
+    await stratumClient.destroy();
+
+    const repo = dataSource.getRepository(ClientStatisticsEntity);
+    const rows = await repo.find();
+    expect(rows.length).toBe(1);
+    expect(rows[0].rejectedCount).toBe(2);
+  });
+});

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -112,6 +112,10 @@ export class StratumV1Client {
 
     public async destroy() {
 
+        if (this.entity) {
+            await this.statistics.flush(this.entity);
+        }
+
         const sid = this.entity?.sessionId || this.extraNonceAndSessionId;
         if (sid) {
             await this.clientService.delete(sid);
@@ -392,6 +396,12 @@ export class StratumV1Client {
                     if (!success) {
                         return;
                     }
+                    if (this.stratumInitialized) {
+                        await this.ensureEntity();
+                        if (this.entity) {
+                            await this.statistics.addRejectedShare(this.entity, this.sessionDifficulty);
+                        }
+                    }
                 }
                 break;
             }
@@ -557,8 +567,7 @@ export class StratumV1Client {
     }
 
 
-    private async handleMiningSubmission(submission: MiningSubmitMessage) {
-
+    private async ensureEntity() {
         if (this.entity == null) {
             if (this.creatingEntity == null) {
                 this.creatingEntity = new Promise(async (resolve, reject) => {
@@ -582,11 +591,15 @@ export class StratumV1Client {
                     resolve();
                 });
                 await this.creatingEntity;
-
             } else {
                 await this.creatingEntity;
             }
         }
+    }
+
+    private async handleMiningSubmission(submission: MiningSubmitMessage) {
+
+        await this.ensureEntity();
 
         const submissionHash = submission.hash();
         if(this.miningSubmissionHashes.has(submissionHash)){
@@ -597,6 +610,9 @@ export class StratumV1Client {
             const success = await this.write(err);
             if (!success) {
                 return false;
+            }
+            if (this.entity) {
+                await this.statistics.addRejectedShare(this.entity, this.sessionDifficulty);
             }
             return false;
         }else{
@@ -615,6 +631,9 @@ export class StratumV1Client {
             const success = await this.write(err);
             if (!success) {
                 return false;
+            }
+            if (this.entity) {
+                await this.statistics.addRejectedShare(this.entity, this.sessionDifficulty);
             }
             return false;
         }
@@ -701,6 +720,9 @@ export class StratumV1Client {
             const success = await this.write(err);
             if (!success) {
                 return false;
+            }
+            if (this.entity) {
+                await this.statistics.addRejectedShare(this.entity, this.sessionDifficulty);
             }
 
             return false;

--- a/src/models/StratumV1ClientStatistics.ts
+++ b/src/models/StratumV1ClientStatistics.ts
@@ -8,6 +8,7 @@ export class StratumV1ClientStatistics {
 
     private shares: number = 0;
     private acceptedCount: number = 0;
+    private rejectedCount: number = 0;
 
     private submissionCacheStart: Date;
     private submissionCache: { time: Date, difficulty: number }[] = [];
@@ -53,11 +54,12 @@ export class StratumV1ClientStatistics {
             this.currentTimeSlotTime = new Date();
             this.currentTimeSlot = timeSlot;
             this.shares += targetDifficulty;
-            this.acceptedCount++;
+            this.acceptedCount += targetDifficulty;
             await this.clientStatisticsService.insert({
                 time: this.currentTimeSlot,
                 shares: this.shares,
                 acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
                 address: client.address,
                 clientName: client.clientName,
                 sessionId: client.sessionId
@@ -70,6 +72,7 @@ export class StratumV1ClientStatistics {
                 time: this.currentTimeSlot,
                 shares: this.shares,
                 acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
                 address: client.address,
                 clientName: client.clientName,
                 sessionId: client.sessionId
@@ -80,11 +83,13 @@ export class StratumV1ClientStatistics {
             // Set the new time slot and add incoming shares then insert it
             this.currentTimeSlot = timeSlot;
             this.shares = targetDifficulty;
-            this.acceptedCount = 1
+            this.acceptedCount = targetDifficulty;
+            this.rejectedCount = 0;
             await this.clientStatisticsService.insert({
                 time: this.currentTimeSlot,
                 shares: this.shares,
                 acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
                 address: client.address,
                 clientName: client.clientName,
                 sessionId: client.sessionId
@@ -93,11 +98,12 @@ export class StratumV1ClientStatistics {
         } else if ((date.getTime() - 60 * 1000) > this.lastSave) {
             // If we haven't saved for a minute, update the table
             this.shares += targetDifficulty;
-            this.acceptedCount++;
+            this.acceptedCount += targetDifficulty;
             await this.clientStatisticsService.update({
                 time: this.currentTimeSlot,
                 shares: this.shares,
                 acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
                 address: client.address,
                 clientName: client.clientName,
                 sessionId: client.sessionId
@@ -107,13 +113,93 @@ export class StratumV1ClientStatistics {
             // Accept the shares if none of the prior conditions are met,
             // saving to memory for storing later
             this.shares += targetDifficulty;
-            this.acceptedCount++;
+            this.acceptedCount += targetDifficulty;
 			if(this.shares > 0) {
             const time = new Date().getTime() - this.previousTimeSlotTime.getTime();
             this.hashRate = ((this.previousShares + this.shares) * 4294967296) / (time / 1000);
         }
         }
 
+    }
+
+    public async addRejectedShare(client: ClientEntity, targetDifficulty: number) {
+
+        var coeff = 1000 * 60 * 10;
+        var date = new Date();
+        var timeSlot = new Date(Math.floor(date.getTime() / coeff) * coeff).getTime();
+
+        if (this.currentTimeSlot == null) {
+            this.previousTimeSlotTime = new Date();
+            this.currentTimeSlotTime = new Date();
+            this.currentTimeSlot = timeSlot;
+            this.rejectedCount += targetDifficulty;
+            await this.clientStatisticsService.insert({
+                time: this.currentTimeSlot,
+                shares: this.shares,
+                acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
+                address: client.address,
+                clientName: client.clientName,
+                sessionId: client.sessionId
+            });
+            this.lastSave = new Date().getTime();
+        } else if (this.currentTimeSlot != timeSlot) {
+            await this.clientStatisticsService.update({
+                time: this.currentTimeSlot,
+                shares: this.shares,
+                acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
+                address: client.address,
+                clientName: client.clientName,
+                sessionId: client.sessionId
+            });
+            this.previousShares = this.shares;
+            this.previousTimeSlotTime = this.currentTimeSlotTime;
+            this.currentTimeSlotTime = new Date();
+            this.currentTimeSlot = timeSlot;
+            this.shares = 0;
+            this.acceptedCount = 0;
+            this.rejectedCount = targetDifficulty;
+            await this.clientStatisticsService.insert({
+                time: this.currentTimeSlot,
+                shares: this.shares,
+                acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
+                address: client.address,
+                clientName: client.clientName,
+                sessionId: client.sessionId
+            });
+            this.lastSave = new Date().getTime();
+        } else if ((date.getTime() - 60 * 1000) > this.lastSave) {
+            this.rejectedCount += targetDifficulty;
+            await this.clientStatisticsService.update({
+                time: this.currentTimeSlot,
+                shares: this.shares,
+                acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
+                address: client.address,
+                clientName: client.clientName,
+                sessionId: client.sessionId
+            });
+            this.lastSave = new Date().getTime();
+        } else {
+            this.rejectedCount += targetDifficulty;
+        }
+
+    }
+
+    public async flush(client: ClientEntity) {
+        if (this.currentTimeSlot != null) {
+            await this.clientStatisticsService.update({
+                time: this.currentTimeSlot,
+                shares: this.shares,
+                acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
+                address: client.address,
+                clientName: client.clientName,
+                sessionId: client.sessionId
+            });
+        }
     }
 
     public getSuggestedDifficulty(clientDifficulty: number) {

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -18,6 +18,7 @@ export class AppService implements OnModuleInit {
     }
 
     async onModuleInit() {
+        await this.dataSource.runMigrations();
         // if (process.env.NODE_APP_INSTANCE == '0') {
         //     await this.dataSource.query(`VACUUM;`);
         // }


### PR DESCRIPTION
## Summary
- track rejected share counts in client statistics entity and service
- update client statistics logic to store rejected counts for each time slot
- increment rejected share statistics when a share submission is rejected