### PR TITLE
Restore rejected share stats

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -136,22 +136,15 @@ export class AppController {
     const totals30d = await this.poolShareStatisticsService.getTotalsSince(now - oneDay * 30);
     const totalsSinceBlock = await this.poolShareStatisticsService.getTotalsSince(sinceBlock);
 
-    const rejected1dMap = await this.poolRejectedStatisticsService.getTotalsSince(now - oneDay);
-    const rejected14dMap = await this.poolRejectedStatisticsService.getTotalsSince(now - oneDay * 14);
-    const rejected30dMap = await this.poolRejectedStatisticsService.getTotalsSince(now - oneDay * 30);
-    const rejectedSinceBlockMap = await this.poolRejectedStatisticsService.getTotalsSince(sinceBlock);
-
-    const sum = (m: Record<string, number>) => Object.values(m).reduce((a, b) => a + b, 0);
-
     const data = {
       accepted1d: totals1d.accepted,
-      rejected1d: sum(rejected1dMap),
+      rejected1d: totals1d.rejected,
       accepted14d: totals14d.accepted,
-      rejected14d: sum(rejected14dMap),
+      rejected14d: totals14d.rejected,
       accepted30d: totals30d.accepted,
-      rejected30d: sum(rejected30dMap),
+      rejected30d: totals30d.rejected,
       acceptedSinceBlock: totalsSinceBlock.accepted,
-      rejectedSinceBlock: sum(rejectedSinceBlockMap),
+      rejectedSinceBlock: totalsSinceBlock.rejected,
     };
 
     await this.cacheManager.set(CACHE_KEY, data, 10 * 60 * 1000);

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -596,6 +596,7 @@ export class StratumV1Client {
 
         const submissionHash = submission.hash();
         if(this.miningSubmissionHashes.has(submissionHash)){
+            await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
             await this.poolRejectedStatisticsService.addRejectedShare(eStratumErrorCode[eStratumErrorCode.DuplicateShare], this.sessionDifficulty);
             await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.DuplicateShare], 1);
             const err = new StratumErrorMessage(
@@ -615,6 +616,7 @@ export class StratumV1Client {
 
         // a miner may submit a job that doesn't exist anymore if it was removed by a new block notification (or expired, 5 min)
         if (job == null) {
+            await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
             await this.poolRejectedStatisticsService.addRejectedShare(eStratumErrorCode[eStratumErrorCode.JobNotFound], this.sessionDifficulty);
             await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.JobNotFound], 1);
             const err = new StratumErrorMessage(
@@ -704,6 +706,7 @@ export class StratumV1Client {
             }
 
         } else {
+            await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
             await this.poolRejectedStatisticsService.addRejectedShare(eStratumErrorCode[eStratumErrorCode.LowDifficultyShare], this.sessionDifficulty);
             await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.LowDifficultyShare], 1);
             const err = new StratumErrorMessage(


### PR DESCRIPTION
## Summary
- track rejected shares in `PoolShareStatisticsService` again.
- use pool share totals for `/api/info/shares`
