### PR TITLE
Optimize PoolShareStatisticsService + reduce beginning bestdiff notifications after server restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to **BlitzPool**, a lightweight and open-source Bitcoin mining pool based on the [public-pool](https://github.com/benjamin-wilson/public-pool) project – extended with powerful new features and real-world integrations.
 
-Current Version: **v1.2.1**
+Current Version: **v1.2.2**
 
 🌐 **Live Pool:** [https://blitzpool.yourdevice.ch/#/](https://blitzpool.yourdevice.ch/#/)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "public-pool",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "public-pool",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-pool",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "",
   "author": "",
   "private": true,

--- a/src/ORM/pool-share-statistics/pool-share-statistics.service.ts
+++ b/src/ORM/pool-share-statistics/pool-share-statistics.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Mutex } from 'async-mutex';
@@ -15,56 +16,62 @@ export class PoolShareStatisticsService {
   private mutex = new Mutex();
 
   private currentTimeSlot: number = null;
-  private lastSave: number = null;
   private accepted = 0;
   private rejected = 0;
 
-  private async addShares(accepted: number, rejected: number) {
+  @Interval(60 * 1000)
+  private async flushInterval() {
+    await this.flush();
+  }
+
+  private async handleShare(accepted: number, rejected: number) {
+    const coeff = 1000 * 60 * 10;
+    const now = Date.now();
+    const timeSlot = Math.floor(now / coeff) * coeff;
+
+    if (this.currentTimeSlot === null) {
+      this.currentTimeSlot = timeSlot;
+      const existing = await this.poolShareStatisticsRepository.findOneBy({ time: timeSlot });
+      if (existing) {
+        this.accepted = existing.accepted;
+        this.rejected = existing.rejected;
+      } else {
+        this.accepted = 0;
+        this.rejected = 0;
+      }
+    } else if (this.currentTimeSlot !== timeSlot) {
+      await this.flush();
+      this.currentTimeSlot = timeSlot;
+      const existing = await this.poolShareStatisticsRepository.findOneBy({ time: timeSlot });
+      if (existing) {
+        this.accepted = existing.accepted;
+        this.rejected = existing.rejected;
+      } else {
+        this.accepted = 0;
+        this.rejected = 0;
+      }
+    }
+
+    this.accepted += accepted;
+    this.rejected += rejected;
+  }
+
+  private async flush() {
     await this.mutex.runExclusive(async () => {
-      const coeff = 1000 * 60 * 10;
-      const now = Date.now();
-      const timeSlot = Math.floor(now / coeff) * coeff;
-
       if (this.currentTimeSlot == null) {
-        const existing = await this.poolShareStatisticsRepository.findOneBy({ time: timeSlot });
-        if (existing) {
-          this.currentTimeSlot = existing.time;
-          this.accepted = existing.accepted;
-          this.rejected = existing.rejected;
-          this.lastSave = now;
-        } else {
-          this.currentTimeSlot = timeSlot;
-          this.accepted = 0;
-          this.rejected = 0;
-          await this.insert({ time: this.currentTimeSlot, accepted: 0, rejected: 0 });
-          this.lastSave = now;
-        }
+        return;
       }
-
-      if (this.currentTimeSlot !== timeSlot) {
+      const existing = await this.poolShareStatisticsRepository.findOneBy({ time: this.currentTimeSlot });
+      if (existing) {
         await this.update({ time: this.currentTimeSlot, accepted: this.accepted, rejected: this.rejected });
-        const existing = await this.poolShareStatisticsRepository.findOneBy({ time: timeSlot });
-        if (existing) {
-          this.currentTimeSlot = existing.time;
-          this.accepted = existing.accepted;
-          this.rejected = existing.rejected;
-        } else {
-          this.currentTimeSlot = timeSlot;
-          this.accepted = 0;
-          this.rejected = 0;
-          await this.insert({ time: this.currentTimeSlot, accepted: 0, rejected: 0 });
-        }
-        this.lastSave = now;
-      }
-
-      this.accepted += accepted;
-      this.rejected += rejected;
-
-      if (now - this.lastSave > 60 * 1000) {
-        await this.update({ time: this.currentTimeSlot, accepted: this.accepted, rejected: this.rejected });
-        this.lastSave = now;
+      } else {
+        await this.insert({ time: this.currentTimeSlot, accepted: this.accepted, rejected: this.rejected });
       }
     });
+  }
+
+  private async addShares(accepted: number, rejected: number) {
+    await this.handleShare(accepted, rejected);
   }
 
   public async addAcceptedShare(difficulty: number) {

--- a/src/ORM/pool-share-statistics/pool-share-statistics.service.ts
+++ b/src/ORM/pool-share-statistics/pool-share-statistics.service.ts
@@ -24,32 +24,19 @@ export class PoolShareStatisticsService {
     await this.flush();
   }
 
-  private async handleShare(accepted: number, rejected: number) {
+  private getTimeSlot(): number {
     const coeff = 1000 * 60 * 10;
-    const now = Date.now();
-    const timeSlot = Math.floor(now / coeff) * coeff;
+    return Math.floor(Date.now() / coeff) * coeff;
+  }
+
+  private async handleShare(accepted: number, rejected: number) {
+    const timeSlot = this.getTimeSlot();
 
     if (this.currentTimeSlot === null) {
       this.currentTimeSlot = timeSlot;
-      const existing = await this.poolShareStatisticsRepository.findOneBy({ time: timeSlot });
-      if (existing) {
-        this.accepted = existing.accepted;
-        this.rejected = existing.rejected;
-      } else {
-        this.accepted = 0;
-        this.rejected = 0;
-      }
     } else if (this.currentTimeSlot !== timeSlot) {
       await this.flush();
       this.currentTimeSlot = timeSlot;
-      const existing = await this.poolShareStatisticsRepository.findOneBy({ time: timeSlot });
-      if (existing) {
-        this.accepted = existing.accepted;
-        this.rejected = existing.rejected;
-      } else {
-        this.accepted = 0;
-        this.rejected = 0;
-      }
     }
 
     this.accepted += accepted;
@@ -57,16 +44,31 @@ export class PoolShareStatisticsService {
   }
 
   private async flush() {
+    if (this.currentTimeSlot == null) return;
+
     await this.mutex.runExclusive(async () => {
-      if (this.currentTimeSlot == null) {
-        return;
-      }
+      if (this.accepted === 0 && this.rejected === 0) return;
+
       const existing = await this.poolShareStatisticsRepository.findOneBy({ time: this.currentTimeSlot });
       if (existing) {
-        await this.update({ time: this.currentTimeSlot, accepted: this.accepted, rejected: this.rejected });
+        await this.poolShareStatisticsRepository.update(
+          { time: this.currentTimeSlot },
+          {
+            accepted: existing.accepted + this.accepted,
+            rejected: existing.rejected + this.rejected,
+            updatedAt: new Date(),
+          },
+        );
       } else {
-        await this.insert({ time: this.currentTimeSlot, accepted: this.accepted, rejected: this.rejected });
+        await this.poolShareStatisticsRepository.insert({
+          time: this.currentTimeSlot,
+          accepted: this.accepted,
+          rejected: this.rejected,
+        });
       }
+
+      this.accepted = 0;
+      this.rejected = 0;
     });
   }
 

--- a/src/ORM/telegram-subscriptions/telegram-subscriptions.service.ts
+++ b/src/ORM/telegram-subscriptions/telegram-subscriptions.service.ts
@@ -51,4 +51,12 @@ export class TelegramSubscriptionsService {
             { bestDiffNotificationsEnabled: enabled }
         );
     }
+
+    public async getAllAddresses(): Promise<string[]> {
+        const rows = await this.telegramSubscriptions
+            .createQueryBuilder('sub')
+            .select('DISTINCT sub.address', 'address')
+            .getRawMany();
+        return rows.map(r => r.address);
+    }
 }

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -689,15 +689,14 @@ export class StratumV1Client {
                 console.log(e);
             }
 
-            if (submissionDifficulty > this.entity.bestDifficulty) {
+            const addressSettings = await this.addressSettingsService.getSettings(this.clientAuthorization.address, true);
+            const storedBestDifficulty = addressSettings?.bestDifficulty ?? 0;
 
+            if (submissionDifficulty > this.entity.bestDifficulty && submissionDifficulty > storedBestDifficulty) {
                 await this.notificationService.notifySubscribersBestDiff(this.clientAuthorization.address, submissionDifficulty);
-
                 await this.clientService.updateBestDifficulty(this.entity.sessionId, submissionDifficulty);
+                await this.addressSettingsService.updateBestDifficulty(this.clientAuthorization.address, submissionDifficulty, this.entity.userAgent);
                 this.entity.bestDifficulty = submissionDifficulty;
-                if (submissionDifficulty > (await this.addressSettingsService.getSettings(this.clientAuthorization.address, true)).bestDifficulty) {
-                    await this.addressSettingsService.updateBestDifficulty(this.clientAuthorization.address, submissionDifficulty, this.entity.userAgent);
-                }
             }
 
 

--- a/src/services/telegram.service.ts
+++ b/src/services/telegram.service.ts
@@ -55,6 +55,15 @@ export class TelegramService implements OnModuleInit {
     async onModuleInit(): Promise<void> {
         if (!this.bot) return;
 
+        const addresses = await this.telegramSubscriptionsService.getAllAddresses();
+        if (addresses.length > 0) {
+            const values = await Promise.all(addresses.map(a => this.addressSettingsService.getSettings(a, false)));
+            addresses.forEach((addr, idx) => {
+                const best = values[idx]?.bestDifficulty ?? 0;
+                this.bestDiffCache.set(addr, best);
+            });
+        }
+
         // Telegram Menübefehle registrieren
         await this.bot.setMyCommands([
             { command: '/start', description: 'Zeigt Willkommensnachricht' },
@@ -128,6 +137,8 @@ export class TelegramService implements OnModuleInit {
             const wasSubscribed = existingForChat.some(s => s.address === address);
 
             await this.telegramSubscriptionsService.saveSubscription(msg.chat.id, address);
+            const settings = await this.addressSettingsService.getSettings(address, false);
+            this.bestDiffCache.set(address, settings?.bestDifficulty ?? 0);
 
             if (wasSubscribed) {
                 this.reply(msg.chat.id, {
@@ -309,6 +320,7 @@ I will decrypt it and respond just like with plain text. 🔒`
             }
 
             await this.telegramSubscriptionsService.removeSubscription(chatId, address);
+            this.bestDiffCache.delete(address);
             this.reply(chatId, {
                 de: 'Adresse entfernt.',
                 en: 'Address removed.'
@@ -455,7 +467,12 @@ I will decrypt it and respond just like with plain text. 🔒`
     public async notifySubscribersBestDiff(address: string, submissionDifficulty: number) {
         if (!this.bot || !this.diffNotifications) return;
 
-        const currentBest = this.bestDiffCache.get(address) ?? 0;
+        let currentBest = this.bestDiffCache.get(address);
+        if (currentBest === undefined) {
+            const settings = await this.addressSettingsService.getSettings(address, false);
+            currentBest = settings?.bestDifficulty ?? 0;
+            this.bestDiffCache.set(address, currentBest);
+        }
 
         if (submissionDifficulty > currentBest) {
             this.bestDiffCache.set(address, submissionDifficulty);

--- a/src/services/telegram.service.ts
+++ b/src/services/telegram.service.ts
@@ -479,12 +479,19 @@ I will decrypt it and respond just like with plain text. 🔒`
 
             const subscribers = await this.telegramSubscriptionsService.getSubscriptions(address);
             const subscriberMessages = subscribers
-                .filter(subscriber => subscriber.bestDiffNotificationsEnabled)
-                .map(subscriber => {
-                    const msg = this.getLanguage(subscriber.telegramChatId) === 'de'
-                        ? `🏆 Neue beste Difficulty für deine Adresse!\nWert: ${this.numberSuffix.to(submissionDifficulty)}`
-                        : `🏆 New best difficulty for your address!\nValue: ${this.numberSuffix.to(submissionDifficulty)}`;
-                    return this.bot.sendMessage(subscriber.telegramChatId, msg);
+                .filter(sub => sub.bestDiffNotificationsEnabled)
+                .map(async sub => {
+                    const chatSubs = await this.telegramSubscriptionsService.getChatSubscriptions(sub.telegramChatId);
+                    const includeAddress = chatSubs.length > 1;
+                    const formatted = this.formatAddress(address);
+                    const msg = this.getLanguage(sub.telegramChatId) === 'de'
+                        ? includeAddress
+                            ? `🏆 Neue beste Difficulty für Adresse ${formatted}!\nWert: ${this.numberSuffix.to(submissionDifficulty)}`
+                            : `🏆 Neue beste Difficulty für deine Adresse!\nWert: ${this.numberSuffix.to(submissionDifficulty)}`
+                        : includeAddress
+                            ? `🏆 New best difficulty for address ${formatted}!\nValue: ${this.numberSuffix.to(submissionDifficulty)}`
+                            : `🏆 New best difficulty for your address!\nValue: ${this.numberSuffix.to(submissionDifficulty)}`;
+                    return this.bot.sendMessage(sub.telegramChatId, msg);
                 });
 
             Promise.all(subscriberMessages).then();


### PR DESCRIPTION
## Summary
- collect accepted/rejected shares in memory
- periodically persist pooled share stats
- stop telegram bestdiff spam after server restart. Only show new total best diffs per address
