### PR TITLE
Handle failed difficulty adjustment writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to **BlitzPool**, a lightweight and open-source Bitcoin mining pool based on the [public-pool](https://github.com/benjamin-wilson/public-pool) project – extended with powerful new features and real-world integrations.
 
-Current Version: **v1.2.2**
+Current Version: **v1.2.3**
 
 🌐 **Live Pool:** [https://blitzpool.yourdevice.ch/#/](https://blitzpool.yourdevice.ch/#/)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "public-pool",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "public-pool",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-pool",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "",
   "author": "",
   "private": true,

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -774,7 +774,10 @@ export class StratumV1Client {
             }) + '\n';
 
 
-            await this.socket.write(data);
+            const success = await this.write(data);
+            if (!success) {
+                return;
+            }
 
             const jobTemplate = await firstValueFrom(this.stratumV1JobsService.newMiningJob$);
             // we need to clear the jobs so that the difficulty set takes effect. Otherwise the different miner implementations can cause issues

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -814,14 +814,14 @@ export class StratumV1Client {
                 return true;
             } else {
                 console.error(`Error: Cannot write to closed or ended socket. ${this.extraNonceAndSessionId} ${message}`);
-                this.destroy();
+                await this.destroy();
                 if (!this.socket.destroyed) {
                     this.socket.destroy();
                 }
                 return false;
             }
         } catch (error) {
-            this.destroy();
+            await this.destroy();
             if (!this.socket.writableEnded) {
                 await this.socket.end();
             } else if (!this.socket.destroyed) {

--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -88,7 +88,10 @@ export class StratumV1Service implements OnModuleInit {
         socket.destroy();
       });
 
-      socket.on('error', async (error: Error) => { });
+      socket.on('error', async (error: Error) => {
+        console.error('Socket error', error);
+        socket.destroy();
+      });
 
       //   //console.log(`Client disconnected, socket error,  ${client.extraNonceAndSessionId}`);
 


### PR DESCRIPTION
## Summary
- use internal `write` helper when notifying clients of new difficulty
- bail out of difficulty adjustment if writing to socket fails
