### PR TITLE
feat: add accepted share statistics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ curl -d "/subscribe 1DEF..." $NTFY_SERVER_URL/myPrefix1ABC...
 - New `/api/info/shares` endpoint provides pool-wide accepted and rejected share totals
 - New `/api/info/rejected` endpoint lists rejected share reasons pool-wide (supports `range=1d|3d|7d`)
 - New `/api/client/<btc_address>/rejected` shows rejected reasons for a specific address (supports `range=1d|3d|7d`)
+- New `/api/info/accepted` endpoint lists pool-wide accepted share counts per 10-minute slot (supports `range=1d|3d|7d`)
+- New `/api/client/<btc_address>/accepted` shows accepted share counts for a specific address (supports `range=1d|3d|7d`)
 - Old jobs are cleaned after 90 seconds by default (`JOB_RETENTION_MS` can adjust this)
 - Desired share rate per worker can be tuned with `TARGET_SHARES_PER_MINUTE` (default `6`)
 - How often miners are checked for new difficulty can be set via `DIFFICULTY_CHECK_INTERVAL_MS` (default `60000` ms)
@@ -88,8 +90,10 @@ curl -d "/subscribe 1DEF..." $NTFY_SERVER_URL/myPrefix1ABC...
 - `GET /api/info/chart?range=1d|1m` – Returns pool hashrate statistics.
 - `GET /api/info/shares` – Provides pool-wide accepted and rejected share totals.
 - `GET /api/info/rejected?range=1d|3d|7d` – Lists rejected share reasons pool-wide (difficulty weighted).
+- `GET /api/info/accepted?range=1d|3d|7d` – Lists accepted share counts pool-wide per 10-minute slot.
 - `GET /api/info/version` – Returns the BlitzPool version.
 - `GET /api/client/<btc_address>/rejected?range=1d|3d|7d` – Shows rejected reasons for a specific address (counts per share).
+- `GET /api/client/<btc_address>/accepted?range=1d|3d|7d` – Shows accepted share counts for a specific address per 10-minute slot.
 
 #### Blitzpool-UI
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to **BlitzPool**, a lightweight and open-source Bitcoin mining pool based on the [public-pool](https://github.com/benjamin-wilson/public-pool) project – extended with powerful new features and real-world integrations.
 
-Current Version: **v1.2.3**
+Current Version: **v1.2.5**
 
 🌐 **Live Pool:** [https://blitzpool.yourdevice.ch/#/](https://blitzpool.yourdevice.ch/#/)
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ curl -d "/subscribe 1DEF..." $NTFY_SERVER_URL/myPrefix1ABC...
 - New `/api/info/rejected` endpoint lists rejected share reasons pool-wide (supports `range=1d|3d|7d`)
 - New `/api/client/<btc_address>/rejected` shows rejected reasons for a specific address (supports `range=1d|3d|7d`)
 - New `/api/info/accepted` endpoint lists pool-wide accepted share counts per 10-minute slot (supports `range=1d|3d|7d`)
-- New `/api/client/<btc_address>/accepted` shows accepted share counts for a specific address (supports `range=1d|3d|7d`)
+- New `/api/client/<btc_address>/accepted` shows diff-1 weighted accepted share counts for a specific address (supports `range=1d|3d|7d`), unlike the rejected endpoint which reports full-share counts
 - Old jobs are cleaned after 90 seconds by default (`JOB_RETENTION_MS` can adjust this)
 - Desired share rate per worker can be tuned with `TARGET_SHARES_PER_MINUTE` (default `6`)
 - How often miners are checked for new difficulty can be set via `DIFFICULTY_CHECK_INTERVAL_MS` (default `60000` ms)
@@ -93,7 +93,7 @@ curl -d "/subscribe 1DEF..." $NTFY_SERVER_URL/myPrefix1ABC...
 - `GET /api/info/accepted?range=1d|3d|7d` – Lists accepted share counts pool-wide per 10-minute slot.
 - `GET /api/info/version` – Returns the BlitzPool version.
 - `GET /api/client/<btc_address>/rejected?range=1d|3d|7d` – Shows rejected reasons for a specific address (counts per share).
-- `GET /api/client/<btc_address>/accepted?range=1d|3d|7d` – Shows accepted share counts for a specific address per 10-minute slot.
+- `GET /api/client/<btc_address>/accepted?range=1d|3d|7d` – Shows diff-1 weighted accepted share counts for a specific address per 10-minute slot (unlike the rejected endpoint's full-share counts).
 
 #### Blitzpool-UI
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "public-pool",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "public-pool",
-      "version": "1.2.3",
+      "version": "1.2.5",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-pool",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "description": "",
   "author": "",
   "private": true,

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -347,6 +347,20 @@ export class ClientStatisticsService {
 
     }
 
+    public async getAcceptedEntriesSince(address: string, time: number): Promise<Array<{ time: number; accepted: number }>> {
+        const query = this.clientStatisticsRepository
+            .createQueryBuilder('stat')
+            .select('stat.time', 'time')
+            .addSelect('SUM(stat.acceptedCount)', 'accepted')
+            .where('stat.address = :address', { address })
+            .andWhere('stat.time > :time', { time })
+            .groupBy('stat.time')
+            .orderBy('stat.time', 'ASC');
+
+        const result = await query.getRawMany();
+        return result.map(r => ({ time: Number(r.time), accepted: Number(r.accepted) }));
+    }
+
     public async getTotalSharesForAddress(address: string): Promise<number> {
         const result = await this.clientStatisticsRepository
             .createQueryBuilder('entry')

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -347,18 +347,18 @@ export class ClientStatisticsService {
 
     }
 
-    public async getAcceptedEntriesSince(address: string, time: number): Promise<Array<{ time: number; accepted: number }>> {
+    public async getAcceptedEntriesSince(address: string, time: number): Promise<Array<{ time: number; shares: number }>> {
         const query = this.clientStatisticsRepository
             .createQueryBuilder('stat')
             .select('stat.time', 'time')
-            .addSelect('SUM(stat.acceptedCount)', 'accepted')
+            .addSelect('SUM(stat.shares)', 'shares')
             .where('stat.address = :address', { address })
             .andWhere('stat.time > :time', { time })
             .groupBy('stat.time')
             .orderBy('stat.time', 'ASC');
 
         const result = await query.getRawMany();
-        return result.map(r => ({ time: Number(r.time), accepted: Number(r.accepted) }));
+        return result.map(r => ({ time: Number(r.time), shares: Number(r.shares) }));
     }
 
     public async getTotalSharesForAddress(address: string): Promise<number> {

--- a/src/ORM/pool-share-statistics/pool-share-statistics.service.ts
+++ b/src/ORM/pool-share-statistics/pool-share-statistics.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Interval } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, MoreThan } from 'typeorm';
 import { Mutex } from 'async-mutex';
 
 import { PoolShareStatisticsEntity } from './pool-share-statistics.entity';
@@ -118,5 +118,14 @@ export class PoolShareStatisticsService {
       accepted: result?.accepted ? parseFloat(result.accepted) : 0,
       rejected: result?.rejected ? parseFloat(result.rejected) : 0,
     };
+  }
+
+  public async getEntriesSince(
+    time: number,
+  ): Promise<PoolShareStatisticsEntity[]> {
+    return this.poolShareStatisticsRepository.find({
+      where: { time: MoreThan(time) },
+      order: { time: 'ASC' },
+    });
   }
 }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -164,6 +164,44 @@ export class AppController {
 
   }
 
+  @Get('info/accepted')
+  public async infoAccepted(
+    @Query('range') range: '1d' | '3d' | '7d' = '1d',
+  ) {
+    const CACHE_KEY = `POOL_ACCEPTED_STATS_${range}`;
+    const cachedResult = await this.cacheManager.get(CACHE_KEY);
+
+    if (cachedResult != null) {
+      return cachedResult;
+    }
+
+    const now = Date.now();
+    const oneDay = 24 * 60 * 60 * 1000;
+    const days = range === '7d' ? 7 : range === '3d' ? 3 : 1;
+    const sinceTime = now - days * oneDay;
+
+    const entries = await this.poolShareStatisticsService.getEntriesSince(sinceTime);
+    const slotMap = new Map<number, number>();
+    for (const entry of entries) {
+      slotMap.set(entry.time, entry.accepted);
+    }
+
+    const coeff = 1000 * 60 * 10;
+    const startSlot = Math.floor(sinceTime / coeff) * coeff;
+    const endSlot = Math.floor(now / coeff) * coeff;
+    const slotData: { time: string; counts: { accepted: number } }[] = [];
+    for (let t = startSlot; t <= endSlot; t += coeff) {
+      slotData.push({
+        time: new Date(t).toISOString(),
+        counts: { accepted: slotMap.get(t) || 0 },
+      });
+    }
+
+    await this.cacheManager.set(CACHE_KEY, { slotData }, 10 * 60 * 1000);
+
+    return { slotData };
+  }
+
   @Get('info/rejected')
   public async infoRejected(
     @Query('range') range: '1d' | '3d' | '7d' = '1d',

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -77,7 +77,7 @@ export class ClientController {
         const entries = await this.clientStatisticsService.getAcceptedEntriesSince(address, sinceTime);
         const slotMap = new Map<number, number>();
         for (const entry of entries) {
-            slotMap.set(entry.time, entry.accepted);
+            slotMap.set(entry.time, entry.shares);
         }
 
         const coeff = 1000 * 60 * 10;

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -64,6 +64,33 @@ export class ClientController {
         return workerShares.map(ws => ({ workerName: ws.clientName, totalShares: ws.total }));
     }
 
+    @Get(':address/accepted')
+    async getAddressAccepted(
+        @Param('address') address: string,
+        @Query('range') range: '1d' | '3d' | '7d' = '1d'
+    ) {
+        const now = Date.now();
+        const oneDay = 24 * 60 * 60 * 1000;
+        const days = range === '7d' ? 7 : range === '3d' ? 3 : 1;
+        const sinceTime = now - days * oneDay;
+
+        const entries = await this.clientStatisticsService.getAcceptedEntriesSince(address, sinceTime);
+        const slotMap = new Map<number, number>();
+        for (const entry of entries) {
+            slotMap.set(entry.time, entry.accepted);
+        }
+
+        const coeff = 1000 * 60 * 10;
+        const startSlot = Math.floor(sinceTime / coeff) * coeff;
+        const endSlot = Math.floor(now / coeff) * coeff;
+        const slotData: { time: string; counts: { accepted: number } }[] = [];
+        for (let t = startSlot; t <= endSlot; t += coeff) {
+            slotData.push({ time: new Date(t).toISOString(), counts: { accepted: slotMap.get(t) || 0 } });
+        }
+
+        return { slotData };
+    }
+
     @Get(':address/rejected')
     async getAddressRejected(
         @Param('address') address: string,


### PR DESCRIPTION
## Summary
- add getEntriesSince to pool share statistics service
- expose pool accepted statistics via /info/accepted endpoint with 10-minute cache
- add client statistics accepted tracking via /client/:address/accepted endpoint
- document accepted share endpoints in README