### PR TITLE
feat: allow resetting miner sessions by address

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to **BlitzPool**, a lightweight and open-source Bitcoin mining pool based on the [public-pool](https://github.com/benjamin-wilson/public-pool) project – extended with powerful new features and real-world integrations.
 
-Current Version: **v1.2.5**
+Current Version: **v1.2.6**
 
 🌐 **Live Pool:** [https://blitzpool.yourdevice.ch/#/](https://blitzpool.yourdevice.ch/#/)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "public-pool",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "public-pool",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-pool",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "",
   "author": "",
   "private": true,

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -1,10 +1,11 @@
-import { Controller, Get, NotFoundException, Param, Query } from '@nestjs/common';
+import { Controller, Get, NotFoundException, Param, Query, Post } from '@nestjs/common';
 
 import { AddressSettingsService } from '../../ORM/address-settings/address-settings.service';
 import { ClientStatisticsService } from '../../ORM/client-statistics/client-statistics.service';
 import { ClientService } from '../../ORM/client/client.service';
 import { ClientRejectedStatisticsService } from '../../ORM/client-rejected-statistics/client-rejected-statistics.service';
 import { eStratumErrorCode } from '../../models/enums/eStratumErrorCode';
+import { StratumV1Service } from '../../services/stratum-v1.service';
 
 
 @Controller('client')
@@ -14,7 +15,8 @@ export class ClientController {
         private readonly clientService: ClientService,
         private readonly clientStatisticsService: ClientStatisticsService,
         private readonly addressSettingsService: AddressSettingsService,
-        private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService
+        private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
+        private readonly stratumV1Service: StratumV1Service,
     ) { }
 
 
@@ -41,6 +43,12 @@ export class ClientController {
                 })
             )
         }
+    }
+
+    @Post(':address/reset')
+    resetClients(@Param('address') address: string) {
+        this.stratumV1Service.resetClientsForAddress(address);
+        return { status: 'reset' };
     }
 
     @Get(':address/chart')

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -32,6 +32,7 @@ import { DifficultyUtils } from '../utils/difficulty.utils';
 import { PoolShareStatisticsService } from '../ORM/pool-share-statistics/pool-share-statistics.service';
 import { PoolRejectedStatisticsService } from '../ORM/pool-rejected-statistics/pool-rejected-statistics.service';
 import { ClientRejectedStatisticsService } from '../ORM/client-rejected-statistics/client-rejected-statistics.service';
+import { StratumV1Service } from '../services/stratum-v1.service';
 
 
 export class StratumV1Client {
@@ -84,7 +85,8 @@ export class StratumV1Client {
         private readonly poolShareStatisticsService: PoolShareStatisticsService,
         private readonly poolRejectedStatisticsService: PoolRejectedStatisticsService,
         private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
-        private readonly externalSharesService: ExternalSharesService
+        private readonly externalSharesService: ExternalSharesService,
+        private readonly stratumV1Service: StratumV1Service,
     ) {
 
         const networkConfig = this.configService.get('NETWORK');
@@ -121,11 +123,19 @@ export class StratumV1Client {
 
     }
 
+    public get address(): string | undefined {
+        return this.clientAuthorization?.address;
+    }
+
     public async destroy() {
 
         const sid = this.entity?.sessionId || this.extraNonceAndSessionId;
         if (sid) {
             await this.clientService.delete(sid);
+        }
+
+        if (this.clientAuthorization) {
+            this.stratumV1Service.unregisterClient(this.clientAuthorization.address, this);
         }
 
         if (this.stratumSubscription != null) {
@@ -261,6 +271,7 @@ export class StratumV1Client {
                 if (errors.length === 0) {
                     this.clientAuthorization = authorizationMessage;
                     this.authorizeResponse = JSON.stringify(this.clientAuthorization.response()) + '\n';
+                    this.stratumV1Service.registerClient(this.clientAuthorization.address, this);
                 } else {
                     console.error('Authorization validation error');
                     const err = new StratumErrorMessage(

--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -19,6 +19,8 @@ import { ClientRejectedStatisticsService } from '../ORM/client-rejected-statisti
 @Injectable()
 export class StratumV1Service implements OnModuleInit {
 
+  private readonly clientsByAddress = new Map<string, Set<StratumV1Client>>();
+
   constructor(
     private readonly bitcoinRpcService: BitcoinRpcService,
     private readonly clientService: ClientService,
@@ -70,7 +72,8 @@ export class StratumV1Service implements OnModuleInit {
         this.poolShareStatisticsService,
         this.poolRejectedStatisticsService,
         this.clientRejectedStatisticsService,
-        this.externalSharesService
+        this.externalSharesService,
+        this,
       );
 
 
@@ -78,6 +81,7 @@ export class StratumV1Service implements OnModuleInit {
         if (client.extraNonceAndSessionId != null) {
           // Handle socket disconnection
           await client.destroy();
+          this.unregisterClient(client.address, client);
           console.log(`Client ${client.extraNonceAndSessionId} disconnected, hadError?:${hadError}`);
         }
       });
@@ -102,6 +106,46 @@ export class StratumV1Service implements OnModuleInit {
       console.log(`Stratum server is listening on port ${process.env.STRATUM_PORT}`);
     });
 
+  }
+
+  registerClient(address: string, client: StratumV1Client) {
+    if (!address) {
+      return;
+    }
+    if (!this.clientsByAddress.has(address)) {
+      this.clientsByAddress.set(address, new Set());
+    }
+    this.clientsByAddress.get(address).add(client);
+  }
+
+  unregisterClient(address: string | undefined, client: StratumV1Client) {
+    if (!address) {
+      return;
+    }
+    const clients = this.clientsByAddress.get(address);
+    if (!clients) {
+      return;
+    }
+    clients.delete(client);
+    if (clients.size === 0) {
+      this.clientsByAddress.delete(address);
+    }
+  }
+
+  resetClientsForAddress(address: string) {
+    const clients = this.clientsByAddress.get(address);
+    if (!clients) {
+      return;
+    }
+    for (const client of clients) {
+      try {
+        client.socket.end();
+        client.socket.destroy();
+      } catch {
+        // ignore errors while closing sockets
+      }
+    }
+    this.clientsByAddress.delete(address);
   }
 
 }


### PR DESCRIPTION
## Summary
- add `/api/client/:address/reset` endpoint to disconnect miners for an address
- track stratum clients per address and support register/unregister/reset helpers
- register and unregister clients on authorization and disconnect

This is for reseting bestdiff stats for friendspool mining on the upcoming UI Update