### PR TITLE
multiple fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to **BlitzPool**, a lightweight and open-source Bitcoin mining pool based on the [public-pool](https://github.com/benjamin-wilson/public-pool) project – extended with powerful new features and real-world integrations.
 
-Current Version: **v1.2.6**
+Current Version: **v1.2.7**
 
 🌐 **Live Pool:** [https://blitzpool.yourdevice.ch/#/](https://blitzpool.yourdevice.ch/#/)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "public-pool",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "public-pool",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-pool",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "",
   "author": "",
   "private": true,

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -226,7 +226,7 @@ export class ClientStatisticsService {
         return result.map(res => {
             res.label = new Date(res.label).toISOString();
             return res;
-        }).slice(0, result.length - 1);
+        });
 
 
     }

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -132,7 +132,12 @@ export class ClientStatisticsService {
         const query = `
             SELECT
                 time AS label,
-                ROUND(((SUM(shares) * 4294967296) / 600)) AS data
+                SUM((shares * 4294967296) /
+                    CASE
+                        WHEN (strftime('%s', updatedAt) - strftime('%s', createdAt)) < 1 THEN 600
+                        ELSE (strftime('%s', updatedAt) - strftime('%s', createdAt))
+                    END
+                ) AS data
             FROM
                 client_statistics_entity AS entry
             WHERE
@@ -198,12 +203,12 @@ export class ClientStatisticsService {
         const query = `
                 SELECT
                     time label,
-                    CASE
-                        WHEN (MAX(strftime('%s', updatedAt)) - MIN(strftime('%s', createdAt))) < 1
-                            THEN (SUM(shares) * 4294967296) / 600
-                        ELSE (SUM(shares) * 4294967296) /
-                             (MAX(strftime('%s', updatedAt)) - MIN(strftime('%s', createdAt)))
-                    END AS data
+                    SUM((shares * 4294967296) /
+                        CASE
+                            WHEN (strftime('%s', updatedAt) - strftime('%s', createdAt)) < 1 THEN 600
+                            ELSE (strftime('%s', updatedAt) - strftime('%s', createdAt))
+                        END
+                    ) AS data
                 FROM
                     client_statistics_entity AS entry
                 WHERE
@@ -229,11 +234,13 @@ export class ClientStatisticsService {
 
     public async getHashRateForGroup(address: string, clientName: string) {
 
-        var oneHour = new Date(new Date().getTime() - (60 * 60 * 1000));
+        const oneHour = new Date(Date.now() - (60 * 60 * 1000));
 
         const query = `
             SELECT
-            SUM(entry.shares) AS difficultySum
+                SUM(entry.shares) AS difficultySum,
+                MAX(strftime('%s', entry.updatedAt)) AS maxUpdated,
+                MIN(strftime('%s', entry.createdAt)) AS minCreated
             FROM
                 client_statistics_entity AS entry
             WHERE
@@ -242,10 +249,14 @@ export class ClientStatisticsService {
 
         const result = await this.clientStatisticsRepository.query(query, [address, clientName]);
 
+        const { difficultySum = 0, maxUpdated = 0, minCreated = 0 } = result[0] || {};
 
-        const difficultySum = result[0].difficultySum;
+        const totalSeconds = maxUpdated - minCreated;
+        if (difficultySum === 0 || totalSeconds <= 0) {
+            return 0;
+        }
 
-        return (difficultySum * 4294967296) / (600);
+        return (difficultySum * 4294967296) / totalSeconds;
 
     }
 
@@ -255,7 +266,12 @@ export class ClientStatisticsService {
         const query = `
             SELECT
                 time label,
-                (SUM(shares) * 4294967296) / 600 AS data
+                SUM((shares * 4294967296) /
+                    CASE
+                        WHEN (strftime('%s', updatedAt) - strftime('%s', createdAt)) < 1 THEN 600
+                        ELSE (strftime('%s', updatedAt) - strftime('%s', createdAt))
+                    END
+                ) AS data
             FROM
                 client_statistics_entity AS entry
             WHERE
@@ -326,7 +342,12 @@ export class ClientStatisticsService {
         const query = `
             SELECT
                 time label,
-                (SUM(shares) * 4294967296) / 600 AS data
+                SUM((shares * 4294967296) /
+                    CASE
+                        WHEN (strftime('%s', updatedAt) - strftime('%s', createdAt)) < 1 THEN 600
+                        ELSE (strftime('%s', updatedAt) - strftime('%s', createdAt))
+                    END
+                ) AS data
             FROM
                 client_statistics_entity AS entry
             WHERE

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -288,7 +288,7 @@ export class ClientStatisticsService {
         return result.map(res => {
             res.label = new Date(res.label).toISOString();
             return res;
-        }).slice(0, result.length - 1);
+        });
 
 
     }
@@ -364,7 +364,7 @@ export class ClientStatisticsService {
         return result.map(res => {
             res.label = new Date(res.label).toISOString();
             return res;
-        }).slice(0, result.length - 1);
+        });
 
     }
 

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -188,7 +188,7 @@ export class ClientController {
 
         const worker = await this.clientService.getBySessionId(address, workerName, sessionId);
         if (worker == null) {
-            return new NotFoundException();
+            throw new NotFoundException();
         }
         const chartData = await this.clientStatisticsService.getChartDataForSession(worker.address, worker.clientName, worker.sessionId);
 

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -61,16 +61,22 @@ export class ClientController {
 
         const coeff = 1000 * 60 * 10;
         const currentSlot = Math.floor(Date.now() / coeff) * coeff;
+        const currentLabel = new Date(currentSlot).toISOString();
         const liveClients = this.stratumV1Service.getClientsByAddress(address);
-        let liveHashRate = 0;
 
         for (const client of liveClients) {
             if (client.statistics.currentTimeSlot === currentSlot) {
-                liveHashRate += client.statistics.hashRate;
+                const elapsed = Date.now() - client.statistics.currentTimeSlotStart.getTime();
+                const rate = (client.statistics.shares * 4294967296) / (elapsed / 1000);
+                let entry = chartData.find(e => e.label === currentLabel);
+                if (!entry) {
+                    entry = { label: currentLabel, data: 0 };
+                    chartData.push(entry);
+                }
+                entry.data += rate;
             }
         }
 
-        chartData.push({ label: new Date(currentSlot).toISOString(), data: liveHashRate });
         return chartData;
     }
 

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -62,19 +62,14 @@ export class ClientController {
         const coeff = 1000 * 60 * 10;
         const currentSlot = Math.floor(Date.now() / coeff) * coeff;
         const currentLabel = new Date(currentSlot).toISOString();
-        const liveClients = this.stratumV1Service.getClientsByAddress(address);
-
-        for (const client of liveClients) {
-            if (client.statistics.currentTimeSlot === currentSlot) {
-                const elapsed = Date.now() - client.statistics.currentTimeSlotStart.getTime();
-                const rate = (client.statistics.shares * 4294967296) / (elapsed / 1000);
-                let entry = chartData.find(e => e.label === currentLabel);
-                if (!entry) {
-                    entry = { label: currentLabel, data: 0 };
-                    chartData.push(entry);
-                }
-                entry.data += rate;
+        const liveRate = this.stratumV1Service.getCurrentHashRate(address);
+        if (liveRate > 0) {
+            let entry = chartData.find(e => e.label === currentLabel);
+            if (!entry) {
+                entry = { label: currentLabel, data: 0 };
+                chartData.push(entry);
             }
+            entry.data += liveRate;
         }
 
         return chartData;

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -66,10 +66,11 @@ export class ClientController {
         if (liveRate > 0) {
             let entry = chartData.find(e => e.label === currentLabel);
             if (!entry) {
-                entry = { label: currentLabel, data: 0 };
+                entry = { label: currentLabel, data: liveRate };
                 chartData.push(entry);
+            } else {
+                entry.data = liveRate;
             }
-            entry.data += liveRate;
         }
 
         return chartData;

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { Controller, Get, NotFoundException, Param, Query, Post } from '@nestjs/common';
 
 import { AddressSettingsService } from '../../ORM/address-settings/address-settings.service';
@@ -57,6 +58,19 @@ export class ClientController {
         @Query('range') range: '1d' | '3d' | '7d' = '1d'
     ) {
         const chartData = await this.clientStatisticsService.getChartDataForAddress(address, range);
+
+        const coeff = 1000 * 60 * 10;
+        const currentSlot = Math.floor(Date.now() / coeff) * coeff;
+        const liveClients = this.stratumV1Service.getClientsByAddress(address);
+        let liveHashRate = 0;
+
+        for (const client of liveClients) {
+            if (client.statistics.currentTimeSlot === currentSlot) {
+                liveHashRate += client.statistics.hashRate;
+            }
+        }
+
+        chartData.push({ label: new Date(currentSlot).toISOString(), data: liveHashRate });
         return chartData;
     }
 
@@ -91,6 +105,16 @@ export class ClientController {
         const coeff = 1000 * 60 * 10;
         const startSlot = Math.floor(sinceTime / coeff) * coeff;
         const endSlot = Math.floor(now / coeff) * coeff;
+
+        const liveClients = this.stratumV1Service.getClientsByAddress(address);
+        for (const client of liveClients) {
+            const slot = client.statistics.currentTimeSlot;
+            if (slot != null && slot >= startSlot) {
+                const unsavedShares = client.statistics.shares - client.statistics.savedShares;
+                slotMap.set(slot, (slotMap.get(slot) || 0) + unsavedShares);
+            }
+        }
+
         const slotData: { time: string; counts: { accepted: number } }[] = [];
         for (let t = startSlot; t <= endSlot; t += coeff) {
             slotData.push({ time: new Date(t).toISOString(), counts: { accepted: slotMap.get(t) || 0 } });

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -194,7 +194,11 @@ export class StratumV1Client {
 
                     if (this.sessionStart == null) {
                         this.sessionStart = new Date();
-                        this.statistics = new StratumV1ClientStatistics(this.clientStatisticsService, this.configService);
+                        this.statistics = new StratumV1ClientStatistics(
+                            this.clientStatisticsService,
+                            this.configService,
+                            this.stratumV1Service,
+                        );
                         this.extraNonceAndSessionId = this.getRandomHexString();
                         console.log(`New client ID: : ${this.extraNonceAndSessionId}, ${this.socket.remoteAddress}:${this.socket.remotePort}`);
                     }

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -105,21 +105,19 @@ export class StratumV1Client {
         const parsed = parseInt(this.configService.get('DIFFICULTY_CHECK_INTERVAL_MS') ?? '60000');
         this.difficultyCheckIntervalMs = isNaN(parsed) ? 60000 : parsed;
 
-        this.socket.on('data', (data: string) => {
+        this.socket.on('data', async (data: string) => {
             this.buffer += data;
             const lines = this.buffer.split('\n');
             this.buffer = lines.pop() || ''; // Save the last part of the data (incomplete line) to the buffer
 
-            lines
-                .filter(m => m.length > 0)
-                .forEach(async (m) => {
-                    try {
-                        await this.handleMessage(m);
-                    } catch (e) {
-                        this.socket.end();
-                        console.error(e);
-                    }
-                });
+            for (const m of lines.filter(x => x.length > 0)) {
+                try {
+                    await this.handleMessage(m);
+                } catch (e) {
+                    this.socket.end();
+                    console.error(e);
+                }
+            }
         });
 
 

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { ConfigService } from '@nestjs/config';
 import * as bitcoinjs from 'bitcoinjs-lib';
 import { plainToInstance } from 'class-transformer';
@@ -34,6 +35,11 @@ import { PoolRejectedStatisticsService } from '../ORM/pool-rejected-statistics/p
 import { ClientRejectedStatisticsService } from '../ORM/client-rejected-statistics/client-rejected-statistics.service';
 import { StratumV1Service } from '../services/stratum-v1.service';
 
+const NETWORKS: Record<string, bitcoinjs.Network> = {
+    mainnet: bitcoinjs.networks.bitcoin,
+    testnet: bitcoinjs.networks.testnet,
+    regtest: bitcoinjs.networks.regtest,
+};
 
 export class StratumV1Client {
 
@@ -44,10 +50,10 @@ export class StratumV1Client {
     private stratumSubscription: Subscription;
     private backgroundWork: NodeJS.Timer[] = [];
 
-    private statistics: StratumV1ClientStatistics;
+    public statistics: StratumV1ClientStatistics;
     private stratumInitialized = false;
     private usedSuggestedDifficulty = false;
-    private sessionDifficulty: number = 16384;
+    private sessionDifficulty = 16384;
 
     private entity: ClientEntity;
     private creatingEntity: Promise<void>;
@@ -55,13 +61,13 @@ export class StratumV1Client {
     public extraNonceAndSessionId: string;
     public sessionStart: Date;
     public noFee: boolean;
-    public hashRate: number = 0;
+    public hashRate = 0;
 
-    private buffer: string = '';
+    private buffer = '';
 
-    private miningSubmissionHashes = new Set<string>()
-    private extraNonceSubscribed: boolean = false;
-    private sentExtraNonce: boolean = false;
+    private miningSubmissionHashes = new Set<string>();
+    private extraNonceSubscribed = false;
+    private sentExtraNonce = false;
 
     private network: bitcoinjs.networks.Network;
 
@@ -90,22 +96,18 @@ export class StratumV1Client {
     ) {
 
         const networkConfig = this.configService.get('NETWORK');
-        if (networkConfig === 'mainnet') {
-            this.network = bitcoinjs.networks.bitcoin;
-        } else if (networkConfig === 'testnet') {
-            this.network = bitcoinjs.networks.testnet;
-        } else if (networkConfig === 'regtest') {
-            this.network = bitcoinjs.networks.regtest;
-        } else {
+        const network = networkConfig ? NETWORKS[networkConfig] : undefined;
+        if (!network) {
             throw new Error('Invalid network configuration');
         }
+        this.network = network;
 
         const parsed = parseInt(this.configService.get('DIFFICULTY_CHECK_INTERVAL_MS') ?? '60000');
         this.difficultyCheckIntervalMs = isNaN(parsed) ? 60000 : parsed;
 
         this.socket.on('data', (data: string) => {
             this.buffer += data;
-            let lines = this.buffer.split('\n');
+            const lines = this.buffer.split('\n');
             this.buffer = lines.pop() || ''; // Save the last part of the data (incomplete line) to the buffer
 
             lines
@@ -114,7 +116,7 @@ export class StratumV1Client {
                     try {
                         await this.handleMessage(m);
                     } catch (e) {
-                        await this.socket.end();
+                        this.socket.end();
                         console.error(e);
                     }
                 });
@@ -168,7 +170,7 @@ export class StratumV1Client {
             parsedMessage = JSON.parse(message);
         } catch (e) {
             //console.log("Invalid JSON");
-            await this.socket.end();
+            this.socket.end();
             return;
         }
 
@@ -375,7 +377,7 @@ export class StratumV1Client {
 
                 if (this.stratumInitialized == false) {
                     console.log('Submit before initalized');
-                    await this.socket.end();
+                    this.socket.end();
                     return;
                 }
 
@@ -420,7 +422,7 @@ export class StratumV1Client {
             // default: {
             //     console.log("Invalid message");
             //     console.log(parsedMessage);
-            //     await this.socket.end();
+            //     this.socket.end();
             //     return;
             // }
         }
@@ -498,7 +500,7 @@ export class StratumV1Client {
                 }
                 await this.sendNewMiningJob(jobTemplate);
             } catch (e) {
-                await this.socket.end();
+                this.socket.end();
                 console.error(e);
             }
         });
@@ -834,7 +836,7 @@ export class StratumV1Client {
         } catch (error) {
             await this.destroy();
             if (!this.socket.writableEnded) {
-                await this.socket.end();
+                this.socket.end();
             } else if (!this.socket.destroyed) {
                 this.socket.destroy();
             }

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -708,6 +708,7 @@ export class StratumV1Client {
             }
             try {
                 await this.statistics.addShares(this.entity, this.sessionDifficulty);
+                this.hashRate = this.statistics.hashRate;
                 const now = new Date();
                 // only update every minute
                 if (this.entity.updatedAt == null || now.getTime() - this.entity.updatedAt.getTime() > 1000 * 60) {

--- a/src/models/StratumV1ClientStatistics.ts
+++ b/src/models/StratumV1ClientStatistics.ts
@@ -49,6 +49,10 @@ export class StratumV1ClientStatistics {
         return this._currentTimeSlot;
     }
 
+    public get currentTimeSlotStart(): Date {
+        return this.currentTimeSlotTime;
+    }
+
 
     // We don't want to save them here because it can be DB intensive, instead do it every once in
     // awhile with saveShares()

--- a/src/models/StratumV1ClientStatistics.ts
+++ b/src/models/StratumV1ClientStatistics.ts
@@ -74,15 +74,15 @@ export class StratumV1ClientStatistics {
             time: date,
             difficulty: targetDifficulty,
         });
+        this._shares += targetDifficulty;
+        this.acceptedCount++;
 
 
         if (this._currentTimeSlot == null) {
             // First record, insert it
-			this.previousTimeSlotTime = new Date();
+                        this.previousTimeSlotTime = new Date();
             this.currentTimeSlotTime = new Date();
             this._currentTimeSlot = timeSlot;
-            this._shares += targetDifficulty;
-            this.acceptedCount++;
             await this.clientStatisticsService.insert({
                 time: this._currentTimeSlot,
                 shares: this._shares,
@@ -98,13 +98,13 @@ export class StratumV1ClientStatistics {
             // First update the old time slot with the latest data
             await this.clientStatisticsService.update({
                 time: this._currentTimeSlot,
-                shares: this._shares,
-                acceptedCount: this.acceptedCount,
+                shares: this._shares - targetDifficulty,
+                acceptedCount: this.acceptedCount - 1,
                 address: client.address,
                 clientName: client.clientName,
                 sessionId: client.sessionId
             });
-                         this.previousShares = this._shares;
+                         this.previousShares = this._shares - targetDifficulty;
             this.previousTimeSlotTime = this.currentTimeSlotTime;
             this.currentTimeSlotTime = new Date();
             // Set the new time slot and add incoming shares then insert it
@@ -123,8 +123,6 @@ export class StratumV1ClientStatistics {
             this._savedShares = this._shares;
         } else if ((date.getTime() - 30 * 1000) > this.lastSave) {
             // If we haven't saved for ~30 seconds, update the table
-            this._shares += targetDifficulty;
-            this.acceptedCount++;
             await this.clientStatisticsService.update({
                 time: this._currentTimeSlot,
                 shares: this._shares,
@@ -135,15 +133,11 @@ export class StratumV1ClientStatistics {
             });
             this.lastSave = new Date().getTime();
             this._savedShares = this._shares;
-        } else {
-            // Accept the shares if none of the prior conditions are met,
-            // saving to memory for storing later
-            this._shares += targetDifficulty;
-            this.acceptedCount++;
-                        if(this._shares > 0) {
-            const time = new Date().getTime() - this.previousTimeSlotTime.getTime();
-            this.hashRate = ((this.previousShares + this._shares) * 4294967296) / (time / 1000);
         }
+
+        const elapsed = Date.now() - this.previousTimeSlotTime.getTime();
+        if (elapsed > 0) {
+            this.hashRate = ((this.previousShares + this._shares) * 4294967296) / (elapsed / 1000);
         }
 
     }

--- a/src/models/StratumV1ClientStatistics.ts
+++ b/src/models/StratumV1ClientStatistics.ts
@@ -2,6 +2,7 @@
 import { ClientStatisticsService } from '../ORM/client-statistics/client-statistics.service';
 import { ClientEntity } from '../ORM/client/client.entity';
 import { ConfigService } from '@nestjs/config';
+import { StratumV1Service } from '../services/stratum-v1.service';
 
 const CACHE_SIZE = 30;
 const CACHE_WINDOW_SECONDS = 300;
@@ -30,6 +31,7 @@ export class StratumV1ClientStatistics {
     constructor(
         private readonly clientStatisticsService: ClientStatisticsService,
         private readonly configService: ConfigService,
+        private readonly stratumV1Service: StratumV1Service,
     ) {
         this.submissionCacheStart = new Date();
         const tpm = parseFloat(this.configService.get('TARGET_SHARES_PER_MINUTE') ?? '6');
@@ -141,7 +143,12 @@ export class StratumV1ClientStatistics {
 
         const elapsed = Date.now() - this.previousTimeSlotTime.getTime();
         if (elapsed > 0) {
+            const prevRate = this.hashRate;
             this.hashRate = ((this.previousShares + this._shares) * 4294967296) / (elapsed / 1000);
+            this.stratumV1Service.adjustCurrentHashRate(
+                client.address,
+                this.hashRate - prevRate,
+            );
         }
 
     }

--- a/src/models/StratumV1ClientStatistics.ts
+++ b/src/models/StratumV1ClientStatistics.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { ClientStatisticsService } from '../ORM/client-statistics/client-statistics.service';
 import { ClientEntity } from '../ORM/client/client.entity';
 import { ConfigService } from '@nestjs/config';
@@ -7,21 +8,22 @@ const CACHE_WINDOW_SECONDS = 300;
 const MIN_DIFF = 0.00001;
 export class StratumV1ClientStatistics {
 
-    private shares: number = 0;
-    private acceptedCount: number = 0;
+    private _shares = 0;
+    private acceptedCount = 0;
+    private _savedShares = 0;
 
     private submissionCacheStart: Date;
     private submissionCache: { time: Date, difficulty: number }[] = [];
 
-    private currentTimeSlot: number = null;
+    private _currentTimeSlot: number = null;
     private lastSave: number = null;
-	
-	public hashRate = 0;
+
+        public hashRate = 0;
 
     private previousTimeSlotTime: Date;
     private currentTimeSlotTime: Date;
 
-    private previousShares: number = 0;
+    private previousShares = 0;
     private targetSharesPerMinute: number;
     private targetSubmissionPerSecond: number;
 
@@ -35,15 +37,27 @@ export class StratumV1ClientStatistics {
         this.targetSubmissionPerSecond = 60 / this.targetSharesPerMinute;
     }
 
+    public get shares(): number {
+        return this._shares;
+    }
+
+    public get savedShares(): number {
+        return this._savedShares;
+    }
+
+    public get currentTimeSlot(): number {
+        return this._currentTimeSlot;
+    }
+
 
     // We don't want to save them here because it can be DB intensive, instead do it every once in
     // awhile with saveShares()
     public async addShares(client: ClientEntity, targetDifficulty: number) {
 
         // 10 min
-        var coeff = 1000 * 60 * 10;
-        var date = new Date();
-        var timeSlot = new Date(Math.floor(date.getTime() / coeff) * coeff).getTime();
+        const coeff = 1000 * 60 * 10;
+        const date = new Date();
+        const timeSlot = new Date(Math.floor(date.getTime() / coeff) * coeff).getTime();
 
         while (
             this.submissionCache.length &&
@@ -62,70 +76,73 @@ export class StratumV1ClientStatistics {
         });
 
 
-        if (this.currentTimeSlot == null) {
+        if (this._currentTimeSlot == null) {
             // First record, insert it
 			this.previousTimeSlotTime = new Date();
             this.currentTimeSlotTime = new Date();
-            this.currentTimeSlot = timeSlot;
-            this.shares += targetDifficulty;
+            this._currentTimeSlot = timeSlot;
+            this._shares += targetDifficulty;
             this.acceptedCount++;
             await this.clientStatisticsService.insert({
-                time: this.currentTimeSlot,
-                shares: this.shares,
+                time: this._currentTimeSlot,
+                shares: this._shares,
                 acceptedCount: this.acceptedCount,
                 address: client.address,
                 clientName: client.clientName,
                 sessionId: client.sessionId
             });
             this.lastSave = new Date().getTime();
-        } else if (this.currentTimeSlot != timeSlot) {
+            this._savedShares = this._shares;
+        } else if (this._currentTimeSlot != timeSlot) {
             // Transitioning to a new time slot,
             // First update the old time slot with the latest data
             await this.clientStatisticsService.update({
-                time: this.currentTimeSlot,
-                shares: this.shares,
+                time: this._currentTimeSlot,
+                shares: this._shares,
                 acceptedCount: this.acceptedCount,
                 address: client.address,
                 clientName: client.clientName,
                 sessionId: client.sessionId
             });
-			 this.previousShares = this.shares;
+                         this.previousShares = this._shares;
             this.previousTimeSlotTime = this.currentTimeSlotTime;
             this.currentTimeSlotTime = new Date();
             // Set the new time slot and add incoming shares then insert it
-            this.currentTimeSlot = timeSlot;
-            this.shares = targetDifficulty;
+            this._currentTimeSlot = timeSlot;
+            this._shares = targetDifficulty;
             this.acceptedCount = 1
             await this.clientStatisticsService.insert({
-                time: this.currentTimeSlot,
-                shares: this.shares,
+                time: this._currentTimeSlot,
+                shares: this._shares,
                 acceptedCount: this.acceptedCount,
                 address: client.address,
                 clientName: client.clientName,
                 sessionId: client.sessionId
             });
             this.lastSave = new Date().getTime();
-        } else if ((date.getTime() - 60 * 1000) > this.lastSave) {
-            // If we haven't saved for a minute, update the table
-            this.shares += targetDifficulty;
+            this._savedShares = this._shares;
+        } else if ((date.getTime() - 30 * 1000) > this.lastSave) {
+            // If we haven't saved for ~30 seconds, update the table
+            this._shares += targetDifficulty;
             this.acceptedCount++;
             await this.clientStatisticsService.update({
-                time: this.currentTimeSlot,
-                shares: this.shares,
+                time: this._currentTimeSlot,
+                shares: this._shares,
                 acceptedCount: this.acceptedCount,
                 address: client.address,
                 clientName: client.clientName,
                 sessionId: client.sessionId
             });
             this.lastSave = new Date().getTime();
+            this._savedShares = this._shares;
         } else {
             // Accept the shares if none of the prior conditions are met,
             // saving to memory for storing later
-            this.shares += targetDifficulty;
+            this._shares += targetDifficulty;
             this.acceptedCount++;
-			if(this.shares > 0) {
+                        if(this._shares > 0) {
             const time = new Date().getTime() - this.previousTimeSlotTime.getTime();
-            this.hashRate = ((this.previousShares + this.shares) * 4294967296) / (time / 1000);
+            this.hashRate = ((this.previousShares + this._shares) * 4294967296) / (time / 1000);
         }
         }
 

--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -15,10 +15,8 @@ import { PoolShareStatisticsService } from '../ORM/pool-share-statistics/pool-sh
 import { PoolRejectedStatisticsService } from '../ORM/pool-rejected-statistics/pool-rejected-statistics.service';
 import { ClientRejectedStatisticsService } from '../ORM/client-rejected-statistics/client-rejected-statistics.service';
 
-
 @Injectable()
 export class StratumV1Service implements OnModuleInit {
-
   private readonly clientsByAddress = new Map<string, Set<StratumV1Client>>();
 
   constructor(
@@ -33,25 +31,20 @@ export class StratumV1Service implements OnModuleInit {
     private readonly poolShareStatisticsService: PoolShareStatisticsService,
     private readonly poolRejectedStatisticsService: PoolRejectedStatisticsService,
     private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
-    private readonly externalSharesService: ExternalSharesService
-  ) {
-
-  }
+    private readonly externalSharesService: ExternalSharesService,
+  ) {}
 
   async onModuleInit(): Promise<void> {
-
-      if (process.env.NODE_APP_INSTANCE == '0') {
-        await this.clientService.deleteAll();
-      }
-      setTimeout(() => {
-        this.startSocketServer();
-      }, 1000 * 10)
-
+    if (process.env.NODE_APP_INSTANCE === '0') {
+      await this.clientService.deleteAll();
+    }
+    setTimeout(() => {
+      this.startSocketServer();
+    }, 1000 * 10);
   }
 
   private startSocketServer() {
     const server = new Server(async (socket: Socket) => {
-
       // Disable Nagle's algorithm and use UTF-8 encoding for better latency
       socket.setNoDelay(true);
       socket.setEncoding('utf8');
@@ -76,36 +69,32 @@ export class StratumV1Service implements OnModuleInit {
         this,
       );
 
-
       socket.on('close', async (hadError: boolean) => {
         if (client.extraNonceAndSessionId != null) {
           // Handle socket disconnection
           await client.destroy();
-          this.unregisterClient(client.address, client);
-          console.log(`Client ${client.extraNonceAndSessionId} disconnected, hadError?:${hadError}`);
+          console.log(
+            `Client ${client.extraNonceAndSessionId} disconnected, hadError?:${hadError}`,
+          );
         }
       });
 
       socket.on('timeout', () => {
         console.log('socket timeout');
-        socket.end();
         socket.destroy();
       });
 
-      socket.on('error', async (error: Error) => {
+      socket.on('error', (error: Error) => {
         console.error('Socket error', error);
         socket.destroy();
       });
-
-      //   //console.log(`Client disconnected, socket error,  ${client.extraNonceAndSessionId}`);
-
-
     });
 
     server.listen(process.env.STRATUM_PORT, () => {
-      console.log(`Stratum server is listening on port ${process.env.STRATUM_PORT}`);
+      console.log(
+        `Stratum server is listening on port ${process.env.STRATUM_PORT}`,
+      );
     });
-
   }
 
   registerClient(address: string, client: StratumV1Client) {
@@ -139,7 +128,6 @@ export class StratumV1Service implements OnModuleInit {
     }
     for (const client of clients) {
       try {
-        client.socket.end();
         client.socket.destroy();
       } catch {
         // ignore errors while closing sockets
@@ -148,4 +136,7 @@ export class StratumV1Service implements OnModuleInit {
     this.clientsByAddress.delete(address);
   }
 
+  getClientsByAddress(address: string): StratumV1Client[] {
+    return Array.from(this.clientsByAddress.get(address) || []);
+  }
 }

--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -18,6 +18,7 @@ import { ClientRejectedStatisticsService } from '../ORM/client-rejected-statisti
 @Injectable()
 export class StratumV1Service implements OnModuleInit {
   private readonly clientsByAddress = new Map<string, Set<StratumV1Client>>();
+  private readonly liveHashRateByAddress = new Map<string, number>();
 
   constructor(
     private readonly bitcoinRpcService: BitcoinRpcService,
@@ -116,6 +117,7 @@ export class StratumV1Service implements OnModuleInit {
       return;
     }
     clients.delete(client);
+    this.adjustCurrentHashRate(address, -(client.statistics?.hashRate || 0));
     if (clients.size === 0) {
       this.clientsByAddress.delete(address);
     }
@@ -138,5 +140,22 @@ export class StratumV1Service implements OnModuleInit {
 
   getClientsByAddress(address: string): StratumV1Client[] {
     return Array.from(this.clientsByAddress.get(address) || []);
+  }
+
+  adjustCurrentHashRate(address: string, delta: number) {
+    if (!address || !Number.isFinite(delta)) {
+      return;
+    }
+    const current = this.liveHashRateByAddress.get(address) || 0;
+    const next = current + delta;
+    if (next === 0) {
+      this.liveHashRateByAddress.delete(address);
+    } else {
+      this.liveHashRateByAddress.set(address, next);
+    }
+  }
+
+  getCurrentHashRate(address: string): number {
+    return this.liveHashRateByAddress.get(address) || 0;
   }
 }


### PR DESCRIPTION
## Summary
- track persisted shares per slot so in-memory counts only include unsaved work
- combine only unsaved shares from live workers when building accepted-share charts
