### PR TITLE
Skip anomalous rejected shares

### DIFF
--- a/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
+++ b/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
@@ -17,6 +17,7 @@ export class PoolRejectedStatisticsService {
   private currentTimeSlot: number = null;
   private lastSave: number = null;
   private counts: Map<string, number> = new Map();
+  private recentDiffs: Map<string, number[]> = new Map();
 
   @Interval(60 * 1000)
   private async flushInterval() {
@@ -28,8 +29,8 @@ export class PoolRejectedStatisticsService {
     }
   }
 
-  public async addRejectedShare(reason: string, diff: number) {
-    await this.mutex.runExclusive(async () => {
+  public async addRejectedShare(reason: string, diff: number): Promise<boolean> {
+    return await this.mutex.runExclusive(async () => {
       const coeff = 1000 * 60 * 10;
       const now = Date.now();
       const timeSlot = Math.floor(now / coeff) * coeff;
@@ -55,6 +56,21 @@ export class PoolRejectedStatisticsService {
         this.lastSave = now;
       }
 
+      let history = this.recentDiffs.get(reason) || [];
+      if (history.length > 0) {
+        const avg = history.reduce((sum, d) => sum + d, 0) / history.length;
+        if (avg > 0 && diff > avg * 4) {
+          console.warn(`Anomalous diff ${diff} for reason ${reason} (avg ${avg})`);
+          return false;
+        }
+      }
+
+      history.push(diff);
+      if (history.length > 5) {
+        history.shift();
+      }
+      this.recentDiffs.set(reason, history);
+
       const current = this.counts.get(reason) || 0;
       this.counts.set(reason, current + diff);
 
@@ -62,6 +78,8 @@ export class PoolRejectedStatisticsService {
         await this.saveCurrent();
         this.lastSave = now;
       }
+
+      return true;
     });
   }
 

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -603,8 +603,13 @@ export class StratumV1Client {
 
         const submissionHash = submission.hash();
         if(this.miningSubmissionHashes.has(submissionHash)){
-            await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
-            await this.poolRejectedStatisticsService.addRejectedShare(eStratumErrorCode[eStratumErrorCode.DuplicateShare], this.sessionDifficulty);
+            const accepted = await this.poolRejectedStatisticsService.addRejectedShare(
+                eStratumErrorCode[eStratumErrorCode.DuplicateShare],
+                this.sessionDifficulty
+            );
+            if (accepted) {
+                await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
+            }
             await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.DuplicateShare], 1);
             const err = new StratumErrorMessage(
                 submission.id,
@@ -623,8 +628,13 @@ export class StratumV1Client {
 
         // a miner may submit a job that doesn't exist anymore if it was removed by a new block notification (or expired, 5 min)
         if (job == null) {
-            await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
-            await this.poolRejectedStatisticsService.addRejectedShare(eStratumErrorCode[eStratumErrorCode.JobNotFound], this.sessionDifficulty);
+            const accepted = await this.poolRejectedStatisticsService.addRejectedShare(
+                eStratumErrorCode[eStratumErrorCode.JobNotFound],
+                this.sessionDifficulty
+            );
+            if (accepted) {
+                await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
+            }
             await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.JobNotFound], 1);
             const err = new StratumErrorMessage(
                 submission.id,
@@ -640,8 +650,13 @@ export class StratumV1Client {
         const jobTemplate = this.stratumV1JobsService.getJobTemplateById(job.jobTemplateId);
 
         if (jobTemplate == null) {
-            await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
-            await this.poolRejectedStatisticsService.addRejectedShare(eStratumErrorCode[eStratumErrorCode.JobNotFound], this.sessionDifficulty);
+            const accepted = await this.poolRejectedStatisticsService.addRejectedShare(
+                eStratumErrorCode[eStratumErrorCode.JobNotFound],
+                this.sessionDifficulty
+            );
+            if (accepted) {
+                await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
+            }
             await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.JobNotFound], 1);
             console.warn(`Job template ${job.jobTemplateId} not found for job ${submission.jobId}`);
             delete this.stratumV1JobsService.jobs[submission.jobId];
@@ -736,8 +751,13 @@ export class StratumV1Client {
             }
 
         } else {
-            await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
-            await this.poolRejectedStatisticsService.addRejectedShare(eStratumErrorCode[eStratumErrorCode.LowDifficultyShare], this.sessionDifficulty);
+            const accepted = await this.poolRejectedStatisticsService.addRejectedShare(
+                eStratumErrorCode[eStratumErrorCode.LowDifficultyShare],
+                this.sessionDifficulty
+            );
+            if (accepted) {
+                await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
+            }
             await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.LowDifficultyShare], 1);
             const err = new StratumErrorMessage(
                 submission.id,


### PR DESCRIPTION
## Summary
- Guard rejected share stats with anomaly detection to prevent outliers from skewing `api/info/rejected`
- Only update global share totals when a rejection passes anomaly checks
