### PR TITLE
Adapt rejected-share anomaly detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to **BlitzPool**, a lightweight and open-source Bitcoin mining pool based on the [public-pool](https://github.com/benjamin-wilson/public-pool) project – extended with powerful new features and real-world integrations.
 
-Current Version: **v1.2.7**
+Current Version: **v1.2.8**
 
 🌐 **Live Pool:** [https://blitzpool.yourdevice.ch/#/](https://blitzpool.yourdevice.ch/#/)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "public-pool",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "public-pool",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-pool",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "",
   "author": "",
   "private": true,

--- a/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
+++ b/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
@@ -18,24 +18,54 @@ export class PoolRejectedStatisticsService {
   private lastSave: number = null;
   private counts: Map<string, number> = new Map();
   private recentDiffs: Map<string, number[]> = new Map();
+  private static readonly buckets = [
+    { label: '<10', lower: 0, upper: 10 },
+    { label: '10-1k', lower: 10, upper: 1000 },
+    { label: '1k-50k', lower: 1000, upper: 50000 },
+    { label: '50k-250k', lower: 50000, upper: 250000 },
+    { label: '250k-1M', lower: 250000, upper: 1000000 },
+    { label: '>=1M', lower: 1000000, upper: Infinity },
+  ];
 
-  private getBucket(diff: number): string {
-    if (diff < 10) {
-      return '<10';
+  private lastBuckets: Map<string, string> = new Map();
+
+  private getBucket(diff: number, reason: string): string {
+    let idx = PoolRejectedStatisticsService.buckets.findIndex(
+      b => diff >= b.lower && diff < b.upper,
+    );
+    if (idx === -1) {
+      idx = PoolRejectedStatisticsService.buckets.length - 1;
     }
-    if (diff < 1000) {
-      return '10-1k';
+
+    const last = this.lastBuckets.get(reason);
+    if (last) {
+      let lastIdx = PoolRejectedStatisticsService.buckets.findIndex(
+        b => b.label === last,
+      );
+      if (lastIdx === -1) {
+        lastIdx = idx;
+      }
+
+      while (
+        lastIdx < PoolRejectedStatisticsService.buckets.length - 1 &&
+        diff >=
+          PoolRejectedStatisticsService.buckets[lastIdx].upper * 1.1
+      ) {
+        lastIdx++;
+      }
+      while (
+        lastIdx > 0 &&
+        diff <=
+          PoolRejectedStatisticsService.buckets[lastIdx].lower * 0.9
+      ) {
+        lastIdx--;
+      }
+      idx = lastIdx;
     }
-    if (diff < 50000) {
-      return '1k-50k';
-    }
-    if (diff < 250000) {
-      return '50k-250k';
-    }
-    if (diff < 1000000) {
-      return '250k-1M';
-    }
-    return '>=1M';
+
+    const bucket = PoolRejectedStatisticsService.buckets[idx].label;
+    this.lastBuckets.set(reason, bucket);
+    return bucket;
   }
 
   @Interval(60 * 1000)
@@ -75,7 +105,7 @@ export class PoolRejectedStatisticsService {
         this.lastSave = now;
       }
 
-        const bucket = this.getBucket(diff);
+        const bucket = this.getBucket(diff, reason);
         const key = `${reason}:${bucket}`;
         let history = this.recentDiffs.get(key) || [];
         if (history.length > 0) {

--- a/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
+++ b/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
@@ -17,6 +17,7 @@ export class PoolRejectedStatisticsService {
   private currentTimeSlot: number = null;
   private lastSave: number = null;
   private counts: Map<string, number> = new Map();
+  private recentDiffs: Map<string, number[]> = new Map();
 
   @Interval(60 * 1000)
   private async flushInterval() {
@@ -28,8 +29,8 @@ export class PoolRejectedStatisticsService {
     }
   }
 
-  public async addRejectedShare(reason: string, diff: number) {
-    await this.mutex.runExclusive(async () => {
+  public async addRejectedShare(reason: string, diff: number): Promise<boolean> {
+    return await this.mutex.runExclusive(async () => {
       const coeff = 1000 * 60 * 10;
       const now = Date.now();
       const timeSlot = Math.floor(now / coeff) * coeff;
@@ -55,6 +56,26 @@ export class PoolRejectedStatisticsService {
         this.lastSave = now;
       }
 
+      let history = this.recentDiffs.get(reason) || [];
+      if (history.length > 0) {
+        const avg = history.reduce((sum, d) => sum + d, 0) / history.length;
+        if (avg > 0 && diff > avg * 4) {
+          history.push(diff);
+          if (history.length > 20) {
+            history.shift();
+          }
+          this.recentDiffs.set(reason, history);
+          console.warn(`Anomalous diff ${diff} for reason ${reason} (avg ${avg})`);
+          return false;
+        }
+      }
+
+      history.push(diff);
+      if (history.length > 20) {
+        history.shift();
+      }
+      this.recentDiffs.set(reason, history);
+
       const current = this.counts.get(reason) || 0;
       this.counts.set(reason, current + diff);
 
@@ -62,6 +83,8 @@ export class PoolRejectedStatisticsService {
         await this.saveCurrent();
         this.lastSave = now;
       }
+
+      return true;
     });
   }
 

--- a/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
+++ b/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
@@ -29,7 +29,13 @@ export class PoolRejectedStatisticsService {
     if (diff < 50000) {
       return '1k-50k';
     }
-    return '>=50k';
+    if (diff < 250000) {
+      return '50k-250k';
+    }
+    if (diff < 1000000) {
+      return '250k-1M';
+    }
+    return '>=1M';
   }
 
   @Interval(60 * 1000)

--- a/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
+++ b/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
@@ -19,6 +19,19 @@ export class PoolRejectedStatisticsService {
   private counts: Map<string, number> = new Map();
   private recentDiffs: Map<string, number[]> = new Map();
 
+  private getBucket(diff: number): string {
+    if (diff < 10) {
+      return '<10';
+    }
+    if (diff < 1000) {
+      return '10-1k';
+    }
+    if (diff < 50000) {
+      return '1k-50k';
+    }
+    return '>=50k';
+  }
+
   @Interval(60 * 1000)
   private async flushInterval() {
     if (this.currentTimeSlot != null) {
@@ -56,25 +69,27 @@ export class PoolRejectedStatisticsService {
         this.lastSave = now;
       }
 
-      let history = this.recentDiffs.get(reason) || [];
-      if (history.length > 0) {
-        const avg = history.reduce((sum, d) => sum + d, 0) / history.length;
-        if (avg > 0 && diff > avg * 4) {
-          history.push(diff);
-          if (history.length > 20) {
-            history.shift();
+        const bucket = this.getBucket(diff);
+        const key = `${reason}:${bucket}`;
+        let history = this.recentDiffs.get(key) || [];
+        if (history.length > 0) {
+          const avg = history.reduce((sum, d) => sum + d, 0) / history.length;
+          if (avg > 0 && diff > avg * 4) {
+            history.push(diff);
+            if (history.length > 20) {
+              history.shift();
+            }
+            this.recentDiffs.set(key, history);
+            console.warn(`Anomalous diff ${diff} for reason ${reason} (avg ${avg})`);
+            return false;
           }
-          this.recentDiffs.set(reason, history);
-          console.warn(`Anomalous diff ${diff} for reason ${reason} (avg ${avg})`);
-          return false;
         }
-      }
 
-      history.push(diff);
-      if (history.length > 20) {
-        history.shift();
-      }
-      this.recentDiffs.set(reason, history);
+        history.push(diff);
+        if (history.length > 20) {
+          history.shift();
+        }
+        this.recentDiffs.set(key, history);
 
       const current = this.counts.get(reason) || 0;
       this.counts.set(reason, current + diff);

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -603,8 +603,13 @@ export class StratumV1Client {
 
         const submissionHash = submission.hash();
         if(this.miningSubmissionHashes.has(submissionHash)){
-            await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
-            await this.poolRejectedStatisticsService.addRejectedShare(eStratumErrorCode[eStratumErrorCode.DuplicateShare], this.sessionDifficulty);
+            const accepted = await this.poolRejectedStatisticsService.addRejectedShare(
+                eStratumErrorCode[eStratumErrorCode.DuplicateShare],
+                this.sessionDifficulty
+            );
+            if (accepted) {
+                await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
+            }
             await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.DuplicateShare], 1);
             const err = new StratumErrorMessage(
                 submission.id,
@@ -623,8 +628,13 @@ export class StratumV1Client {
 
         // a miner may submit a job that doesn't exist anymore if it was removed by a new block notification (or expired, 5 min)
         if (job == null) {
-            await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
-            await this.poolRejectedStatisticsService.addRejectedShare(eStratumErrorCode[eStratumErrorCode.JobNotFound], this.sessionDifficulty);
+            const accepted = await this.poolRejectedStatisticsService.addRejectedShare(
+                eStratumErrorCode[eStratumErrorCode.JobNotFound],
+                this.sessionDifficulty
+            );
+            if (accepted) {
+                await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
+            }
             await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.JobNotFound], 1);
             const err = new StratumErrorMessage(
                 submission.id,
@@ -640,8 +650,13 @@ export class StratumV1Client {
         const jobTemplate = this.stratumV1JobsService.getJobTemplateById(job.jobTemplateId);
 
         if (jobTemplate == null) {
-            await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
-            await this.poolRejectedStatisticsService.addRejectedShare(eStratumErrorCode[eStratumErrorCode.JobNotFound], this.sessionDifficulty);
+            const accepted = await this.poolRejectedStatisticsService.addRejectedShare(
+                eStratumErrorCode[eStratumErrorCode.JobNotFound],
+                this.sessionDifficulty
+            );
+            if (accepted) {
+                await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
+            }
             await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.JobNotFound], 1);
             console.warn(`Job template ${job.jobTemplateId} not found for job ${submission.jobId}`);
             delete this.stratumV1JobsService.jobs[submission.jobId];
@@ -736,8 +751,13 @@ export class StratumV1Client {
             }
 
         } else {
-            await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
-            await this.poolRejectedStatisticsService.addRejectedShare(eStratumErrorCode[eStratumErrorCode.LowDifficultyShare], this.sessionDifficulty);
+            const accepted = await this.poolRejectedStatisticsService.addRejectedShare(
+                eStratumErrorCode[eStratumErrorCode.LowDifficultyShare],
+                this.sessionDifficulty
+            );
+            if (accepted) {
+                await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
+            }
             await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.LowDifficultyShare], 1);
             const err = new StratumErrorMessage(
                 submission.id,


### PR DESCRIPTION
## Summary
- record anomalous diff values in history while skipping totals
- expand safeguard window to last 20 difficulties
- update Stratum client so global counts rise only after service accepts
- remove unused rejected-statistics test file
