### PR TITLE
Clear client table on startup

### DIFF
--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -25,10 +25,12 @@ export class AppService implements OnModuleInit {
         //https://phiresky.github.io/blog/2020/sqlite-performance-tuning/
         // //500 MB DB cache
         // await this.dataSource.query(`PRAGMA cache_size = -500000;`);
-        //Normal is still completely corruption safe in WAL mode, and means only WAL checkpoints have to wait for FSYNC. 
+        //Normal is still completely corruption safe in WAL mode, and means only WAL checkpoints have to wait for FSYNC.
         await this.dataSource.query(`PRAGMA synchronous = off;`);
         // //6Gb
         // await this.dataSource.query(`PRAGMA mmap_size = 6000000000;`);
+
+        await this.clientService.deleteAll();
 
         if (process.env.NODE_APP_INSTANCE == null || process.env.NODE_APP_INSTANCE == '0') {
 


### PR DESCRIPTION
## Summary
- reset client table during module initialization to prevent double counting on restart
