### PR TITLE
feat: expose weighted rejected share totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ BlitzPool enriches peer information using the free [ip-api.com](https://ip-api.c
 - Telegram bot subscriptions managed via a custom ORM
 - New `/api/info/shares` endpoint provides pool-wide accepted and rejected share totals
 - New `/api/info/rejected` endpoint lists rejected share reasons pool-wide (supports `range=1d|3d|7d`)
-- New `/api/client/<btc_address>/rejected` shows rejected reasons for a specific address (supports `range=1d|3d|7d`)
+- New `/api/client/<btc_address>/rejected` shows rejected reasons for a specific address with per-reason share counts and diff-1 weighted totals (supports `range=1d|3d|7d`)
 - New `/api/info/accepted` endpoint lists pool-wide accepted share counts per 10-minute slot (supports `range=1d|3d|7d`)
-- New `/api/client/<btc_address>/accepted` shows diff-1 weighted accepted share counts for a specific address (supports `range=1d|3d|7d`), unlike the rejected endpoint which reports full-share counts
+- New `/api/client/<btc_address>/accepted` shows diff-1 weighted accepted share counts for a specific address per 10-minute slot
 - Old jobs are cleaned after 90 seconds by default (`JOB_RETENTION_MS` can adjust this)
 - Desired share rate per worker can be tuned with `TARGET_SHARES_PER_MINUTE` (default `6`)
 - How often miners are checked for new difficulty can be set via `DIFFICULTY_CHECK_INTERVAL_MS` (default `60000` ms)
@@ -96,8 +96,8 @@ BlitzPool enriches peer information using the free [ip-api.com](https://ip-api.c
 - `GET /api/info/rejected?range=1d|3d|7d` – Lists rejected share reasons pool-wide (difficulty weighted).
 - `GET /api/info/accepted?range=1d|3d|7d` – Lists accepted share counts pool-wide per 10-minute slot.
 - `GET /api/info/version` – Returns the BlitzPool version.
-- `GET /api/client/<btc_address>/rejected?range=1d|3d|7d` – Shows rejected reasons for a specific address (counts per share).
-- `GET /api/client/<btc_address>/accepted?range=1d|3d|7d` – Shows diff-1 weighted accepted share counts for a specific address per 10-minute slot (unlike the rejected endpoint's full-share counts).
+- `GET /api/client/<btc_address>/rejected?range=1d|3d|7d` – Returns per 10-minute slot each rejected reason with its share count and diff-1 weighted total (`diffMinusOne`).
+- `GET /api/client/<btc_address>/accepted?range=1d|3d|7d` – Shows diff-1 weighted accepted share counts for a specific address per 10-minute slot.
 
 #### Blitzpool-UI
 

--- a/src/ORM/client-rejected-statistics/client-rejected-statistics.entity.ts
+++ b/src/ORM/client-rejected-statistics/client-rejected-statistics.entity.ts
@@ -19,4 +19,7 @@ export class ClientRejectedStatisticsEntity extends TrackedEntity {
 
   @Column({ type: 'real', default: 0 })
   count: number;
+
+  @Column({ type: 'real', default: 0 })
+  shares: number;
 }

--- a/src/ORM/client-rejected-statistics/client-rejected-statistics.service.ts
+++ b/src/ORM/client-rejected-statistics/client-rejected-statistics.service.ts
@@ -16,7 +16,7 @@ export class ClientRejectedStatisticsService {
   private mutex = new Mutex();
   private currentTimeSlot: number = null;
   private lastSave: number = null;
-  private counts: Map<string, Map<string, number>> = new Map();
+  private counts: Map<string, Map<string, { count: number; shares: number }>> = new Map();
 
   @Interval(60 * 1000)
   private async flushInterval() {
@@ -28,7 +28,7 @@ export class ClientRejectedStatisticsService {
     }
   }
 
-  public async addRejectedShare(address: string, reason: string, _diff: number) {
+  public async addRejectedShare(address: string, reason: string, diff: number) {
     await this.mutex.runExclusive(async () => {
       const coeff = 1000 * 60 * 10;
       const now = Date.now();
@@ -42,7 +42,9 @@ export class ClientRejectedStatisticsService {
           if (!this.counts.has(rec.address)) {
             this.counts.set(rec.address, new Map());
           }
-          this.counts.get(rec.address).set(rec.reason, rec.count);
+          this.counts
+            .get(rec.address)
+            .set(rec.reason, { count: rec.count, shares: rec.shares ?? 0 });
         }
         this.lastSave = now;
       }
@@ -56,7 +58,9 @@ export class ClientRejectedStatisticsService {
           if (!this.counts.has(rec.address)) {
             this.counts.set(rec.address, new Map());
           }
-          this.counts.get(rec.address).set(rec.reason, rec.count);
+          this.counts
+            .get(rec.address)
+            .set(rec.reason, { count: rec.count, shares: rec.shares ?? 0 });
         }
         this.lastSave = now;
       }
@@ -65,8 +69,11 @@ export class ClientRejectedStatisticsService {
         this.counts.set(address, new Map());
       }
       const addrMap = this.counts.get(address);
-      const current = addrMap.get(reason) || 0;
-      addrMap.set(reason, current + 1);
+      const current = addrMap.get(reason) || { count: 0, shares: 0 };
+      addrMap.set(reason, {
+        count: current.count + 1,
+        shares: current.shares + Math.max(0, diff - 1),
+      });
 
       if (now - this.lastSave > 60 * 1000) {
         await this.saveCurrent();
@@ -77,33 +84,50 @@ export class ClientRejectedStatisticsService {
 
   private async saveCurrent() {
     for (const [address, reasons] of this.counts) {
-      for (const [reason, count] of reasons) {
-        const existing = await this.clientRejectedStatisticsRepository.findOneBy({ time: this.currentTimeSlot, address, reason });
+      for (const [reason, stats] of reasons) {
+        const existing = await this.clientRejectedStatisticsRepository.findOneBy({
+          time: this.currentTimeSlot,
+          address,
+          reason,
+        });
         if (existing) {
           await this.clientRejectedStatisticsRepository.update(
             { time: this.currentTimeSlot, address, reason },
-            { count, updatedAt: new Date() },
+            { count: stats.count, shares: stats.shares, updatedAt: new Date() },
           );
         } else {
-          await this.clientRejectedStatisticsRepository.insert({ time: this.currentTimeSlot, address, reason, count });
+          await this.clientRejectedStatisticsRepository.insert({
+            time: this.currentTimeSlot,
+            address,
+            reason,
+            count: stats.count,
+            shares: stats.shares,
+          });
         }
       }
     }
   }
 
-  public async getTotalsSince(address: string, time: number): Promise<Record<string, number>> {
+  public async getTotalsSince(
+    address: string,
+    time: number,
+  ): Promise<Record<string, { count: number; shares: number }>> {
     const query = this.clientRejectedStatisticsRepository
       .createQueryBuilder('stat')
       .select('stat.reason', 'reason')
       .addSelect('SUM(stat.count)', 'count')
+      .addSelect('SUM(stat.shares)', 'shares')
       .where('stat.time > :time', { time })
       .andWhere('stat.address = :address', { address })
       .groupBy('stat.reason');
     const result = await query.getRawMany();
 
-    const totals: Record<string, number> = {};
+    const totals: Record<string, { count: number; shares: number }> = {};
     result.forEach(r => {
-      totals[r.reason] = r.count ? parseFloat(r.count) : 0;
+      totals[r.reason] = {
+        count: r.count ? parseFloat(r.count) : 0,
+        shares: r.shares ? parseFloat(r.shares) : 0,
+      };
     });
     return totals;
   }

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -137,24 +137,25 @@ export class ClientController {
         const sinceTime = now - days * oneDay;
 
         const entries = await this.clientRejectedStatisticsService.getEntriesSince(address, sinceTime);
-        const slotMap = new Map<number, Record<string, number>>();
+        const slotMap = new Map<number, Record<string, { count: number; diffMinusOne: number }>>();
         for (const entry of entries) {
             if (!slotMap.has(entry.time)) {
                 slotMap.set(entry.time, {});
             }
             const r = slotMap.get(entry.time);
-            r[entry.reason] = entry.count;
+            r[entry.reason] = { count: entry.count, diffMinusOne: entry.shares };
         }
 
         const coeff = 1000 * 60 * 10;
         const startSlot = Math.floor(sinceTime / coeff) * coeff;
         const endSlot = Math.floor(now / coeff) * coeff;
         const allReasons = Object.keys(eStratumErrorCode).filter(k => isNaN(Number(k)));
-        const slotData: { time: string; counts: Record<string, number> }[] = [];
+        const slotData: { time: string; counts: Record<string, { count: number; diffMinusOne: number }> }[] = [];
         for (let t = startSlot; t <= endSlot; t += coeff) {
-            const counts: Record<string, number> = {};
+            const counts: Record<string, { count: number; diffMinusOne: number }> = {};
             for (const reason of allReasons) {
-                counts[reason] = slotMap.get(t)?.[reason] || 0;
+                const current = slotMap.get(t)?.[reason] || { count: 0, diffMinusOne: 0 };
+                counts[reason] = current;
             }
             slotData.push({ time: new Date(t).toISOString(), counts });
         }

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -610,7 +610,11 @@ export class StratumV1Client {
             if (accepted) {
                 await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
             }
-            await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.DuplicateShare], 1);
+            await this.clientRejectedStatisticsService.addRejectedShare(
+                this.clientAuthorization.address,
+                eStratumErrorCode[eStratumErrorCode.DuplicateShare],
+                this.sessionDifficulty,
+            );
             const err = new StratumErrorMessage(
                 submission.id,
                 eStratumErrorCode.DuplicateShare,
@@ -635,7 +639,11 @@ export class StratumV1Client {
             if (accepted) {
                 await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
             }
-            await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.JobNotFound], 1);
+            await this.clientRejectedStatisticsService.addRejectedShare(
+                this.clientAuthorization.address,
+                eStratumErrorCode[eStratumErrorCode.JobNotFound],
+                this.sessionDifficulty,
+            );
             const err = new StratumErrorMessage(
                 submission.id,
                 eStratumErrorCode.JobNotFound,
@@ -657,7 +665,11 @@ export class StratumV1Client {
             if (accepted) {
                 await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
             }
-            await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.JobNotFound], 1);
+            await this.clientRejectedStatisticsService.addRejectedShare(
+                this.clientAuthorization.address,
+                eStratumErrorCode[eStratumErrorCode.JobNotFound],
+                this.sessionDifficulty,
+            );
             console.warn(`Job template ${job.jobTemplateId} not found for job ${submission.jobId}`);
             delete this.stratumV1JobsService.jobs[submission.jobId];
             const err = new StratumErrorMessage(
@@ -758,7 +770,11 @@ export class StratumV1Client {
             if (accepted) {
                 await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
             }
-            await this.clientRejectedStatisticsService.addRejectedShare(this.clientAuthorization.address, eStratumErrorCode[eStratumErrorCode.LowDifficultyShare], 1);
+            await this.clientRejectedStatisticsService.addRejectedShare(
+                this.clientAuthorization.address,
+                eStratumErrorCode[eStratumErrorCode.LowDifficultyShare],
+                this.sessionDifficulty,
+            );
             const err = new StratumErrorMessage(
                 submission.id,
                 eStratumErrorCode.LowDifficultyShare,


### PR DESCRIPTION
## Summary
- track diff-1 weighted rejections in ORM and service
- send session difficulty when recording rejections
- return per-reason count and weighted totals from client rejected endpoint
