### PR TITLE
feat: expose current block template

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ BlitzPool enriches peer information using the free [ip-api.com](https://ip-api.c
 - `GET /api/info/shares` – Provides pool-wide accepted and rejected share totals.
 - `GET /api/info/rejected?range=1d|3d|7d` – Lists rejected share reasons pool-wide (difficulty weighted).
 - `GET /api/info/accepted?range=1d|3d|7d` – Lists accepted share counts pool-wide per 10-minute slot.
+- `GET /api/info/block-template` – Returns the current block template used for mining.
 - `GET /api/info/version` – Returns the BlitzPool version.
 - `GET /api/client/<btc_address>/rejected?range=1d|3d|7d` – Returns per 10-minute slot each rejected reason with its share count and diff-1 weighted total (`diffMinusOne`).
 - `GET /api/client/<btc_address>/accepted?range=1d|3d|7d` – Shows diff-1 weighted accepted share counts for a specific address per 10-minute slot.

--- a/src/app.controller.block-template.spec.ts
+++ b/src/app.controller.block-template.spec.ts
@@ -1,0 +1,58 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { of } from 'rxjs';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+
+import { AppController } from './app.controller';
+import { BitcoinRpcService } from './services/bitcoin-rpc.service';
+import { GeoIpService } from './services/geoip.service';
+import { ClientService } from './ORM/client/client.service';
+import { ClientStatisticsService } from './ORM/client-statistics/client-statistics.service';
+import { BlocksService } from './ORM/blocks/blocks.service';
+import { PoolShareStatisticsService } from './ORM/pool-share-statistics/pool-share-statistics.service';
+import { PoolRejectedStatisticsService } from './ORM/pool-rejected-statistics/pool-rejected-statistics.service';
+import { AddressSettingsService } from './ORM/address-settings/address-settings.service';
+
+describe('AppController /api/info/block-template', () => {
+  let app: NestFastifyApplication;
+  let bitcoinRpcService: BitcoinRpcService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AppController],
+      providers: [
+        { provide: CACHE_MANAGER, useValue: { get: jest.fn(), set: jest.fn() } },
+        { provide: ClientService, useValue: {} },
+        { provide: ClientStatisticsService, useValue: {} },
+        { provide: BlocksService, useValue: {} },
+        { provide: PoolShareStatisticsService, useValue: {} },
+        { provide: PoolRejectedStatisticsService, useValue: {} },
+        {
+          provide: BitcoinRpcService,
+          useValue: { newBlock$: of({ blocks: 123 }), getBlockTemplate: jest.fn() },
+        },
+        { provide: AddressSettingsService, useValue: {} },
+        { provide: GeoIpService, useValue: {} },
+      ],
+    }).compile();
+
+    bitcoinRpcService = module.get<BitcoinRpcService>(BitcoinRpcService);
+    app = module.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+    app.setGlobalPrefix('api');
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should return the current block template', async () => {
+    const template = { test: 'template' };
+    (bitcoinRpcService.getBlockTemplate as jest.Mock).mockResolvedValue(template);
+
+    const res = await app.inject({ method: 'GET', url: '/api/info/block-template' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.payload)).toEqual(template);
+    expect(bitcoinRpcService.getBlockTemplate).toHaveBeenCalledWith(123);
+  });
+});

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -95,6 +95,12 @@ export class AppController {
 
   }
 
+  @Get('info/block-template')
+  public async blockTemplate() {
+    const height = (await firstValueFrom(this.bitcoinRpcService.newBlock$)).blocks;
+    return this.bitcoinRpcService.getBlockTemplate(height);
+  }
+
   @Get('pool')
   public async pool() {
 


### PR DESCRIPTION
## Summary
- add `/api/info/block-template` endpoint to surface latest block template
- document the block template API in the README
- test controller behavior with mocked Bitcoin RPC service