### PR TITLE
feat: add stratum rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ curl -d "/subscribe 1DEF..." $NTFY_SERVER_URL/myPrefix1ABC...
 
 BlitzPool enriches peer information using the free [ip-api.com](https://ip-api.com) geolocation service to resolve city and country details. No configuration is required.
 
+### ⏱️ Stratum rate limiter
+BlitzPool tracks how often a peer disconnects within a short window and temporarily blocks IPs that exceed a threshold.
+
+Configure via:
+
+```
+STRATUM_RATE_WINDOW_MS=60000   # time window for counting disconnects (default 60s)
+STRATUM_RATE_THRESHOLD=5       # disconnects within the window to trigger a block
+STRATUM_RATE_BLOCK_MS=1800000  # how long to block the IP (default 30m)
+```
+
 #### 🛠️ Extra Services
 - Integrated `blockTemplateInterval` configuration
 - Hashrate corrections and updated statistics endpoints

--- a/full-setup/blitzpool-example.env
+++ b/full-setup/blitzpool-example.env
@@ -11,6 +11,14 @@ BITCOIN_RPC_TIMEOUT=10000
 API_PORT=3334
 STRATUM_PORT=3333
 
+# Stratum rate limiter configuration
+# Time window for counting disconnects (ms)
+STRATUM_RATE_WINDOW_MS=60000
+# Number of disconnects within the window before blocking
+STRATUM_RATE_THRESHOLD=5
+# Duration to block offending IPs (ms)
+STRATUM_RATE_BLOCK_MS=1800000
+
 #block-template interval
 BLOCK_TEMPLATE_INTERVAL=30000
 JOB_RETENTION_MS=90000

--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -14,12 +14,12 @@ import { ExternalSharesService } from './external-shares.service';
 import { PoolShareStatisticsService } from '../ORM/pool-share-statistics/pool-share-statistics.service';
 import { PoolRejectedStatisticsService } from '../ORM/pool-rejected-statistics/pool-rejected-statistics.service';
 import { ClientRejectedStatisticsService } from '../ORM/client-rejected-statistics/client-rejected-statistics.service';
-
+import { RateLimiter } from '../utils/rate-limiter';
 
 @Injectable()
 export class StratumV1Service implements OnModuleInit {
-
   private readonly clientsByAddress = new Map<string, Set<StratumV1Client>>();
+  private readonly rateLimiter: RateLimiter;
 
   constructor(
     private readonly bitcoinRpcService: BitcoinRpcService,
@@ -33,24 +33,34 @@ export class StratumV1Service implements OnModuleInit {
     private readonly poolShareStatisticsService: PoolShareStatisticsService,
     private readonly poolRejectedStatisticsService: PoolRejectedStatisticsService,
     private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
-    private readonly externalSharesService: ExternalSharesService
+    private readonly externalSharesService: ExternalSharesService,
   ) {
-
+    const windowMs =
+      parseInt(process.env.STRATUM_RATE_WINDOW_MS ?? '', 10) || 60_000;
+    const threshold =
+      parseInt(process.env.STRATUM_RATE_THRESHOLD ?? '', 10) || 5;
+    const blockMs =
+      parseInt(process.env.STRATUM_RATE_BLOCK_MS ?? '', 10) || 30 * 60_000;
+    this.rateLimiter = new RateLimiter({ windowMs, threshold, blockMs });
   }
 
   async onModuleInit(): Promise<void> {
-
-      if (process.env.NODE_APP_INSTANCE == '0') {
-        await this.clientService.deleteAll();
-      }
-      setTimeout(() => {
-        this.startSocketServer();
-      }, 1000 * 10)
-
+    if (process.env.NODE_APP_INSTANCE == '0') {
+      await this.clientService.deleteAll();
+    }
+    setTimeout(() => {
+      this.startSocketServer();
+    }, 1000 * 10);
   }
 
   private startSocketServer() {
     const server = new Server(async (socket: Socket) => {
+      const ip = socket.remoteAddress;
+      if (ip && this.rateLimiter.isBlocked(ip)) {
+        console.log(`Blocking connection from ${ip}`);
+        socket.destroy();
+        return;
+      }
 
       // Disable Nagle's algorithm and use UTF-8 encoding for better latency
       socket.setNoDelay(true);
@@ -76,13 +86,17 @@ export class StratumV1Service implements OnModuleInit {
         this,
       );
 
-
       socket.on('close', async (hadError: boolean) => {
         if (client.sessionId != null) {
           // Handle socket disconnection
           await client.destroy();
           this.unregisterClient(client.address, client);
-          console.log(`Client ${client.sessionId} disconnected, hadError?:${hadError}`);
+          console.log(
+            `Client ${client.sessionId} disconnected, hadError?:${hadError}`,
+          );
+        }
+        if (ip) {
+          this.rateLimiter.recordDisconnect(ip);
         }
       });
 
@@ -98,14 +112,13 @@ export class StratumV1Service implements OnModuleInit {
       });
 
       //   //console.log(`Client disconnected, socket error,  ${client.sessionId}`);
-
-
     });
 
     server.listen(process.env.STRATUM_PORT, () => {
-      console.log(`Stratum server is listening on port ${process.env.STRATUM_PORT}`);
+      console.log(
+        `Stratum server is listening on port ${process.env.STRATUM_PORT}`,
+      );
     });
-
   }
 
   registerClient(address: string, client: StratumV1Client) {
@@ -147,5 +160,4 @@ export class StratumV1Service implements OnModuleInit {
     }
     this.clientsByAddress.delete(address);
   }
-
 }

--- a/src/utils/rate-limiter.spec.ts
+++ b/src/utils/rate-limiter.spec.ts
@@ -1,0 +1,28 @@
+import { RateLimiter } from './rate-limiter';
+
+describe('RateLimiter', () => {
+  it('blocks IP after rapid disconnects', () => {
+    const limiter = new RateLimiter({
+      windowMs: 1000,
+      threshold: 5,
+      blockMs: 1000,
+    });
+    const ip = '1.2.3.4';
+    for (let i = 0; i < 5; i++) {
+      limiter.recordDisconnect(ip);
+    }
+    expect(limiter.isBlocked(ip)).toBe(true);
+  });
+
+  it('unblocks IP after block duration', () => {
+    jest.useFakeTimers();
+    const blockMs = 30 * 60 * 1000;
+    const limiter = new RateLimiter({ windowMs: 1000, threshold: 1, blockMs });
+    const ip = '5.6.7.8';
+    limiter.recordDisconnect(ip);
+    expect(limiter.isBlocked(ip)).toBe(true);
+    jest.advanceTimersByTime(blockMs);
+    expect(limiter.isBlocked(ip)).toBe(false);
+    jest.useRealTimers();
+  });
+});

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -1,0 +1,61 @@
+export interface RateLimiterOptions {
+  windowMs?: number;
+  threshold?: number;
+  blockMs?: number;
+}
+
+interface RateRecord {
+  timestamps: number[];
+  blockedUntil?: number;
+}
+
+export class RateLimiter {
+  private readonly windowMs: number;
+  private readonly threshold: number;
+  private readonly blockMs: number;
+  private readonly records = new Map<string, RateRecord>();
+
+  constructor(options: RateLimiterOptions = {}) {
+    this.windowMs = options.windowMs ?? 60_000;
+    this.threshold = options.threshold ?? 5;
+    this.blockMs = options.blockMs ?? 30 * 60_000;
+  }
+
+  recordDisconnect(ip: string) {
+    if (!ip) {
+      return;
+    }
+    const now = Date.now();
+    const record = this.records.get(ip) ?? { timestamps: [] };
+    record.timestamps = record.timestamps.filter(
+      (ts) => now - ts <= this.windowMs,
+    );
+    record.timestamps.push(now);
+    if (record.timestamps.length >= this.threshold) {
+      record.blockedUntil = now + this.blockMs;
+      record.timestamps = [];
+    }
+    this.records.set(ip, record);
+  }
+
+  isBlocked(ip: string): boolean {
+    if (!ip) {
+      return false;
+    }
+    const record = this.records.get(ip);
+    if (!record || !record.blockedUntil) {
+      return false;
+    }
+    const now = Date.now();
+    if (now < record.blockedUntil) {
+      return true;
+    }
+    delete record.blockedUntil;
+    if (record.timestamps.length === 0) {
+      this.records.delete(ip);
+    } else {
+      this.records.set(ip, record);
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- track per-IP disconnects and temporarily block abusive addresses
- integrate rate limiter with StratumV1 service
- add tests for blocking and unblock after timeout
- document rate limiter settings in example env and README
