### PR TITLE
feat: add client block template endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ STRATUM_RATE_BLOCK_MS=1800000  # how long to block the IP (default 30m)
 - `GET /api/info/version` – Returns the BlitzPool version.
 - `GET /api/client/<btc_address>/rejected?range=1d|3d|7d` – Returns per 10-minute slot each rejected reason with its share count and diff-1 weighted total (`diffMinusOne`).
 - `GET /api/client/<btc_address>/accepted?range=1d|3d|7d` – Shows diff-1 weighted accepted share counts for a specific address per 10-minute slot.
-- `GET /api/client/<btc_address>/block-template` – Returns the block template a miner would use, including the coinbase transaction paying to the specified address.
+- `GET /api/client/<btc_address>/block-template` – Returns the block template a miner would use, including the coinbase transaction paying to the specified address. The response provides a human‑readable `blockTemplate` and the raw serialized `blockHex`.
 
 #### Blitzpool-UI
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ STRATUM_RATE_BLOCK_MS=1800000  # how long to block the IP (default 30m)
 - `GET /api/info/rejected?range=1d|3d|7d` – Lists rejected share reasons pool-wide (difficulty weighted).
 - `GET /api/info/accepted?range=1d|3d|7d` – Lists accepted share counts pool-wide per 10-minute slot.
 - `GET /api/info/block-template` – Returns the current block template used for mining.
+- `GET /api/info/core` – returns Bitcoin Core’s getnetworkinfo output (version, connections, warnings, etc.).
 - `GET /api/info/version` – Returns the BlitzPool version.
 - `GET /api/client/<btc_address>/rejected?range=1d|3d|7d` – Returns per 10-minute slot each rejected reason with its share count and diff-1 weighted total (`diffMinusOne`).
 - `GET /api/client/<btc_address>/accepted?range=1d|3d|7d` – Shows diff-1 weighted accepted share counts for a specific address per 10-minute slot.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ STRATUM_RATE_BLOCK_MS=1800000  # how long to block the IP (default 30m)
 - `GET /api/info/version` – Returns the BlitzPool version.
 - `GET /api/client/<btc_address>/rejected?range=1d|3d|7d` – Returns per 10-minute slot each rejected reason with its share count and diff-1 weighted total (`diffMinusOne`).
 - `GET /api/client/<btc_address>/accepted?range=1d|3d|7d` – Shows diff-1 weighted accepted share counts for a specific address per 10-minute slot.
+- `GET /api/client/<btc_address>/block-template` – Returns the block template a miner would use, including the coinbase transaction paying to the specified address.
 
 #### Blitzpool-UI
 

--- a/src/app.controller.block-template.spec.ts
+++ b/src/app.controller.block-template.spec.ts
@@ -12,6 +12,8 @@ import { BlocksService } from './ORM/blocks/blocks.service';
 import { PoolShareStatisticsService } from './ORM/pool-share-statistics/pool-share-statistics.service';
 import { PoolRejectedStatisticsService } from './ORM/pool-rejected-statistics/pool-rejected-statistics.service';
 import { AddressSettingsService } from './ORM/address-settings/address-settings.service';
+import { ConfigService } from '@nestjs/config';
+import { StratumV1JobsService } from './services/stratum-v1-jobs.service';
 
 describe('AppController /api/info/block-template', () => {
   let app: NestFastifyApplication;
@@ -33,6 +35,8 @@ describe('AppController /api/info/block-template', () => {
         },
         { provide: AddressSettingsService, useValue: {} },
         { provide: GeoIpService, useValue: {} },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: StratumV1JobsService, useValue: { newMiningJob$: of({}), getNextId: jest.fn() } },
       ],
     }).compile();
 

--- a/src/app.controller.client-block-template.spec.ts
+++ b/src/app.controller.client-block-template.spec.ts
@@ -52,7 +52,13 @@ describe('AppController /api/client/:address/block-template', () => {
         { provide: BlocksService, useValue: {} },
         { provide: PoolShareStatisticsService, useValue: {} },
         { provide: PoolRejectedStatisticsService, useValue: {} },
-        { provide: BitcoinRpcService, useValue: { newBlock$: of({ blocks: 123 }), getBlockTemplate: jest.fn() } },
+        {
+          provide: BitcoinRpcService,
+          useValue: {
+            newBlock$: of({ blocks: 123 }),
+            getBlockTemplate: jest.fn().mockResolvedValue({ version: 1 }),
+          },
+        },
         { provide: AddressSettingsService, useValue: {} },
         { provide: GeoIpService, useValue: {} },
         {
@@ -101,6 +107,10 @@ describe('AppController /api/client/:address/block-template', () => {
     const payload = JSON.parse(res.payload);
     expect(payload.coinbaseTxHex).toBeDefined();
     expect(typeof payload.coinbaseTxHex).toBe('string');
-    expect(payload.block).toBeDefined();
+    expect(payload.blockHex).toBeDefined();
+    expect(payload.blockTemplate).toEqual({ version: 1 });
+
+    const bitcoinRpcService = app.get(BitcoinRpcService);
+    expect(bitcoinRpcService.getBlockTemplate).toHaveBeenCalledWith(1);
   });
 });

--- a/src/app.controller.client-block-template.spec.ts
+++ b/src/app.controller.client-block-template.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { of } from 'rxjs';
+import * as bitcoinjs from 'bitcoinjs-lib';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+
+import { AppController } from './app.controller';
+import { BitcoinRpcService } from './services/bitcoin-rpc.service';
+import { GeoIpService } from './services/geoip.service';
+import { ClientService } from './ORM/client/client.service';
+import { ClientStatisticsService } from './ORM/client-statistics/client-statistics.service';
+import { BlocksService } from './ORM/blocks/blocks.service';
+import { PoolShareStatisticsService } from './ORM/pool-share-statistics/pool-share-statistics.service';
+import { PoolRejectedStatisticsService } from './ORM/pool-rejected-statistics/pool-rejected-statistics.service';
+import { AddressSettingsService } from './ORM/address-settings/address-settings.service';
+import { ConfigService } from '@nestjs/config';
+import { StratumV1JobsService, IJobTemplate } from './services/stratum-v1-jobs.service';
+
+describe('AppController /api/client/:address/block-template', () => {
+  let app: NestFastifyApplication;
+
+  beforeEach(async () => {
+    const block = new bitcoinjs.Block();
+    block.version = 1;
+    block.bits = 1;
+    block.timestamp = 1;
+    block.nonce = 0;
+    block.prevHash = Buffer.alloc(32, 0);
+    block.transactions = [new bitcoinjs.Transaction()];
+    block.merkleRoot = Buffer.alloc(32, 0);
+    block.witnessCommit = Buffer.alloc(32, 0);
+
+    const jobTemplate: IJobTemplate = {
+      block,
+      merkle_branch: [],
+      blockData: {
+        id: '1',
+        creation: Date.now(),
+        coinbasevalue: 50 * 1e8,
+        networkDifficulty: 1,
+        height: 1,
+        clearJobs: false,
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AppController],
+      providers: [
+        { provide: CACHE_MANAGER, useValue: { get: jest.fn(), set: jest.fn() } },
+        { provide: ClientService, useValue: {} },
+        { provide: ClientStatisticsService, useValue: {} },
+        { provide: BlocksService, useValue: {} },
+        { provide: PoolShareStatisticsService, useValue: {} },
+        { provide: PoolRejectedStatisticsService, useValue: {} },
+        { provide: BitcoinRpcService, useValue: { newBlock$: of({ blocks: 123 }), getBlockTemplate: jest.fn() } },
+        { provide: AddressSettingsService, useValue: {} },
+        { provide: GeoIpService, useValue: {} },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              switch (key) {
+                case 'NETWORK':
+                  return 'regtest';
+                case 'DEV_FEE_ADDRESS':
+                  return null;
+                case 'DEV_FEE_PERCENT':
+                  return '1.5';
+                case 'POOL_IDENTIFIER':
+                  return 'Test';
+                default:
+                  return null;
+              }
+            },
+          },
+        },
+        {
+          provide: StratumV1JobsService,
+          useValue: {
+            newMiningJob$: of(jobTemplate),
+            getNextId: () => '1',
+          },
+        },
+      ],
+    }).compile();
+
+    app = module.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+    app.setGlobalPrefix('api');
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should return block template with coinbase tx hex', async () => {
+    const address = bitcoinjs.payments.p2wpkh({ hash: Buffer.alloc(20, 0), network: bitcoinjs.networks.regtest }).address;
+
+    const res = await app.inject({ method: 'GET', url: `/api/client/${address}/block-template` });
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.payload);
+    expect(payload.coinbaseTxHex).toBeDefined();
+    expect(typeof payload.coinbaseTxHex).toBe('string');
+    expect(payload.block).toBeDefined();
+  });
+});

--- a/src/app.controller.core-info.spec.ts
+++ b/src/app.controller.core-info.spec.ts
@@ -1,0 +1,63 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { of } from 'rxjs';
+
+import { AppController } from './app.controller';
+import { BitcoinRpcService } from './services/bitcoin-rpc.service';
+import { GeoIpService } from './services/geoip.service';
+import { ClientService } from './ORM/client/client.service';
+import { ClientStatisticsService } from './ORM/client-statistics/client-statistics.service';
+import { BlocksService } from './ORM/blocks/blocks.service';
+import { PoolShareStatisticsService } from './ORM/pool-share-statistics/pool-share-statistics.service';
+import { PoolRejectedStatisticsService } from './ORM/pool-rejected-statistics/pool-rejected-statistics.service';
+import { AddressSettingsService } from './ORM/address-settings/address-settings.service';
+import { ConfigService } from '@nestjs/config';
+import { StratumV1JobsService } from './services/stratum-v1-jobs.service';
+
+describe('AppController /api/info/core', () => {
+  let app: NestFastifyApplication;
+  let bitcoinRpcService: BitcoinRpcService;
+  let cache: { get: jest.Mock; set: jest.Mock };
+
+  beforeEach(async () => {
+    cache = { get: jest.fn().mockResolvedValue(null), set: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AppController],
+      providers: [
+        { provide: CACHE_MANAGER, useValue: cache },
+        { provide: ClientService, useValue: {} },
+        { provide: ClientStatisticsService, useValue: {} },
+        { provide: BlocksService, useValue: {} },
+        { provide: PoolShareStatisticsService, useValue: {} },
+        { provide: PoolRejectedStatisticsService, useValue: {} },
+        { provide: BitcoinRpcService, useValue: { getNetworkInfo: jest.fn(), newBlock$: of({}) } },
+        { provide: AddressSettingsService, useValue: {} },
+        { provide: GeoIpService, useValue: {} },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: StratumV1JobsService, useValue: { newMiningJob$: of({}), getNextId: jest.fn() } },
+      ],
+    }).compile();
+
+    bitcoinRpcService = module.get<BitcoinRpcService>(BitcoinRpcService);
+    app = module.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+    app.setGlobalPrefix('api');
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should return network info from rpc service', async () => {
+    const info = { version: 123, subversion: '/Satoshi:25.0.0/', protocolversion: 70015, connections: 8, warnings: '' };
+    (bitcoinRpcService.getNetworkInfo as jest.Mock).mockResolvedValue(info);
+
+    const res = await app.inject({ method: 'GET', url: '/api/info/core' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.payload)).toEqual(info);
+    expect(bitcoinRpcService.getNetworkInfo).toHaveBeenCalled();
+    expect(cache.set).toHaveBeenCalled();
+  });
+});

--- a/src/app.controller.peerinfo.spec.ts
+++ b/src/app.controller.peerinfo.spec.ts
@@ -10,6 +10,9 @@ import { BlocksService } from './ORM/blocks/blocks.service';
 import { PoolShareStatisticsService } from './ORM/pool-share-statistics/pool-share-statistics.service';
 import { PoolRejectedStatisticsService } from './ORM/pool-rejected-statistics/pool-rejected-statistics.service';
 import { AddressSettingsService } from './ORM/address-settings/address-settings.service';
+import { ConfigService } from '@nestjs/config';
+import { StratumV1JobsService } from './services/stratum-v1-jobs.service';
+import { of } from 'rxjs';
 
 import { IPeerInfo } from './models/bitcoin-rpc/IPeerInfo';
 
@@ -34,6 +37,8 @@ describe('AppController info/peers', () => {
         { provide: BitcoinRpcService, useValue: { getPeerInfo: jest.fn() } },
         { provide: AddressSettingsService, useValue: {} },
         { provide: GeoIpService, useValue: { getLocation: jest.fn() } },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: StratumV1JobsService, useValue: { newMiningJob$: of({}), getNextId: jest.fn() } },
       ],
     }).compile();
 

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -167,10 +167,13 @@ export class AppController {
       tpl.block.timestamp,
     );
 
+    const blockTemplate = await this.bitcoinRpcService.getBlockTemplate(
+      tpl.blockData.height,
+    );
+
     return {
-      block: block.toHex(),
-      blockData: tpl.blockData,
-      merkle_branch: tpl.merkle_branch,
+      blockTemplate,
+      blockHex: block.toHex(),
       coinbaseTxHex: job.getCoinbaseTxHex(),
     };
   }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -107,6 +107,18 @@ export class AppController {
     return this.bitcoinRpcService.getBlockTemplate(height);
   }
 
+  @Get('info/core')
+  public async infoCore() {
+    const CACHE_KEY = 'CORE_INFO';
+    const cached = await this.cacheManager.get(CACHE_KEY);
+    if (cached != null) {
+      return cached;
+    }
+    const data = await this.bitcoinRpcService.getNetworkInfo();
+    await this.cacheManager.set(CACHE_KEY, data, 60 * 1000);
+    return data;
+  }
+
   @Get('client/:address/block-template')
   public async clientBlockTemplate(@Param('address') address: string) {
     const tpl = await firstValueFrom(this.stratumV1JobsService.newMiningJob$);

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,5 +1,5 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Controller, Get, Inject, Query } from '@nestjs/common';
+import { Controller, Get, Inject, Query, Param } from '@nestjs/common';
 import { Cache } from 'cache-manager';
 import { firstValueFrom } from 'rxjs';
 import { readFileSync } from 'fs';
@@ -15,6 +15,10 @@ import { BitcoinRpcService } from './services/bitcoin-rpc.service';
 import { GeoIpService } from './services/geoip.service';
 import { eStratumErrorCode } from './models/enums/eStratumErrorCode';
 import { isIP } from 'net';
+import { ConfigService } from '@nestjs/config';
+import { StratumV1JobsService } from './services/stratum-v1-jobs.service';
+import { MiningJob } from './models/MiningJob';
+import * as bitcoinjs from 'bitcoinjs-lib';
 
 function extractHost(addr: string): string {
   if (!addr) return '';
@@ -60,6 +64,8 @@ export class AppController {
     private readonly bitcoinRpcService: BitcoinRpcService,
     private readonly addressSettingsService: AddressSettingsService,
     private readonly geoIpService: GeoIpService,
+    private readonly configService: ConfigService,
+    private readonly stratumV1JobsService: StratumV1JobsService,
   ) {
     const packagePath = join(__dirname, '..', 'package.json');
     this.version = JSON.parse(readFileSync(packagePath, 'utf8')).version;
@@ -99,6 +105,62 @@ export class AppController {
   public async blockTemplate() {
     const height = (await firstValueFrom(this.bitcoinRpcService.newBlock$)).blocks;
     return this.bitcoinRpcService.getBlockTemplate(height);
+  }
+
+  @Get('client/:address/block-template')
+  public async clientBlockTemplate(@Param('address') address: string) {
+    const tpl = await firstValueFrom(this.stratumV1JobsService.newMiningJob$);
+
+    const devFeeAddress = this.configService.get('DEV_FEE_ADDRESS');
+    const devFeePercent = parseFloat(
+      this.configService.get('DEV_FEE_PERCENT') ?? '1.5',
+    );
+
+    let payoutInformation;
+    if (devFeeAddress == null || devFeeAddress.length < 1) {
+      payoutInformation = [{ address, percent: 100 }];
+    } else {
+      payoutInformation = [
+        { address: devFeeAddress, percent: devFeePercent },
+        { address, percent: 100 - devFeePercent },
+      ];
+    }
+
+    const networkConfig = this.configService.get('NETWORK');
+    let network: bitcoinjs.networks.Network;
+    if (networkConfig === 'mainnet') {
+      network = bitcoinjs.networks.bitcoin;
+    } else if (networkConfig === 'testnet') {
+      network = bitcoinjs.networks.testnet;
+    } else if (networkConfig === 'regtest') {
+      network = bitcoinjs.networks.regtest;
+    } else {
+      throw new Error('Invalid network configuration');
+    }
+
+    const job = new MiningJob(
+      this.configService,
+      network,
+      this.stratumV1JobsService.getNextId(),
+      payoutInformation,
+      tpl,
+    );
+
+    const block = job.copyAndUpdateBlock(
+      tpl,
+      0,
+      0,
+      '00000000',
+      '0000000000000000',
+      tpl.block.timestamp,
+    );
+
+    return {
+      block: block.toHex(),
+      blockData: tpl.blockData,
+      merkle_branch: tpl.merkle_branch,
+      coinbaseTxHex: job.getCoinbaseTxHex(),
+    };
   }
 
   @Get('pool')

--- a/src/models/MiningJob.ts
+++ b/src/models/MiningJob.ts
@@ -90,6 +90,11 @@ export class MiningJob {
 
     }
 
+    public getCoinbaseTxHex(): string {
+        // @ts-ignore
+        return this.coinbaseTransaction.__toBuffer().toString('hex');
+    }
+
     public copyAndUpdateBlock(jobTemplate: IJobTemplate, versionMask: number, nonce: number, extraNonce: string, extraNonce2: string, timestamp: number): bitcoinjs.Block {
 
         const testBlock = Object.assign(new bitcoinjs.Block(), jobTemplate.block);

--- a/src/models/bitcoin-rpc/INetworkInfo.ts
+++ b/src/models/bitcoin-rpc/INetworkInfo.ts
@@ -1,0 +1,7 @@
+export interface INetworkInfo {
+    version: number,
+    subversion: string,
+    protocolversion: number,
+    connections: number,
+    warnings: string,
+}

--- a/src/services/bitcoin-rpc.service.ts
+++ b/src/services/bitcoin-rpc.service.ts
@@ -8,6 +8,7 @@ import * as zmq from 'zeromq';
 import { IBlockTemplate } from '../models/bitcoin-rpc/IBlockTemplate';
 import { IMiningInfo } from '../models/bitcoin-rpc/IMiningInfo';
 import { IPeerInfo } from '../models/bitcoin-rpc/IPeerInfo';
+import { INetworkInfo } from '../models/bitcoin-rpc/INetworkInfo';
 import * as fs from 'node:fs';
 
 @Injectable()
@@ -169,6 +170,15 @@ export class BitcoinRpcService implements OnModuleInit {
             return await this.client.getpeerinfo();
         } catch (e) {
             console.error('Error getpeerinfo', e.message);
+            return null;
+        }
+    }
+
+    public async getNetworkInfo(): Promise<INetworkInfo> {
+        try {
+            return await this.client.getnetworkinfo();
+        } catch (e) {
+            console.error('Error getnetworkinfo', e.message);
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- expose MiningJob coinbase transaction hex for HTTP responses
- add `/api/client/:address/block-template` endpoint with payout embedding
- document client block-template endpoint and cover with tests
