### PR TITLE
Handle StratumV1 client cleanup on socket close

### DIFF
--- a/src/models/stratum-v1-client.spec.ts
+++ b/src/models/stratum-v1-client.spec.ts
@@ -1,0 +1,65 @@
+import { Subscription } from 'rxjs';
+import * as net from 'net';
+import { StratumV1Client } from './StratumV1Client';
+
+// Helper to create a client with mocked dependencies
+function createClient(overrides: Record<string, any> = {}) {
+  const socket = new net.Socket();
+  const dummy = {} as any;
+  const clientService = { delete: jest.fn() };
+  const configService = {
+    get: (key: string) => (key === 'NETWORK' ? 'regtest' : undefined),
+  };
+  const stratumV1Service = { unregisterClient: jest.fn() };
+
+  const client = new StratumV1Client(
+    socket,
+    dummy,
+    dummy,
+    clientService as any,
+    dummy,
+    dummy,
+    dummy,
+    configService as any,
+    dummy,
+    dummy,
+    dummy,
+    dummy,
+    dummy,
+    stratumV1Service as any,
+  );
+
+  Object.assign(client as any, overrides);
+  return { client, socket, stratumV1Service };
+}
+
+describe('StratumV1Client.destroy', () => {
+  it('handles destroy before authorization and subscription', async () => {
+    const { client, socket, stratumV1Service } = createClient();
+    await expect(client.destroy()).resolves.not.toThrow();
+    expect(stratumV1Service.unregisterClient).not.toHaveBeenCalled();
+    socket.destroy();
+  });
+
+  it('handles destroy with subscription but without authorization', async () => {
+    let unsubscribed = false;
+    const { client, socket, stratumV1Service } = createClient({
+      stratumSubscription: new Subscription(() => {
+        unsubscribed = true;
+      }),
+    });
+    await expect(client.destroy()).resolves.not.toThrow();
+    expect(unsubscribed).toBe(true);
+    expect(stratumV1Service.unregisterClient).not.toHaveBeenCalled();
+    socket.destroy();
+  });
+
+  it('handles destroy with authorization but without subscription', async () => {
+    const { client, socket, stratumV1Service } = createClient({
+      clientAuthorization: { address: 'abc' },
+    });
+    await expect(client.destroy()).resolves.not.toThrow();
+    expect(stratumV1Service.unregisterClient).toHaveBeenCalledWith('abc', client);
+    socket.destroy();
+  });
+});

--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -70,14 +70,12 @@ export class StratumV1Service implements OnModuleInit {
       );
 
       socket.on('close', async (hadError: boolean) => {
-        if (client.sessionId != null) {
-          // Handle socket disconnection
-          await client.destroy();
-          this.unregisterClient(client.address, client);
-          console.log(
-            `Client ${client.sessionId} disconnected, hadError?:${hadError}`,
-          );
-        }
+        // Handle socket disconnection
+        await client.destroy();
+        this.unregisterClient(client.address, client);
+        console.log(
+          `Client ${client.sessionId} disconnected, hadError?:${hadError}`,
+        );
       });
 
       socket.on('timeout', () => {


### PR DESCRIPTION
## Summary
- Always destroy and unregister StratumV1 clients when their socket closes
- Add tests covering StratumV1Client.destroy behavior when authorization or subscription is missing
