### PR TITLE
feat: expire geoip cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ curl -d "/subscribe 1DEF..." $NTFY_SERVER_URL/myPrefix1ABC...
 
 ### 🌍 GeoIP service
 
-BlitzPool enriches peer information using the free [ip-api.com](https://ip-api.com) geolocation service to resolve city and country details. No configuration is required.
+BlitzPool enriches peer information using the free [ip-api.com](https://ip-api.com) geolocation service to resolve city and country details. Lookups are cached for ten minutes and automatically refreshed to keep data current. No configuration is required.
 
 #### 🛠️ Extra Services
 - Integrated `blockTemplateInterval` configuration

--- a/src/services/geoip.service.spec.ts
+++ b/src/services/geoip.service.spec.ts
@@ -1,0 +1,38 @@
+import { of } from 'rxjs';
+import { GeoIpService, GEOIP_CACHE_TTL_MS } from './geoip.service';
+
+describe('GeoIpService cache', () => {
+  let service: GeoIpService;
+  const httpService = { get: jest.fn() } as any;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    httpService.get.mockReset();
+    service = new GeoIpService(httpService);
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+    jest.useRealTimers();
+  });
+
+  it('retries lookup after TTL elapses', async () => {
+    httpService.get
+      .mockReturnValueOnce(of({ data: { status: 'success', city: 'A', country: 'B' } }))
+      .mockReturnValueOnce(of({ data: { status: 'success', city: 'C', country: 'D' } }));
+
+    const first = await service.getLocation('1.1.1.1');
+    expect(first).toEqual({ city: 'A', country: 'B' });
+    expect(httpService.get).toHaveBeenCalledTimes(1);
+
+    const cached = await service.getLocation('1.1.1.1');
+    expect(cached).toEqual({ city: 'A', country: 'B' });
+    expect(httpService.get).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(GEOIP_CACHE_TTL_MS);
+
+    const afterTtl = await service.getLocation('1.1.1.1');
+    expect(afterTtl).toEqual({ city: 'C', country: 'D' });
+    expect(httpService.get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/geoip.service.ts
+++ b/src/services/geoip.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 
@@ -7,15 +7,28 @@ interface GeoLocation {
     country: string;
 }
 
+/**
+ * Cached geo lookups are cleared every ten minutes to avoid stale data.
+ */
+export const GEOIP_CACHE_TTL_MS = 600_000;
+
 @Injectable()
-export class GeoIpService {
+export class GeoIpService implements OnModuleDestroy {
     private readonly logger = new Logger(GeoIpService.name);
     private readonly cache = new Map<string, GeoLocation | null>();
     private readonly baseUrl = process.env.GEOIP_API_URL || 'http://ip-api.com';
+    private readonly cacheClearInterval: NodeJS.Timeout;
 
     constructor(
         private readonly httpService: HttpService,
-    ) {}
+    ) {
+        // Periodically prune the cache to ensure lookups are retried.
+        this.cacheClearInterval = setInterval(() => this.cache.clear(), GEOIP_CACHE_TTL_MS);
+    }
+
+    onModuleDestroy() {
+        clearInterval(this.cacheClearInterval);
+    }
 
     public async getLocation(ip: string): Promise<GeoLocation | null> {
         if (this.cache.has(ip)) {

--- a/src/services/telegram.service.ts
+++ b/src/services/telegram.service.ts
@@ -174,24 +174,28 @@ export class TelegramService implements OnModuleInit {
                 let address = addressParam;
 
                 if (!address) {
-                    const subs = await this.telegramSubscriptionsService.getChatSubscriptions(chatId);
-                    if (subs.length === 0) {
-                        this.reply(chatId, {
-                            de: 'Keine Adresse gespeichert. Nutze /subscribe, um eine hinzuzufügen.',
-                            en: 'No address stored. Use /subscribe to add one.'
-                        });
-                        return;
-                    }
-                    const defaultSub = subs.find(s => s.isDefault);
-                    if (subs.length === 1 || defaultSub) {
-                        address = (defaultSub ?? subs[0]).address;
+                    const defaultSub = await this.telegramSubscriptionsService.getDefault(chatId);
+                    if (defaultSub) {
+                        address = defaultSub.address;
                     } else {
-                        const list = subs.map(s => `${s.isDefault ? '*' : ''}${this.formatAddress(s.address)}`).join('\n');
-                        this.reply(chatId, {
-                            de: `Mehrere Adressen gespeichert:\n${list}\nBitte Adresse angeben.`,
-                            en: `Multiple addresses stored:\n${list}\nPlease specify an address.`
-                        });
-                        return;
+                        const subs = await this.telegramSubscriptionsService.getChatSubscriptions(chatId);
+                        if (subs.length === 0) {
+                            this.reply(chatId, {
+                                de: 'Keine Adresse gespeichert. Nutze /subscribe, um eine hinzuzufügen.',
+                                en: 'No address stored. Use /subscribe to add one.'
+                            });
+                            return;
+                        }
+                        if (subs.length === 1) {
+                            address = subs[0].address;
+                        } else {
+                            const list = subs.map(s => `${s.isDefault ? '*' : ''}${this.formatAddress(s.address)}`).join('\n');
+                            this.reply(chatId, {
+                                de: `Mehrere Adressen gespeichert:\n${list}\nBitte Adresse angeben.`,
+                                en: `Multiple addresses stored:\n${list}\nPlease specify an address.`
+                            });
+                            return;
+                        }
                     }
                 } else {
                     const decrypted = decryptMessageIfNeeded(address);


### PR DESCRIPTION
## Summary
- periodically clear GeoIP cache to refresh lookups
- clean up interval on module shutdown
- test cache expiry and refresh logic