### PR TITLE
Restore session guard on Stratum disconnections

### DIFF
--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -70,12 +70,14 @@ export class StratumV1Service implements OnModuleInit {
       );
 
       socket.on('close', async (hadError: boolean) => {
-        // Handle socket disconnection
-        await client.destroy();
-        this.unregisterClient(client.address, client);
-        console.log(
-          `Client ${client.sessionId} disconnected, hadError?:${hadError}`,
-        );
+        // Handle socket disconnection for initialized clients only
+        if (client.sessionId != null) {
+          await client.destroy();
+          this.unregisterClient(client.address, client);
+          console.log(
+            `Client ${client.sessionId} disconnected, hadError?:${hadError}`,
+          );
+        }
       });
 
       socket.on('timeout', () => {


### PR DESCRIPTION
## Summary
- Wrap Stratum close handler with `sessionId` check to skip uninitialized clients
