### PR TITLE
Anchor /subscribe regex

### DIFF
--- a/src/services/telegram.service.ts
+++ b/src/services/telegram.service.ts
@@ -113,7 +113,7 @@ export class TelegramService implements OnModuleInit {
             });
         });
 
-        this.bot.onText(/\/subscribe(?:\s+(.+))?/, async (msg, match) => {
+        this.bot.onText(/^\/subscribe(?:\s+(.+))?$/, async (msg, match) => {
             const raw = match?.[1]?.trim();
             if (!raw) {
                 this.reply(msg.chat.id, {


### PR DESCRIPTION
## Summary
- tighten `/subscribe` command regex with start/end anchors to avoid accidental matches

## Testing
- `npm test`
- `node -e "const re=/^\/subscribe(?:\s+(.+))?$/; console.log('sub', re.test('/subscribe')); console.log('bestdiff', re.test('/subscribe_bestdiff reset')); console.log('addr', re.test('/subscribe abc'));"`

------
https://chatgpt.com/codex/tasks/task_e_68c2b374e464832eac8e384dc702bce6