### PR TITLE
Add support for worker chart ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "public-pool",
-      "version": "1.2.9",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -248,8 +248,26 @@ export class ClientStatisticsService {
     return this.calcHashRate(shares);
   }
 
-  public async getChartDataForGroup(address: string, clientName: string) {
-    const yesterday = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
+  public async getChartDataForGroup(
+    address: string,
+    clientName: string,
+    range: '1d' | '3d' | '7d' = '1d',
+  ) {
+    let diffDays = 1;
+
+    switch (range) {
+      case '3d':
+        diffDays = 3;
+        break;
+      case '7d':
+        diffDays = 7;
+        break;
+      default:
+        diffDays = 1;
+    }
+
+    const since = new Date(Date.now() - diffDays * 24 * 60 * 60 * 1000);
+    const limit = diffDays * 144;
 
     const query = `
             SELECT
@@ -258,12 +276,12 @@ export class ClientStatisticsService {
             FROM
                 client_statistics_entity AS entry
             WHERE
-                entry.address = ? AND entry.clientName = ? AND entry.time > ${yesterday.getTime()}
+                entry.address = ? AND entry.clientName = ? AND entry.time > ${since.getTime()}
             GROUP BY
                 time
             ORDER BY
                 time
-            LIMIT 144;
+            LIMIT ${limit};
         `;
 
     const result = await this.clientStatisticsRepository.query(query, [

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -163,6 +163,16 @@ export class ClientController {
         return { slotData };
     }
 
+    @Get(':address/:workerName/chart')
+    async getWorkerGroupChart(
+        @Param('address') address: string,
+        @Param('workerName') workerName: string,
+        @Query('range') range: '1d' | '3d' | '7d' = '1d'
+    ) {
+        const chartData = await this.clientStatisticsService.getChartDataForGroup(address, workerName, range);
+        return chartData;
+    }
+
     @Get(':address/:workerName')
     async getWorkerGroupInfo(@Param('address') address: string, @Param('workerName') workerName: string) {
 


### PR DESCRIPTION
## Summary
- allow the worker chart query to return 1d, 3d, or 7d statistics
- add a dedicated /api/client/:address/:workerName/chart endpoint with range support

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda8588acc832e82926f53f3a9edc8