### PR TITLE
expose per worker accepted, rejected counts and keep up to one week of data

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to **BlitzPool**, a lightweight and open-source Bitcoin mining pool based on the [public-pool](https://github.com/benjamin-wilson/public-pool) project – extended with powerful new features and real-world integrations.
 
-Current Version: **v1.3.1**
+Current Version: **v1.3.2**
 
 🌐 **Live Pool:** [https://blitzpool.yourdevice.ch/#/](https://blitzpool.yourdevice.ch/#/)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "public-pool",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "public-pool",
-      "version": "1.2.9",
+      "version": "1.3.2",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-pool",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "description": "",
   "author": "",
   "private": true,

--- a/src/ORM/client-statistics/client-statistics.entity.ts
+++ b/src/ORM/client-statistics/client-statistics.entity.ts
@@ -34,5 +34,23 @@ export class ClientStatisticsEntity extends TrackedEntity {
     @Column({ default: 0, type: 'integer' })
     rejectedCount: number;
 
+    @Column({ default: 0, type: 'integer' })
+    rejectedJobNotFoundCount: number;
+
+    @Column({ default: 0, type: 'real' })
+    rejectedJobNotFoundDiff1: number;
+
+    @Column({ default: 0, type: 'integer' })
+    rejectedDuplicateShareCount: number;
+
+    @Column({ default: 0, type: 'real' })
+    rejectedDuplicateShareDiff1: number;
+
+    @Column({ default: 0, type: 'integer' })
+    rejectedLowDifficultyShareCount: number;
+
+    @Column({ default: 0, type: 'real' })
+    rejectedLowDifficultyShareDiff1: number;
+
 
 }

--- a/src/ORM/client-statistics/client-statistics.entity.ts
+++ b/src/ORM/client-statistics/client-statistics.entity.ts
@@ -31,5 +31,8 @@ export class ClientStatisticsEntity extends TrackedEntity {
     @Column({ default: 0, type: 'integer' })
     acceptedCount: number;
 
+    @Column({ default: 0, type: 'integer' })
+    rejectedCount: number;
+
 
 }

--- a/src/ORM/client-statistics/client-statistics.service.spec.ts
+++ b/src/ORM/client-statistics/client-statistics.service.spec.ts
@@ -1,0 +1,32 @@
+import { ClientStatisticsService } from './client-statistics.service';
+
+describe('ClientStatisticsService - getChartDataForGroup', () => {
+  it('returns chart data including accepted shares aggregated over the requested range', async () => {
+    const queryMock = jest.fn().mockResolvedValue([
+      { label: 1700000000000, data: '123.5', accepted: '10', rejected: '2' },
+      { label: 1700000600000, data: '456.75', accepted: '20', rejected: '3' },
+    ]);
+    const service = new ClientStatisticsService({ query: queryMock } as any);
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1700003600000);
+
+    try {
+      const result = await service.getChartDataForGroup('address', 'worker', '3d');
+
+      expect(queryMock).toHaveBeenCalledTimes(1);
+      const queryString = queryMock.mock.calls[0][0] as string;
+      expect(queryString).toContain('SUM(entry.acceptedCount) AS accepted');
+      expect(queryString).toContain('SUM(entry.rejectedCount) AS rejected');
+      expect(queryString).toContain('LIMIT 432;');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        label: new Date(1700000000000).toISOString(),
+        data: 123.5,
+        accepted: 10,
+        rejected: 2,
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+});

--- a/src/ORM/client-statistics/client-statistics.service.spec.ts
+++ b/src/ORM/client-statistics/client-statistics.service.spec.ts
@@ -3,8 +3,28 @@ import { ClientStatisticsService } from './client-statistics.service';
 describe('ClientStatisticsService - getChartDataForGroup', () => {
   it('returns chart data including accepted shares aggregated over the requested range', async () => {
     const queryMock = jest.fn().mockResolvedValue([
-      { label: 1700000000000, data: '123.5', accepted: '10', rejected: '2' },
-      { label: 1700000600000, data: '456.75', accepted: '20', rejected: '3' },
+      {
+        label: 1700000000000,
+        data: '123.5',
+        accepted: '10',
+        rejectedJobNotFound: '1',
+        rejectedJobNotFoundDiff1: '4000',
+        rejectedDuplicatedShare: '2',
+        rejectedDuplicatedShareDiff1: '8000',
+        rejectedLowDifficultyShare: '3',
+        rejectedLowDifficultyShareDiff1: '12000',
+      },
+      {
+        label: 1700000600000,
+        data: '456.75',
+        accepted: '20',
+        rejectedJobNotFound: '0',
+        rejectedJobNotFoundDiff1: '0',
+        rejectedDuplicatedShare: '1',
+        rejectedDuplicatedShareDiff1: '2000',
+        rejectedLowDifficultyShare: '4',
+        rejectedLowDifficultyShareDiff1: '16000',
+      },
     ]);
     const service = new ClientStatisticsService({ query: queryMock } as any);
     const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1700003600000);
@@ -15,7 +35,24 @@ describe('ClientStatisticsService - getChartDataForGroup', () => {
       expect(queryMock).toHaveBeenCalledTimes(1);
       const queryString = queryMock.mock.calls[0][0] as string;
       expect(queryString).toContain('SUM(entry.acceptedCount) AS accepted');
-      expect(queryString).toContain('SUM(entry.rejectedCount) AS rejected');
+      expect(queryString).toContain(
+        'SUM(entry.rejectedJobNotFoundCount) AS rejectedJobNotFound',
+      );
+      expect(queryString).toContain(
+        'SUM(entry.rejectedJobNotFoundDiff1) AS rejectedJobNotFoundDiff1',
+      );
+      expect(queryString).toContain(
+        'SUM(entry.rejectedDuplicateShareCount) AS rejectedDuplicatedShare',
+      );
+      expect(queryString).toContain(
+        'SUM(entry.rejectedDuplicateShareDiff1) AS rejectedDuplicatedShareDiff1',
+      );
+      expect(queryString).toContain(
+        'SUM(entry.rejectedLowDifficultyShareCount) AS rejectedLowDifficultyShare',
+      );
+      expect(queryString).toContain(
+        'SUM(entry.rejectedLowDifficultyShareDiff1) AS rejectedLowDifficultyShareDiff1',
+      );
       expect(queryString).toContain('LIMIT 432;');
 
       expect(result).toHaveLength(1);
@@ -23,7 +60,12 @@ describe('ClientStatisticsService - getChartDataForGroup', () => {
         label: new Date(1700000000000).toISOString(),
         data: 123.5,
         accepted: 10,
-        rejected: 2,
+        rejectedJobNotFound: 1,
+        rejectedJobNotFoundDiff1: 4000,
+        rejectedDuplicatedShare: 2,
+        rejectedDuplicatedShareDiff1: 8000,
+        rejectedLowDifficultyShare: 3,
+        rejectedLowDifficultyShareDiff1: 12000,
       });
     } finally {
       nowSpy.mockRestore();

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -28,6 +28,7 @@ export class ClientStatisticsService {
       {
         shares: clientStatistic.shares,
         acceptedCount: clientStatistic.acceptedCount,
+        rejectedCount: clientStatistic.rejectedCount,
         updatedAt: new Date(),
       },
     );
@@ -53,6 +54,7 @@ export class ClientStatisticsService {
                 time,
                 shares,
                 acceptedCount,
+                rejectedCount,
                 "createdAt",
                 "updatedAt"
             )
@@ -63,6 +65,7 @@ export class ClientStatisticsService {
                 time,
                 SUM(shares),
                 SUM(acceptedCount),
+                SUM(rejectedCount),
                 datetime('now'),
                 datetime('now')
             FROM client_statistics_entity
@@ -78,6 +81,7 @@ export class ClientStatisticsService {
                 time,
                 shares,
                 acceptedCount,
+                rejectedCount,
                 "createdAt",
                 "updatedAt"
             )
@@ -88,6 +92,7 @@ export class ClientStatisticsService {
                 ${detailCutoff.getTime()},
                 SUM(shares),
                 SUM(acceptedCount),
+                SUM(rejectedCount),
                 datetime('now'),
                 datetime('now')
             FROM client_statistics_entity
@@ -248,22 +253,42 @@ export class ClientStatisticsService {
     return this.calcHashRate(shares);
   }
 
-  public async getChartDataForGroup(address: string, clientName: string) {
-    const yesterday = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
+  public async getChartDataForGroup(
+    address: string,
+    clientName: string,
+    range: '1d' | '3d' | '7d' = '1d',
+  ) {
+    let diffDays = 1;
+
+    switch (range) {
+      case '3d':
+        diffDays = 3;
+        break;
+      case '7d':
+        diffDays = 7;
+        break;
+      default:
+        diffDays = 1;
+    }
+
+    const since = new Date(Date.now() - diffDays * 24 * 60 * 60 * 1000);
+    const limit = diffDays * 144;
 
     const query = `
             SELECT
                 time label,
-                (SUM(shares) * ${DIFFICULTY_1}) / 600 AS data
+                (SUM(shares) * ${DIFFICULTY_1}) / 600 AS data,
+                SUM(entry.acceptedCount) AS accepted,
+                SUM(entry.rejectedCount) AS rejected
             FROM
                 client_statistics_entity AS entry
             WHERE
-                entry.address = ? AND entry.clientName = ? AND entry.time > ${yesterday.getTime()}
+                entry.address = ? AND entry.clientName = ? AND entry.time > ${since.getTime()}
             GROUP BY
                 time
             ORDER BY
                 time
-            LIMIT 144;
+            LIMIT ${limit};
         `;
 
     const result = await this.clientStatisticsRepository.query(query, [
@@ -271,12 +296,14 @@ export class ClientStatisticsService {
       clientName,
     ]);
 
-    return result
-      .map((res) => {
-        res.label = new Date(res.label).toISOString();
-        return res;
-      })
-      .slice(0, result.length - 1);
+    const parsed = result.map((res) => ({
+      label: new Date(res.label).toISOString(),
+      data: res.data == null ? 0 : Number(res.data),
+      accepted: res.accepted == null ? 0 : Number(res.accepted),
+      rejected: res.rejected == null ? 0 : Number(res.rejected),
+    }));
+
+    return parsed.slice(0, parsed.length - 1);
   }
 
   public async getHashRateForSession(

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -29,6 +29,14 @@ export class ClientStatisticsService {
         shares: clientStatistic.shares,
         acceptedCount: clientStatistic.acceptedCount,
         rejectedCount: clientStatistic.rejectedCount,
+        rejectedJobNotFoundCount: clientStatistic.rejectedJobNotFoundCount,
+        rejectedJobNotFoundDiff1: clientStatistic.rejectedJobNotFoundDiff1,
+        rejectedDuplicateShareCount: clientStatistic.rejectedDuplicateShareCount,
+        rejectedDuplicateShareDiff1: clientStatistic.rejectedDuplicateShareDiff1,
+        rejectedLowDifficultyShareCount:
+          clientStatistic.rejectedLowDifficultyShareCount,
+        rejectedLowDifficultyShareDiff1:
+          clientStatistic.rejectedLowDifficultyShareDiff1,
         updatedAt: new Date(),
       },
     );
@@ -55,6 +63,12 @@ export class ClientStatisticsService {
                 shares,
                 acceptedCount,
                 rejectedCount,
+                rejectedJobNotFoundCount,
+                rejectedJobNotFoundDiff1,
+                rejectedDuplicateShareCount,
+                rejectedDuplicateShareDiff1,
+                rejectedLowDifficultyShareCount,
+                rejectedLowDifficultyShareDiff1,
                 "createdAt",
                 "updatedAt"
             )
@@ -66,6 +80,12 @@ export class ClientStatisticsService {
                 SUM(shares),
                 SUM(acceptedCount),
                 SUM(rejectedCount),
+                SUM(rejectedJobNotFoundCount),
+                SUM(rejectedJobNotFoundDiff1),
+                SUM(rejectedDuplicateShareCount),
+                SUM(rejectedDuplicateShareDiff1),
+                SUM(rejectedLowDifficultyShareCount),
+                SUM(rejectedLowDifficultyShareDiff1),
                 datetime('now'),
                 datetime('now')
             FROM client_statistics_entity
@@ -82,6 +102,12 @@ export class ClientStatisticsService {
                 shares,
                 acceptedCount,
                 rejectedCount,
+                rejectedJobNotFoundCount,
+                rejectedJobNotFoundDiff1,
+                rejectedDuplicateShareCount,
+                rejectedDuplicateShareDiff1,
+                rejectedLowDifficultyShareCount,
+                rejectedLowDifficultyShareDiff1,
                 "createdAt",
                 "updatedAt"
             )
@@ -93,6 +119,12 @@ export class ClientStatisticsService {
                 SUM(shares),
                 SUM(acceptedCount),
                 SUM(rejectedCount),
+                SUM(rejectedJobNotFoundCount),
+                SUM(rejectedJobNotFoundDiff1),
+                SUM(rejectedDuplicateShareCount),
+                SUM(rejectedDuplicateShareDiff1),
+                SUM(rejectedLowDifficultyShareCount),
+                SUM(rejectedLowDifficultyShareDiff1),
                 datetime('now'),
                 datetime('now')
             FROM client_statistics_entity
@@ -279,7 +311,12 @@ export class ClientStatisticsService {
                 time label,
                 (SUM(shares) * ${DIFFICULTY_1}) / 600 AS data,
                 SUM(entry.acceptedCount) AS accepted,
-                SUM(entry.rejectedCount) AS rejected
+                SUM(entry.rejectedJobNotFoundCount) AS rejectedJobNotFound,
+                SUM(entry.rejectedJobNotFoundDiff1) AS rejectedJobNotFoundDiff1,
+                SUM(entry.rejectedDuplicateShareCount) AS rejectedDuplicatedShare,
+                SUM(entry.rejectedDuplicateShareDiff1) AS rejectedDuplicatedShareDiff1,
+                SUM(entry.rejectedLowDifficultyShareCount) AS rejectedLowDifficultyShare,
+                SUM(entry.rejectedLowDifficultyShareDiff1) AS rejectedLowDifficultyShareDiff1
             FROM
                 client_statistics_entity AS entry
             WHERE
@@ -300,7 +337,28 @@ export class ClientStatisticsService {
       label: new Date(res.label).toISOString(),
       data: res.data == null ? 0 : Number(res.data),
       accepted: res.accepted == null ? 0 : Number(res.accepted),
-      rejected: res.rejected == null ? 0 : Number(res.rejected),
+      rejectedJobNotFound:
+        res.rejectedJobNotFound == null ? 0 : Number(res.rejectedJobNotFound),
+      rejectedJobNotFoundDiff1:
+        res.rejectedJobNotFoundDiff1 == null
+          ? 0
+          : Number(res.rejectedJobNotFoundDiff1),
+      rejectedDuplicatedShare:
+        res.rejectedDuplicatedShare == null
+          ? 0
+          : Number(res.rejectedDuplicatedShare),
+      rejectedDuplicatedShareDiff1:
+        res.rejectedDuplicatedShareDiff1 == null
+          ? 0
+          : Number(res.rejectedDuplicatedShareDiff1),
+      rejectedLowDifficultyShare:
+        res.rejectedLowDifficultyShare == null
+          ? 0
+          : Number(res.rejectedLowDifficultyShare),
+      rejectedLowDifficultyShareDiff1:
+        res.rejectedLowDifficultyShareDiff1 == null
+          ? 0
+          : Number(res.rejectedLowDifficultyShareDiff1),
     }));
 
     return parsed.slice(0, parsed.length - 1);

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -164,7 +164,11 @@ export class ClientController {
     }
 
     @Get(':address/:workerName')
-    async getWorkerGroupInfo(@Param('address') address: string, @Param('workerName') workerName: string) {
+    async getWorkerGroupInfo(
+        @Param('address') address: string,
+        @Param('workerName') workerName: string,
+        @Query('range') range: '1d' | '3d' | '7d' = '7d',
+    ) {
 
         const workers = await this.clientService.getByName(address, workerName);
 
@@ -175,7 +179,7 @@ export class ClientController {
             return pre;
         }, 0);
 
-        const chartData = await this.clientStatisticsService.getChartDataForGroup(address, workerName);
+        const chartData = await this.clientStatisticsService.getChartDataForGroup(address, workerName, range);
         return {
 
             name: workerName,

--- a/src/controllers/client/client.controller.worker.spec.ts
+++ b/src/controllers/client/client.controller.worker.spec.ts
@@ -1,0 +1,85 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+
+jest.mock('node-telegram-bot-api', () => ({}));
+
+import { ClientController } from './client.controller';
+import { ClientService } from '../../ORM/client/client.service';
+import { ClientStatisticsService } from '../../ORM/client-statistics/client-statistics.service';
+import { AddressSettingsService } from '../../ORM/address-settings/address-settings.service';
+import { ClientRejectedStatisticsService } from '../../ORM/client-rejected-statistics/client-rejected-statistics.service';
+import { StratumV1Service } from '../../services/stratum-v1.service';
+
+describe('ClientController worker chart data', () => {
+  let app: NestFastifyApplication;
+  let clientStatisticsService: { getChartDataForGroup: jest.Mock };
+  let clientService: { getByName: jest.Mock };
+
+  beforeEach(async () => {
+    clientStatisticsService = {
+      getChartDataForGroup: jest.fn().mockResolvedValue([
+        { label: '2023-11-14T00:00:00.000Z', data: 100, accepted: 5, rejected: 1 },
+      ]),
+    };
+    clientService = {
+      getByName: jest.fn().mockResolvedValue([
+        { bestDifficulty: 12.34 },
+      ]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ClientController],
+      providers: [
+        { provide: ClientService, useValue: clientService },
+        { provide: ClientStatisticsService, useValue: clientStatisticsService },
+        { provide: AddressSettingsService, useValue: {} },
+        { provide: ClientRejectedStatisticsService, useValue: {} },
+        { provide: StratumV1Service, useValue: {} },
+      ],
+    }).compile();
+
+    app = module.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+    app.setGlobalPrefix('api');
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns worker info including accepted and rejected share totals for a requested range', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/client/addr123/workerA?range=7d',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.payload);
+    expect(payload.chartData).toEqual([
+      { label: '2023-11-14T00:00:00.000Z', data: 100, accepted: 5, rejected: 1 },
+    ]);
+    expect(clientStatisticsService.getChartDataForGroup).toHaveBeenCalledWith(
+      'addr123',
+      'workerA',
+      '7d',
+    );
+  });
+
+  it('defaults to returning seven days of chart data when no range is specified', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/client/addr123/workerA',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.payload);
+    expect(payload.chartData).toEqual([
+      { label: '2023-11-14T00:00:00.000Z', data: 100, accepted: 5, rejected: 1 },
+    ]);
+    const lastCall =
+      clientStatisticsService.getChartDataForGroup.mock.calls[
+        clientStatisticsService.getChartDataForGroup.mock.calls.length - 1
+      ];
+    expect(lastCall).toEqual(['addr123', 'workerA', '7d']);
+  });
+});

--- a/src/controllers/client/client.controller.worker.spec.ts
+++ b/src/controllers/client/client.controller.worker.spec.ts
@@ -18,7 +18,17 @@ describe('ClientController worker chart data', () => {
   beforeEach(async () => {
     clientStatisticsService = {
       getChartDataForGroup: jest.fn().mockResolvedValue([
-        { label: '2023-11-14T00:00:00.000Z', data: 100, accepted: 5, rejected: 1 },
+        {
+          label: '2023-11-14T00:00:00.000Z',
+          data: 100,
+          accepted: 5,
+          rejectedJobNotFound: 1,
+          rejectedJobNotFoundDiff1: 2000,
+          rejectedDuplicatedShare: 0,
+          rejectedDuplicatedShareDiff1: 0,
+          rejectedLowDifficultyShare: 2,
+          rejectedLowDifficultyShareDiff1: 4000,
+        },
       ]),
     };
     clientService = {
@@ -56,7 +66,17 @@ describe('ClientController worker chart data', () => {
     expect(res.statusCode).toBe(200);
     const payload = JSON.parse(res.payload);
     expect(payload.chartData).toEqual([
-      { label: '2023-11-14T00:00:00.000Z', data: 100, accepted: 5, rejected: 1 },
+      {
+        label: '2023-11-14T00:00:00.000Z',
+        data: 100,
+        accepted: 5,
+        rejectedJobNotFound: 1,
+        rejectedJobNotFoundDiff1: 2000,
+        rejectedDuplicatedShare: 0,
+        rejectedDuplicatedShareDiff1: 0,
+        rejectedLowDifficultyShare: 2,
+        rejectedLowDifficultyShareDiff1: 4000,
+      },
     ]);
     expect(clientStatisticsService.getChartDataForGroup).toHaveBeenCalledWith(
       'addr123',
@@ -74,7 +94,17 @@ describe('ClientController worker chart data', () => {
     expect(res.statusCode).toBe(200);
     const payload = JSON.parse(res.payload);
     expect(payload.chartData).toEqual([
-      { label: '2023-11-14T00:00:00.000Z', data: 100, accepted: 5, rejected: 1 },
+      {
+        label: '2023-11-14T00:00:00.000Z',
+        data: 100,
+        accepted: 5,
+        rejectedJobNotFound: 1,
+        rejectedJobNotFoundDiff1: 2000,
+        rejectedDuplicatedShare: 0,
+        rejectedDuplicatedShareDiff1: 0,
+        rejectedLowDifficultyShare: 2,
+        rejectedLowDifficultyShareDiff1: 4000,
+      },
     ]);
     const lastCall =
       clientStatisticsService.getChartDataForGroup.mock.calls[

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -634,6 +634,7 @@ export class StratumV1Client {
                 eStratumErrorCode[eStratumErrorCode.DuplicateShare],
                 this.sessionDifficulty,
             );
+            await this.statistics.addRejectedShare(this.entity);
             const err = new StratumErrorMessage(
                 submission.id,
                 eStratumErrorCode.DuplicateShare,
@@ -663,6 +664,7 @@ export class StratumV1Client {
                 eStratumErrorCode[eStratumErrorCode.JobNotFound],
                 this.sessionDifficulty,
             );
+            await this.statistics.addRejectedShare(this.entity);
             const err = new StratumErrorMessage(
                 submission.id,
                 eStratumErrorCode.JobNotFound,
@@ -689,6 +691,7 @@ export class StratumV1Client {
                 eStratumErrorCode[eStratumErrorCode.JobNotFound],
                 this.sessionDifficulty,
             );
+            await this.statistics.addRejectedShare(this.entity);
             console.warn(`Job template ${job.jobTemplateId} not found for job ${submission.jobId}`);
             delete this.stratumV1JobsService.jobs[submission.jobId];
             const err = new StratumErrorMessage(
@@ -794,6 +797,7 @@ export class StratumV1Client {
                 eStratumErrorCode[eStratumErrorCode.LowDifficultyShare],
                 this.sessionDifficulty,
             );
+            await this.statistics.addRejectedShare(this.entity);
             const err = new StratumErrorMessage(
                 submission.id,
                 eStratumErrorCode.LowDifficultyShare,

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -634,7 +634,11 @@ export class StratumV1Client {
                 eStratumErrorCode[eStratumErrorCode.DuplicateShare],
                 this.sessionDifficulty,
             );
-            await this.statistics.addRejectedShare(this.entity);
+            await this.statistics.addRejectedShare(
+                this.entity,
+                eStratumErrorCode[eStratumErrorCode.DuplicateShare],
+                this.sessionDifficulty,
+            );
             const err = new StratumErrorMessage(
                 submission.id,
                 eStratumErrorCode.DuplicateShare,
@@ -664,7 +668,11 @@ export class StratumV1Client {
                 eStratumErrorCode[eStratumErrorCode.JobNotFound],
                 this.sessionDifficulty,
             );
-            await this.statistics.addRejectedShare(this.entity);
+            await this.statistics.addRejectedShare(
+                this.entity,
+                eStratumErrorCode[eStratumErrorCode.JobNotFound],
+                this.sessionDifficulty,
+            );
             const err = new StratumErrorMessage(
                 submission.id,
                 eStratumErrorCode.JobNotFound,
@@ -691,7 +699,11 @@ export class StratumV1Client {
                 eStratumErrorCode[eStratumErrorCode.JobNotFound],
                 this.sessionDifficulty,
             );
-            await this.statistics.addRejectedShare(this.entity);
+            await this.statistics.addRejectedShare(
+                this.entity,
+                eStratumErrorCode[eStratumErrorCode.JobNotFound],
+                this.sessionDifficulty,
+            );
             console.warn(`Job template ${job.jobTemplateId} not found for job ${submission.jobId}`);
             delete this.stratumV1JobsService.jobs[submission.jobId];
             const err = new StratumErrorMessage(
@@ -797,7 +809,11 @@ export class StratumV1Client {
                 eStratumErrorCode[eStratumErrorCode.LowDifficultyShare],
                 this.sessionDifficulty,
             );
-            await this.statistics.addRejectedShare(this.entity);
+            await this.statistics.addRejectedShare(
+                this.entity,
+                eStratumErrorCode[eStratumErrorCode.LowDifficultyShare],
+                this.sessionDifficulty,
+            );
             const err = new StratumErrorMessage(
                 submission.id,
                 eStratumErrorCode.LowDifficultyShare,

--- a/src/models/StratumV1ClientStatistics.ts
+++ b/src/models/StratumV1ClientStatistics.ts
@@ -10,6 +10,12 @@ export class StratumV1ClientStatistics {
     private shares: number = 0;
     private acceptedCount: number = 0;
     private rejectedCount: number = 0;
+    private rejectedJobNotFoundCount: number = 0;
+    private rejectedJobNotFoundDiff1: number = 0;
+    private rejectedDuplicateShareCount: number = 0;
+    private rejectedDuplicateShareDiff1: number = 0;
+    private rejectedLowDifficultyShareCount: number = 0;
+    private rejectedLowDifficultyShareDiff1: number = 0;
 
     private submissionCacheStart: Date;
     private submissionCache: { time: Date, difficulty: number }[] = [];
@@ -34,6 +40,56 @@ export class StratumV1ClientStatistics {
         const tpm = parseFloat(this.configService.get('TARGET_SHARES_PER_MINUTE') ?? '6');
         this.targetSharesPerMinute = isNaN(tpm) ? 6 : tpm;
         this.targetSubmissionPerSecond = 60 / this.targetSharesPerMinute;
+    }
+
+    private resetRejectedStats() {
+        this.rejectedCount = 0;
+        this.rejectedJobNotFoundCount = 0;
+        this.rejectedJobNotFoundDiff1 = 0;
+        this.rejectedDuplicateShareCount = 0;
+        this.rejectedDuplicateShareDiff1 = 0;
+        this.rejectedLowDifficultyShareCount = 0;
+        this.rejectedLowDifficultyShareDiff1 = 0;
+    }
+
+    private incrementRejectedStats(reason: string, difficulty: number) {
+        const diff1 = Number.isFinite(difficulty) ? difficulty : 0;
+        this.rejectedCount++;
+
+        switch (reason) {
+            case 'JobNotFound':
+                this.rejectedJobNotFoundCount++;
+                this.rejectedJobNotFoundDiff1 += diff1;
+                break;
+            case 'DuplicateShare':
+                this.rejectedDuplicateShareCount++;
+                this.rejectedDuplicateShareDiff1 += diff1;
+                break;
+            case 'LowDifficultyShare':
+                this.rejectedLowDifficultyShareCount++;
+                this.rejectedLowDifficultyShareDiff1 += diff1;
+                break;
+            default:
+                break;
+        }
+    }
+
+    private buildPersistencePayload(client: ClientEntity) {
+        return {
+            time: this.currentTimeSlot,
+            shares: this.shares,
+            acceptedCount: this.acceptedCount,
+            rejectedCount: this.rejectedCount,
+            rejectedJobNotFoundCount: this.rejectedJobNotFoundCount,
+            rejectedJobNotFoundDiff1: this.rejectedJobNotFoundDiff1,
+            rejectedDuplicateShareCount: this.rejectedDuplicateShareCount,
+            rejectedDuplicateShareDiff1: this.rejectedDuplicateShareDiff1,
+            rejectedLowDifficultyShareCount: this.rejectedLowDifficultyShareCount,
+            rejectedLowDifficultyShareDiff1: this.rejectedLowDifficultyShareDiff1,
+            address: client.address,
+            clientName: client.clientName,
+            sessionId: client.sessionId
+        };
     }
 
 
@@ -65,65 +121,33 @@ export class StratumV1ClientStatistics {
 
         if (this.currentTimeSlot == null) {
             // First record, insert it
-			this.previousTimeSlotTime = new Date();
+                        this.previousTimeSlotTime = new Date();
             this.currentTimeSlotTime = new Date();
             this.currentTimeSlot = timeSlot;
             this.shares += targetDifficulty;
             this.acceptedCount++;
-            this.rejectedCount = 0;
-            await this.clientStatisticsService.insert({
-                time: this.currentTimeSlot,
-                shares: this.shares,
-                acceptedCount: this.acceptedCount,
-                rejectedCount: this.rejectedCount,
-                address: client.address,
-                clientName: client.clientName,
-                sessionId: client.sessionId
-            });
+            this.resetRejectedStats();
+            await this.clientStatisticsService.insert(this.buildPersistencePayload(client));
             this.lastSave = new Date().getTime();
         } else if (this.currentTimeSlot != timeSlot) {
             // Transitioning to a new time slot,
             // First update the old time slot with the latest data
-            await this.clientStatisticsService.update({
-                time: this.currentTimeSlot,
-                shares: this.shares,
-                acceptedCount: this.acceptedCount,
-                rejectedCount: this.rejectedCount,
-                address: client.address,
-                clientName: client.clientName,
-                sessionId: client.sessionId
-            });
-			 this.previousShares = this.shares;
+            await this.clientStatisticsService.update(this.buildPersistencePayload(client));
+                         this.previousShares = this.shares;
             this.previousTimeSlotTime = this.currentTimeSlotTime;
             this.currentTimeSlotTime = new Date();
             // Set the new time slot and add incoming shares then insert it
             this.currentTimeSlot = timeSlot;
             this.shares = targetDifficulty;
             this.acceptedCount = 1;
-            this.rejectedCount = 0;
-            await this.clientStatisticsService.insert({
-                time: this.currentTimeSlot,
-                shares: this.shares,
-                acceptedCount: this.acceptedCount,
-                rejectedCount: this.rejectedCount,
-                address: client.address,
-                clientName: client.clientName,
-                sessionId: client.sessionId
-            });
+            this.resetRejectedStats();
+            await this.clientStatisticsService.insert(this.buildPersistencePayload(client));
             this.lastSave = new Date().getTime();
         } else if ((date.getTime() - 60 * 1000) > this.lastSave) {
             // If we haven't saved for a minute, update the table
             this.shares += targetDifficulty;
             this.acceptedCount++;
-            await this.clientStatisticsService.update({
-                time: this.currentTimeSlot,
-                shares: this.shares,
-                acceptedCount: this.acceptedCount,
-                rejectedCount: this.rejectedCount,
-                address: client.address,
-                clientName: client.clientName,
-                sessionId: client.sessionId
-            });
+            await this.clientStatisticsService.update(this.buildPersistencePayload(client));
             this.lastSave = new Date().getTime();
         } else {
             // Accept the shares if none of the prior conditions are met,
@@ -138,7 +162,7 @@ export class StratumV1ClientStatistics {
 
     }
 
-    public async addRejectedShare(client: ClientEntity) {
+    public async addRejectedShare(client: ClientEntity, reason: string, difficulty: number) {
 
         var coeff = 1000 * 60 * 10;
         var date = new Date();
@@ -150,60 +174,30 @@ export class StratumV1ClientStatistics {
             this.currentTimeSlot = timeSlot;
             this.shares = this.shares ?? 0;
             this.acceptedCount = this.acceptedCount ?? 0;
-            this.rejectedCount = 1;
-            await this.clientStatisticsService.insert({
-                time: this.currentTimeSlot,
-                shares: this.shares,
-                acceptedCount: this.acceptedCount,
-                rejectedCount: this.rejectedCount,
-                address: client.address,
-                clientName: client.clientName,
-                sessionId: client.sessionId
-            });
+            this.resetRejectedStats();
+            this.incrementRejectedStats(reason, difficulty);
+            await this.clientStatisticsService.insert(this.buildPersistencePayload(client));
             this.lastSave = null;
             return;
         }
 
         if (this.currentTimeSlot != timeSlot) {
-            await this.clientStatisticsService.update({
-                time: this.currentTimeSlot,
-                shares: this.shares,
-                acceptedCount: this.acceptedCount,
-                rejectedCount: this.rejectedCount,
-                address: client.address,
-                clientName: client.clientName,
-                sessionId: client.sessionId
-            });
+            await this.clientStatisticsService.update(this.buildPersistencePayload(client));
             this.previousShares = this.shares;
             this.previousTimeSlotTime = this.currentTimeSlotTime;
             this.currentTimeSlotTime = new Date();
             this.currentTimeSlot = timeSlot;
             this.shares = 0;
             this.acceptedCount = 0;
-            this.rejectedCount = 1;
-            await this.clientStatisticsService.insert({
-                time: this.currentTimeSlot,
-                shares: this.shares,
-                acceptedCount: this.acceptedCount,
-                rejectedCount: this.rejectedCount,
-                address: client.address,
-                clientName: client.clientName,
-                sessionId: client.sessionId
-            });
+            this.resetRejectedStats();
+            this.incrementRejectedStats(reason, difficulty);
+            await this.clientStatisticsService.insert(this.buildPersistencePayload(client));
             this.lastSave = null;
             return;
         }
 
-        this.rejectedCount++;
-        await this.clientStatisticsService.update({
-            time: this.currentTimeSlot,
-            shares: this.shares,
-            acceptedCount: this.acceptedCount,
-            rejectedCount: this.rejectedCount,
-            address: client.address,
-            clientName: client.clientName,
-            sessionId: client.sessionId
-        });
+        this.incrementRejectedStats(reason, difficulty);
+        await this.clientStatisticsService.update(this.buildPersistencePayload(client));
         this.lastSave = null;
     }
 

--- a/src/models/StratumV1ClientStatistics.ts
+++ b/src/models/StratumV1ClientStatistics.ts
@@ -9,6 +9,7 @@ export class StratumV1ClientStatistics {
 
     private shares: number = 0;
     private acceptedCount: number = 0;
+    private rejectedCount: number = 0;
 
     private submissionCacheStart: Date;
     private submissionCache: { time: Date, difficulty: number }[] = [];
@@ -69,10 +70,12 @@ export class StratumV1ClientStatistics {
             this.currentTimeSlot = timeSlot;
             this.shares += targetDifficulty;
             this.acceptedCount++;
+            this.rejectedCount = 0;
             await this.clientStatisticsService.insert({
                 time: this.currentTimeSlot,
                 shares: this.shares,
                 acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
                 address: client.address,
                 clientName: client.clientName,
                 sessionId: client.sessionId
@@ -85,6 +88,7 @@ export class StratumV1ClientStatistics {
                 time: this.currentTimeSlot,
                 shares: this.shares,
                 acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
                 address: client.address,
                 clientName: client.clientName,
                 sessionId: client.sessionId
@@ -95,11 +99,13 @@ export class StratumV1ClientStatistics {
             // Set the new time slot and add incoming shares then insert it
             this.currentTimeSlot = timeSlot;
             this.shares = targetDifficulty;
-            this.acceptedCount = 1
+            this.acceptedCount = 1;
+            this.rejectedCount = 0;
             await this.clientStatisticsService.insert({
                 time: this.currentTimeSlot,
                 shares: this.shares,
                 acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
                 address: client.address,
                 clientName: client.clientName,
                 sessionId: client.sessionId
@@ -113,6 +119,7 @@ export class StratumV1ClientStatistics {
                 time: this.currentTimeSlot,
                 shares: this.shares,
                 acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
                 address: client.address,
                 clientName: client.clientName,
                 sessionId: client.sessionId
@@ -129,6 +136,75 @@ export class StratumV1ClientStatistics {
         }
         }
 
+    }
+
+    public async addRejectedShare(client: ClientEntity) {
+
+        var coeff = 1000 * 60 * 10;
+        var date = new Date();
+        var timeSlot = new Date(Math.floor(date.getTime() / coeff) * coeff).getTime();
+
+        if (this.currentTimeSlot == null) {
+            this.previousTimeSlotTime = new Date();
+            this.currentTimeSlotTime = new Date();
+            this.currentTimeSlot = timeSlot;
+            this.shares = this.shares ?? 0;
+            this.acceptedCount = this.acceptedCount ?? 0;
+            this.rejectedCount = 1;
+            await this.clientStatisticsService.insert({
+                time: this.currentTimeSlot,
+                shares: this.shares,
+                acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
+                address: client.address,
+                clientName: client.clientName,
+                sessionId: client.sessionId
+            });
+            this.lastSave = null;
+            return;
+        }
+
+        if (this.currentTimeSlot != timeSlot) {
+            await this.clientStatisticsService.update({
+                time: this.currentTimeSlot,
+                shares: this.shares,
+                acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
+                address: client.address,
+                clientName: client.clientName,
+                sessionId: client.sessionId
+            });
+            this.previousShares = this.shares;
+            this.previousTimeSlotTime = this.currentTimeSlotTime;
+            this.currentTimeSlotTime = new Date();
+            this.currentTimeSlot = timeSlot;
+            this.shares = 0;
+            this.acceptedCount = 0;
+            this.rejectedCount = 1;
+            await this.clientStatisticsService.insert({
+                time: this.currentTimeSlot,
+                shares: this.shares,
+                acceptedCount: this.acceptedCount,
+                rejectedCount: this.rejectedCount,
+                address: client.address,
+                clientName: client.clientName,
+                sessionId: client.sessionId
+            });
+            this.lastSave = null;
+            return;
+        }
+
+        this.rejectedCount++;
+        await this.clientStatisticsService.update({
+            time: this.currentTimeSlot,
+            shares: this.shares,
+            acceptedCount: this.acceptedCount,
+            rejectedCount: this.rejectedCount,
+            address: client.address,
+            clientName: client.clientName,
+            sessionId: client.sessionId
+        });
+        this.lastSave = null;
     }
 
     public getSuggestedDifficulty(clientDifficulty: number) {


### PR DESCRIPTION
Added per-worker rejected-share tracking by extending the statistics entity, propagating the new rejectedCount field through update operations, and persisting it from the stratum client statistics layer so rejected totals stay in sync with accepted counts for each time slot.

Updated worker chart aggregation to support 1d/3d/7d ranges while summing accepted and rejected shares, and surfaced those metrics from the worker info endpoint so clients receive { label, data, accepted, rejected } entries by default over seven days.

Added unit and controller coverage to verify the new accepted/rejected rollups and the endpoint’s seven-day default range, preventing regressions in the worker chart payload.
