### PR TITLE
Adjust accepted aggregation to use diff1 shares

### DIFF
--- a/src/ORM/client-statistics/client-statistics.service.spec.ts
+++ b/src/ORM/client-statistics/client-statistics.service.spec.ts
@@ -6,7 +6,7 @@ describe('ClientStatisticsService - getChartDataForGroup', () => {
       {
         label: 1700000000000,
         data: '123.5',
-        accepted: '10',
+        accepted: '4294967296',
         rejectedJobNotFound: '1',
         rejectedJobNotFoundDiff1: '4000',
         rejectedDuplicatedShare: '2',
@@ -17,7 +17,7 @@ describe('ClientStatisticsService - getChartDataForGroup', () => {
       {
         label: 1700000600000,
         data: '456.75',
-        accepted: '20',
+        accepted: '8589934592',
         rejectedJobNotFound: '0',
         rejectedJobNotFoundDiff1: '0',
         rejectedDuplicatedShare: '1',
@@ -34,7 +34,7 @@ describe('ClientStatisticsService - getChartDataForGroup', () => {
 
       expect(queryMock).toHaveBeenCalledTimes(1);
       const queryString = queryMock.mock.calls[0][0] as string;
-      expect(queryString).toContain('SUM(entry.acceptedCount) AS accepted');
+      expect(queryString).toContain('SUM(entry.shares) AS accepted');
       expect(queryString).toContain(
         'SUM(entry.rejectedJobNotFoundCount) AS rejectedJobNotFound',
       );
@@ -59,7 +59,7 @@ describe('ClientStatisticsService - getChartDataForGroup', () => {
       expect(result[0]).toEqual({
         label: new Date(1700000000000).toISOString(),
         data: 123.5,
-        accepted: 10,
+        accepted: 4294967296,
         rejectedJobNotFound: 1,
         rejectedJobNotFoundDiff1: 4000,
         rejectedDuplicatedShare: 2,

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -310,7 +310,7 @@ export class ClientStatisticsService {
             SELECT
                 time label,
                 (SUM(shares) * ${DIFFICULTY_1}) / 600 AS data,
-                SUM(entry.acceptedCount) AS accepted,
+                SUM(entry.shares) AS accepted,
                 SUM(entry.rejectedJobNotFoundCount) AS rejectedJobNotFound,
                 SUM(entry.rejectedJobNotFoundDiff1) AS rejectedJobNotFoundDiff1,
                 SUM(entry.rejectedDuplicateShareCount) AS rejectedDuplicatedShare,
@@ -336,7 +336,7 @@ export class ClientStatisticsService {
     const parsed = result.map((res) => ({
       label: new Date(res.label).toISOString(),
       data: res.data == null ? 0 : Number(res.data),
-      accepted: res.accepted == null ? 0 : Number(res.accepted),
+      accepted: Number(res.accepted ?? 0),
       rejectedJobNotFound:
         res.rejectedJobNotFound == null ? 0 : Number(res.rejectedJobNotFound),
       rejectedJobNotFoundDiff1:

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -167,7 +167,7 @@ export class ClientController {
     async getWorkerGroupInfo(
         @Param('address') address: string,
         @Param('workerName') workerName: string,
-        @Query('range') range: '1d' | '3d' | '7d' = '7d',
+        @Query('range') range: '1d' | '3d' | '7d' = '1d',
     ) {
 
         const workers = await this.clientService.getByName(address, workerName);

--- a/src/controllers/client/client.controller.worker.spec.ts
+++ b/src/controllers/client/client.controller.worker.spec.ts
@@ -21,7 +21,7 @@ describe('ClientController worker chart data', () => {
         {
           label: '2023-11-14T00:00:00.000Z',
           data: 100,
-          accepted: 5,
+          accepted: 4294967296,
           rejectedJobNotFound: 1,
           rejectedJobNotFoundDiff1: 2000,
           rejectedDuplicatedShare: 0,
@@ -69,7 +69,7 @@ describe('ClientController worker chart data', () => {
       {
         label: '2023-11-14T00:00:00.000Z',
         data: 100,
-        accepted: 5,
+        accepted: 4294967296,
         rejectedJobNotFound: 1,
         rejectedJobNotFoundDiff1: 2000,
         rejectedDuplicatedShare: 0,
@@ -97,7 +97,7 @@ describe('ClientController worker chart data', () => {
       {
         label: '2023-11-14T00:00:00.000Z',
         data: 100,
-        accepted: 5,
+        accepted: 4294967296,
         rejectedJobNotFound: 1,
         rejectedJobNotFoundDiff1: 2000,
         rejectedDuplicatedShare: 0,

--- a/src/controllers/client/client.controller.worker.spec.ts
+++ b/src/controllers/client/client.controller.worker.spec.ts
@@ -85,7 +85,7 @@ describe('ClientController worker chart data', () => {
     );
   });
 
-  it('defaults to returning seven days of chart data when no range is specified', async () => {
+  it('defaults to returning one day of chart data when no range is specified', async () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/client/addr123/workerA',
@@ -110,6 +110,6 @@ describe('ClientController worker chart data', () => {
       clientStatisticsService.getChartDataForGroup.mock.calls[
         clientStatisticsService.getChartDataForGroup.mock.calls.length - 1
       ];
-    expect(lastCall).toEqual(['addr123', 'workerA', '7d']);
+    expect(lastCall).toEqual(['addr123', 'workerA', '1d']);
   });
 });


### PR DESCRIPTION
## Summary
- update the worker chart aggregation to sum difficulty-1 weighted shares for accepted totals
- align service and controller tests with the new accepted share semantics
