### PR TITLE
Fix cache TTL units and refresh worker stats

### DIFF
--- a/src/ORM/client/client.service.ts
+++ b/src/ORM/client/client.service.ts
@@ -109,6 +109,22 @@ export class ClientService {
         return await this.clientRepository.count();
     }
 
+    public async getActiveWorkerCounts(): Promise<{ addresses: number; workers: number; sessions: number }> {
+        const result = await this.clientRepository
+            .createQueryBuilder('client')
+            .select('COUNT(DISTINCT client.address)', 'addresses')
+            .addSelect("COUNT(DISTINCT client.address || '-' || client.clientName)", 'workers')
+            .addSelect('COUNT(*)', 'sessions')
+            .where('client.deletedAt IS NULL')
+            .getRawOne<{ addresses: string; workers: string; sessions: string }>();
+
+        return {
+            addresses: Number(result?.addresses ?? 0),
+            workers: Number(result?.workers ?? 0),
+            sessions: Number(result?.sessions ?? 0),
+        };
+    }
+
     public async getByAddress(address: string): Promise<ClientEntity[]> {
         return await this.clientRepository.find({
             where: {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -95,7 +95,7 @@ export class AppController {
     };
 
     //1 min
-    await this.cacheManager.set(CACHE_KEY, data, 1 * 60 * 1000);
+    await this.cacheManager.set(CACHE_KEY, data, 1 * 60);
 
     return data;
 
@@ -115,7 +115,7 @@ export class AppController {
       return cached;
     }
     const data = await this.bitcoinRpcService.getNetworkInfo();
-    await this.cacheManager.set(CACHE_KEY, data, 60 * 1000);
+    await this.cacheManager.set(CACHE_KEY, data, 60);
     return data;
   }
 
@@ -204,7 +204,7 @@ export class AppController {
     }
 
     //5 min
-    await this.cacheManager.set(CACHE_KEY, data, 5 * 60 * 1000);
+    await this.cacheManager.set(CACHE_KEY, data, 5 * 60);
 
     return data;
   }
@@ -250,7 +250,7 @@ export class AppController {
       })
     );
 
-    await this.cacheManager.set(CACHE_KEY, result, 1 * 60 * 1000);
+    await this.cacheManager.set(CACHE_KEY, result, 1 * 60);
     return result;
   }
 
@@ -273,7 +273,7 @@ export class AppController {
     const chartData = await this.clientStatisticsService.getChartDataForSite(range);
 
     //10 min
-    await this.cacheManager.set(CACHE_KEY, chartData, 10 * 60 * 1000);
+    await this.cacheManager.set(CACHE_KEY, chartData, 10 * 60);
 
     return chartData;
 
@@ -311,7 +311,7 @@ export class AppController {
       rejectedSinceBlock: totalsSinceBlock.rejected,
     };
 
-    await this.cacheManager.set(CACHE_KEY, data, 10 * 60 * 1000);
+    await this.cacheManager.set(CACHE_KEY, data, 10 * 60);
 
     return data;
 
@@ -350,7 +350,7 @@ export class AppController {
       });
     }
 
-    await this.cacheManager.set(CACHE_KEY, { slotData }, 10 * 60 * 1000);
+    await this.cacheManager.set(CACHE_KEY, { slotData }, 10 * 60);
 
     return { slotData };
   }
@@ -405,7 +405,13 @@ export class AppController {
       });
     }
 
-    await this.cacheManager.set(CACHE_KEY, { slotData }, 10 * 60 * 1000);
+    const currentSlot = Math.floor(now / coeff) * coeff;
+    if (endSlot === currentSlot && slotData.length > 0) {
+      const liveCounts = await this.clientService.getActiveWorkerCounts();
+      slotData[slotData.length - 1].counts = liveCounts;
+    }
+
+    await this.cacheManager.set(CACHE_KEY, { slotData }, 10 * 60);
 
     return { slotData };
   }
@@ -450,7 +456,7 @@ export class AppController {
       slotData.push({ time: new Date(t).toISOString(), counts });
     }
 
-    await this.cacheManager.set(CACHE_KEY, { slotData }, 10 * 60 * 1000);
+    await this.cacheManager.set(CACHE_KEY, { slotData }, 10 * 60);
 
     return { slotData };
   }


### PR DESCRIPTION
## Summary
- update all cache writes in `app.controller.ts` to use TTL values in seconds rather than milliseconds
- ensure the worker stats endpoint now respects the intended ten-minute cache duration
- add live worker, address, and session counts for the latest interval by querying active clients directly
