### PR TITLE
Fix pool rejected stats flush increments in pm2 mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to **BlitzPool**, a lightweight and open-source Bitcoin mining pool based on the [public-pool](https://github.com/benjamin-wilson/public-pool) project – extended with powerful new features and real-world integrations.
 
-Current Version: **v1.3.2**
+Current Version: **v1.3.3**
 
 🌐 **Live Pool:** [https://blitzpool.yourdevice.ch/#/](https://blitzpool.yourdevice.ch/#/)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "public-pool",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "public-pool",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-pool",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "",
   "author": "",
   "private": true,

--- a/src/ORM/client-rejected-statistics/client-rejected-statistics.service.spec.ts
+++ b/src/ORM/client-rejected-statistics/client-rejected-statistics.service.spec.ts
@@ -1,0 +1,69 @@
+import { DataSource } from 'typeorm';
+
+import { ClientRejectedStatisticsEntity } from './client-rejected-statistics.entity';
+import { ClientRejectedStatisticsService } from './client-rejected-statistics.service';
+
+describe('ClientRejectedStatisticsService', () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: 'sqlite',
+      database: ':memory:',
+      entities: [ClientRejectedStatisticsEntity],
+      synchronize: true,
+    });
+    await dataSource.initialize();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it('accumulates deltas when flushing over an existing row', async () => {
+    const repository = dataSource.getRepository(ClientRejectedStatisticsEntity);
+    const service = new ClientRejectedStatisticsService(repository as any);
+
+    const tenMinutes = 1000 * 60 * 10;
+    const now = 1700000000000;
+    const timeSlot = Math.floor(now / tenMinutes) * tenMinutes;
+
+    await repository.insert({
+      address: 'addr',
+      reason: 'duplicate',
+      time: timeSlot,
+      count: 10,
+      shares: 100,
+    });
+
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(timeSlot + 5_000);
+
+    try {
+      await service.addRejectedShare('addr', 'duplicate', 5);
+      await (service as any).saveCurrent();
+
+      let row = await repository.findOneBy({
+        address: 'addr',
+        reason: 'duplicate',
+        time: timeSlot,
+      });
+
+      expect(row).toMatchObject({ count: 11, shares: 104 });
+
+      await service.addRejectedShare('addr', 'duplicate', 3);
+      await (service as any).saveCurrent();
+
+      row = await repository.findOneBy({
+        address: 'addr',
+        reason: 'duplicate',
+        time: timeSlot,
+      });
+
+      expect(row).toMatchObject({ count: 12, shares: 106 });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+});

--- a/src/ORM/client-rejected-statistics/client-rejected-statistics.service.ts
+++ b/src/ORM/client-rejected-statistics/client-rejected-statistics.service.ts
@@ -36,32 +36,14 @@ export class ClientRejectedStatisticsService {
 
       if (this.currentTimeSlot == null) {
         this.currentTimeSlot = timeSlot;
-        const existing = await this.clientRejectedStatisticsRepository.findBy({ time: timeSlot });
         this.counts.clear();
-        for (const rec of existing) {
-          if (!this.counts.has(rec.address)) {
-            this.counts.set(rec.address, new Map());
-          }
-          this.counts
-            .get(rec.address)
-            .set(rec.reason, { count: rec.count, shares: rec.shares ?? 0 });
-        }
         this.lastSave = now;
       }
 
       if (this.currentTimeSlot !== timeSlot) {
         await this.saveCurrent();
         this.currentTimeSlot = timeSlot;
-        const existing = await this.clientRejectedStatisticsRepository.findBy({ time: timeSlot });
         this.counts.clear();
-        for (const rec of existing) {
-          if (!this.counts.has(rec.address)) {
-            this.counts.set(rec.address, new Map());
-          }
-          this.counts
-            .get(rec.address)
-            .set(rec.reason, { count: rec.count, shares: rec.shares ?? 0 });
-        }
         this.lastSave = now;
       }
 
@@ -83,29 +65,51 @@ export class ClientRejectedStatisticsService {
   }
 
   private async saveCurrent() {
-    for (const [address, reasons] of this.counts) {
-      for (const [reason, stats] of reasons) {
-        const existing = await this.clientRejectedStatisticsRepository.findOneBy({
+    if (this.counts.size === 0) {
+      return;
+    }
+
+    const values: Array<{
+      time: number;
+      address: string;
+      reason: string;
+      count: number;
+      shares: number;
+    }> = [];
+
+    for (const [address, reasons] of this.counts.entries()) {
+      for (const [reason, stats] of reasons.entries()) {
+        if (stats.count === 0 && stats.shares === 0) {
+          continue;
+        }
+
+        values.push({
           time: this.currentTimeSlot,
           address,
           reason,
+          count: stats.count,
+          shares: stats.shares,
         });
-        if (existing) {
-          await this.clientRejectedStatisticsRepository.update(
-            { time: this.currentTimeSlot, address, reason },
-            { count: stats.count, shares: stats.shares, updatedAt: new Date() },
-          );
-        } else {
-          await this.clientRejectedStatisticsRepository.insert({
-            time: this.currentTimeSlot,
-            address,
-            reason,
-            count: stats.count,
-            shares: stats.shares,
-          });
-        }
       }
     }
+
+    if (values.length === 0) {
+      this.counts.clear();
+      return;
+    }
+
+    await this.clientRejectedStatisticsRepository
+      .createQueryBuilder()
+      .insert()
+      .into(ClientRejectedStatisticsEntity)
+      .values(values)
+      .onConflict(
+        '("time", "address", "reason") DO UPDATE SET "count" = "count" + EXCLUDED."count", "shares" = COALESCE("shares", 0) + EXCLUDED."shares", "updatedAt" = :updatedAt',
+      )
+      .setParameters({ updatedAt: new Date() })
+      .execute();
+
+    this.counts.clear();
   }
 
   public async getTotalsSince(

--- a/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
+++ b/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
@@ -86,22 +86,14 @@ export class PoolRejectedStatisticsService {
 
       if (this.currentTimeSlot == null) {
         this.currentTimeSlot = timeSlot;
-        const existing = await this.poolRejectedStatisticsRepository.findBy({ time: timeSlot });
         this.counts.clear();
-        for (const rec of existing) {
-          this.counts.set(rec.reason, rec.count);
-        }
         this.lastSave = now;
       }
 
       if (this.currentTimeSlot !== timeSlot) {
         await this.saveCurrent();
         this.currentTimeSlot = timeSlot;
-        const existing = await this.poolRejectedStatisticsRepository.findBy({ time: timeSlot });
         this.counts.clear();
-        for (const rec of existing) {
-          this.counts.set(rec.reason, rec.count);
-        }
         this.lastSave = now;
       }
 
@@ -140,17 +132,35 @@ export class PoolRejectedStatisticsService {
   }
 
   private async saveCurrent() {
-    for (const [reason, count] of this.counts) {
-      const existing = await this.poolRejectedStatisticsRepository.findOneBy({ time: this.currentTimeSlot, reason });
-      if (existing) {
-        await this.poolRejectedStatisticsRepository.update(
-          { time: this.currentTimeSlot, reason },
-          { count, updatedAt: new Date() },
-        );
-      } else {
-        await this.poolRejectedStatisticsRepository.insert({ time: this.currentTimeSlot, reason, count });
-      }
+    if (this.counts.size === 0) {
+      return;
     }
+
+    const values = Array.from(this.counts.entries())
+      .filter(([, delta]) => delta !== 0)
+      .map(([reason, delta]) => ({
+        time: this.currentTimeSlot,
+        reason,
+        count: delta,
+      }));
+
+    if (values.length === 0) {
+      this.counts.clear();
+      return;
+    }
+
+    await this.poolRejectedStatisticsRepository
+      .createQueryBuilder()
+      .insert()
+      .into(PoolRejectedStatisticsEntity)
+      .values(values)
+      .onConflict(
+        '("time", "reason") DO UPDATE SET "count" = "count" + EXCLUDED."count", "updatedAt" = :updatedAt',
+      )
+      .setParameters({ updatedAt: new Date() })
+      .execute();
+
+    this.counts.clear();
   }
 
   public async getTotalsSince(time: number): Promise<Record<string, number>> {

--- a/src/ORM/pool-share-statistics/pool-share-statistics.service.spec.ts
+++ b/src/ORM/pool-share-statistics/pool-share-statistics.service.spec.ts
@@ -58,4 +58,103 @@ describe('PoolShareStatisticsService', () => {
       nowSpy.mockRestore();
     }
   });
+
+  it('retains shares added while a flush is executing', async () => {
+    const tenMinutes = 1000 * 60 * 10;
+    const baseTimestamp = 1800000000000;
+    const timeSlot = Math.floor(baseTimestamp / tenMinutes) * tenMinutes;
+
+    const nowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(baseTimestamp + 30_000);
+
+    const rows = new Map<
+      number,
+      { accepted: number; rejected: number }
+    >();
+
+    let resolveExecute: () => void = () => {};
+    const executeBlocker = new Promise<void>((resolve) => {
+      resolveExecute = resolve;
+    });
+    let notifyStarted: () => void = () => {};
+    const executeStarted = new Promise<void>((resolve) => {
+      notifyStarted = resolve;
+    });
+    let firstExecute = true;
+
+    const repository = {
+      createQueryBuilder: () => {
+        const builder: any = {
+          payload: {
+            time: timeSlot,
+            accepted: 0,
+            rejected: 0,
+          },
+          insert() {
+            return this;
+          },
+          into() {
+            return this;
+          },
+          values(value: Partial<PoolShareStatisticsEntity>) {
+            this.payload = value;
+            return this;
+          },
+          onConflict() {
+            return this;
+          },
+          setParameters() {
+            return this;
+          },
+          async execute() {
+            if (firstExecute) {
+              firstExecute = false;
+              notifyStarted();
+              await executeBlocker;
+            }
+            const { time, accepted = 0, rejected = 0 } = this.payload;
+            const current = rows.get(time) ?? { accepted: 0, rejected: 0 };
+            rows.set(time, {
+              accepted: current.accepted + accepted,
+              rejected: current.rejected + rejected,
+            });
+          },
+        };
+        return builder;
+      },
+      findOneBy({ time }: { time: number }) {
+        const row = rows.get(time);
+        return row ? { time, ...row } : null;
+      },
+    };
+
+    const service = new PoolShareStatisticsService(repository as any);
+
+    try {
+      await service.addAcceptedShare(2);
+      await service.addRejectedShare(1);
+
+      const flushPromise = (service as any).flush();
+
+      await executeStarted;
+
+      await service.addAcceptedShare(5);
+      await service.addRejectedShare(4);
+
+      resolveExecute();
+
+      await flushPromise;
+
+      let row = await repository.findOneBy({ time: timeSlot });
+      expect(row).toMatchObject({ accepted: 2, rejected: 1 });
+
+      await (service as any).flush();
+
+      row = await repository.findOneBy({ time: timeSlot });
+      expect(row).toMatchObject({ accepted: 7, rejected: 5 });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
 });

--- a/src/ORM/pool-share-statistics/pool-share-statistics.service.spec.ts
+++ b/src/ORM/pool-share-statistics/pool-share-statistics.service.spec.ts
@@ -157,4 +157,84 @@ describe('PoolShareStatisticsService', () => {
       nowSpy.mockRestore();
     }
   });
+
+  it('requeues the snapshot if persistence fails', async () => {
+    const tenMinutes = 1000 * 60 * 10;
+    const baseTimestamp = 1900000000000;
+    const timeSlot = Math.floor(baseTimestamp / tenMinutes) * tenMinutes;
+
+    const nowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(baseTimestamp + 15_000);
+
+    const rows = new Map<
+      number,
+      { accepted: number; rejected: number }
+    >();
+
+    let shouldFail = true;
+
+    const repository = {
+      createQueryBuilder: () => {
+        const builder: any = {
+          payload: {
+            time: timeSlot,
+            accepted: 0,
+            rejected: 0,
+          },
+          insert() {
+            return this;
+          },
+          into() {
+            return this;
+          },
+          values(value: Partial<PoolShareStatisticsEntity>) {
+            this.payload = value;
+            return this;
+          },
+          onConflict() {
+            return this;
+          },
+          setParameters() {
+            return this;
+          },
+          async execute() {
+            if (shouldFail) {
+              shouldFail = false;
+              throw new Error('boom');
+            }
+            const { time, accepted = 0, rejected = 0 } = this.payload;
+            const current = rows.get(time) ?? { accepted: 0, rejected: 0 };
+            rows.set(time, {
+              accepted: current.accepted + accepted,
+              rejected: current.rejected + rejected,
+            });
+          },
+        };
+        return builder;
+      },
+      findOneBy({ time }: { time: number }) {
+        const row = rows.get(time);
+        return row ? { time, ...row } : null;
+      },
+    };
+
+    const service = new PoolShareStatisticsService(repository as any);
+
+    try {
+      await service.addAcceptedShare(6);
+      await service.addRejectedShare(2);
+
+      await expect((service as any).flush()).rejects.toThrow('boom');
+
+      expect(rows.size).toBe(0);
+
+      await (service as any).flush();
+
+      const row = await repository.findOneBy({ time: timeSlot });
+      expect(row).toMatchObject({ accepted: 6, rejected: 2 });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
 });

--- a/src/ORM/pool-share-statistics/pool-share-statistics.service.spec.ts
+++ b/src/ORM/pool-share-statistics/pool-share-statistics.service.spec.ts
@@ -1,0 +1,61 @@
+import { DataSource } from 'typeorm';
+
+import { PoolShareStatisticsEntity } from './pool-share-statistics.entity';
+import { PoolShareStatisticsService } from './pool-share-statistics.service';
+
+describe('PoolShareStatisticsService', () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: 'sqlite',
+      database: ':memory:',
+      entities: [PoolShareStatisticsEntity],
+      synchronize: true,
+    });
+    await dataSource.initialize();
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it('adds deltas to an existing bucket on each flush', async () => {
+    const repository = dataSource.getRepository(PoolShareStatisticsEntity);
+    const service = new PoolShareStatisticsService(repository as any);
+
+    const tenMinutes = 1000 * 60 * 10;
+    const baseTimestamp = 1700000000000;
+    const timeSlot = Math.floor(baseTimestamp / tenMinutes) * tenMinutes;
+
+    await repository.insert({
+      time: timeSlot,
+      accepted: 100,
+      rejected: 5,
+    });
+
+    const nowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(baseTimestamp + 5_000);
+
+    try {
+      await service.addAcceptedShare(3);
+      await service.addRejectedShare(2);
+      await (service as any).flush();
+
+      let row = await repository.findOneBy({ time: timeSlot });
+      expect(row).toMatchObject({ accepted: 103, rejected: 7 });
+
+      await service.addAcceptedShare(4);
+      await service.addRejectedShare(1);
+      await (service as any).flush();
+
+      row = await repository.findOneBy({ time: timeSlot });
+      expect(row).toMatchObject({ accepted: 107, rejected: 8 });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+});

--- a/src/ORM/pool-share-statistics/pool-share-statistics.service.ts
+++ b/src/ORM/pool-share-statistics/pool-share-statistics.service.ts
@@ -55,23 +55,22 @@ export class PoolShareStatisticsService {
     await this.mutex.runExclusive(async () => {
       if (this.accepted === 0 && this.rejected === 0) return;
 
-      const existing = await this.poolShareStatisticsRepository.findOneBy({ time: this.currentTimeSlot });
-      if (existing) {
-        await this.poolShareStatisticsRepository.update(
-          { time: this.currentTimeSlot },
-          {
-            accepted: existing.accepted + this.accepted,
-            rejected: existing.rejected + this.rejected,
-            updatedAt: new Date(),
-          },
-        );
-      } else {
-        await this.poolShareStatisticsRepository.insert({
+      const updatedAt = new Date();
+
+      await this.poolShareStatisticsRepository
+        .createQueryBuilder()
+        .insert()
+        .into(PoolShareStatisticsEntity)
+        .values({
           time: this.currentTimeSlot,
           accepted: this.accepted,
           rejected: this.rejected,
-        });
-      }
+        })
+        .onConflict(
+          '("time") DO UPDATE SET "accepted" = "accepted" + EXCLUDED."accepted", "rejected" = "rejected" + EXCLUDED."rejected", "updatedAt" = :updatedAt',
+        )
+        .setParameters({ updatedAt })
+        .execute();
 
       this.accepted = 0;
       this.rejected = 0;

--- a/src/ORM/pool-share-statistics/pool-share-statistics.service.ts
+++ b/src/ORM/pool-share-statistics/pool-share-statistics.service.ts
@@ -55,6 +55,13 @@ export class PoolShareStatisticsService {
     await this.mutex.runExclusive(async () => {
       if (this.accepted === 0 && this.rejected === 0) return;
 
+      const accepted = this.accepted;
+      const rejected = this.rejected;
+      const timeSlot = this.currentTimeSlot;
+
+      this.accepted = 0;
+      this.rejected = 0;
+
       const updatedAt = new Date();
 
       await this.poolShareStatisticsRepository
@@ -62,18 +69,15 @@ export class PoolShareStatisticsService {
         .insert()
         .into(PoolShareStatisticsEntity)
         .values({
-          time: this.currentTimeSlot,
-          accepted: this.accepted,
-          rejected: this.rejected,
+          time: timeSlot,
+          accepted,
+          rejected,
         })
         .onConflict(
           '("time") DO UPDATE SET "accepted" = "accepted" + EXCLUDED."accepted", "rejected" = "rejected" + EXCLUDED."rejected", "updatedAt" = :updatedAt',
         )
         .setParameters({ updatedAt })
         .execute();
-
-      this.accepted = 0;
-      this.rejected = 0;
     });
   }
 

--- a/src/ORM/pool-share-statistics/pool-share-statistics.service.ts
+++ b/src/ORM/pool-share-statistics/pool-share-statistics.service.ts
@@ -64,20 +64,26 @@ export class PoolShareStatisticsService {
 
       const updatedAt = new Date();
 
-      await this.poolShareStatisticsRepository
-        .createQueryBuilder()
-        .insert()
-        .into(PoolShareStatisticsEntity)
-        .values({
-          time: timeSlot,
-          accepted,
-          rejected,
-        })
-        .onConflict(
-          '("time") DO UPDATE SET "accepted" = "accepted" + EXCLUDED."accepted", "rejected" = "rejected" + EXCLUDED."rejected", "updatedAt" = :updatedAt',
-        )
-        .setParameters({ updatedAt })
-        .execute();
+      try {
+        await this.poolShareStatisticsRepository
+          .createQueryBuilder()
+          .insert()
+          .into(PoolShareStatisticsEntity)
+          .values({
+            time: timeSlot,
+            accepted,
+            rejected,
+          })
+          .onConflict(
+            '("time") DO UPDATE SET "accepted" = "accepted" + EXCLUDED."accepted", "rejected" = "rejected" + EXCLUDED."rejected", "updatedAt" = :updatedAt',
+          )
+          .setParameters({ updatedAt })
+          .execute();
+      } catch (error) {
+        this.accepted += accepted;
+        this.rejected += rejected;
+        throw error;
+      }
     });
   }
 

--- a/src/services/app.service.spec.ts
+++ b/src/services/app.service.spec.ts
@@ -1,0 +1,63 @@
+import { AppService } from './app.service';
+
+describe('AppService.onModuleInit', () => {
+  let dataSource: { query: jest.Mock };
+  let clientService: {
+    deleteAll: jest.Mock;
+    killDeadClients: jest.Mock;
+    deleteOldClients: jest.Mock;
+  };
+  let clientStatisticsService: { deleteOldStatistics: jest.Mock };
+  let rpcBlockService: { deleteOldBlocks: jest.Mock };
+  let setIntervalSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    dataSource = { query: jest.fn().mockResolvedValue(undefined) };
+    clientService = {
+      deleteAll: jest.fn().mockResolvedValue(undefined),
+      killDeadClients: jest.fn().mockResolvedValue(undefined),
+      deleteOldClients: jest.fn().mockResolvedValue({ affected: 0 }),
+    };
+    clientStatisticsService = {
+      deleteOldStatistics: jest.fn().mockResolvedValue(undefined),
+    };
+    rpcBlockService = {
+      deleteOldBlocks: jest.fn().mockResolvedValue(undefined),
+    };
+    setIntervalSpy = jest
+      .spyOn(global, 'setInterval')
+      .mockReturnValue(null as unknown as NodeJS.Timeout);
+    delete process.env.NODE_APP_INSTANCE;
+  });
+
+  afterEach(() => {
+    setIntervalSpy.mockRestore();
+    delete process.env.NODE_APP_INSTANCE;
+  });
+
+  function createService() {
+    return new AppService(
+      clientStatisticsService as any,
+      clientService as any,
+      dataSource as any,
+      rpcBlockService as any,
+    );
+  }
+
+  it('clears clients when running as a single instance', async () => {
+    const service = createService();
+
+    await service.onModuleInit();
+
+    expect(clientService.deleteAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips clearing clients when NODE_APP_INSTANCE is set', async () => {
+    process.env.NODE_APP_INSTANCE = '1';
+    const service = createService();
+
+    await service.onModuleInit();
+
+    expect(clientService.deleteAll).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -30,7 +30,9 @@ export class AppService implements OnModuleInit {
         // //6Gb
         // await this.dataSource.query(`PRAGMA mmap_size = 6000000000;`);
 
-        await this.clientService.deleteAll();
+        if (process.env.NODE_APP_INSTANCE === undefined) {
+            await this.clientService.deleteAll();
+        }
 
         if (process.env.NODE_APP_INSTANCE == null || process.env.NODE_APP_INSTANCE == '0') {
 

--- a/src/services/stratum-v1.service.spec.ts
+++ b/src/services/stratum-v1.service.spec.ts
@@ -1,0 +1,55 @@
+jest.mock('node-telegram-bot-api', () => jest.fn());
+
+import { StratumV1Service } from './stratum-v1.service';
+
+describe('StratumV1Service.onModuleInit', () => {
+  let clientService: { deleteAll: jest.Mock };
+  let setTimeoutSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    clientService = { deleteAll: jest.fn().mockResolvedValue(undefined) };
+    setTimeoutSpy = jest
+      .spyOn(global, 'setTimeout')
+      .mockReturnValue(null as unknown as NodeJS.Timeout);
+    delete process.env.NODE_APP_INSTANCE;
+  });
+
+  afterEach(() => {
+    setTimeoutSpy.mockRestore();
+    delete process.env.NODE_APP_INSTANCE;
+  });
+
+  function createService() {
+    return new StratumV1Service(
+      {} as any,
+      clientService as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+  }
+
+  it('clears clients when running as a single instance', async () => {
+    const service = createService();
+
+    await service.onModuleInit();
+
+    expect(clientService.deleteAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips clearing clients when NODE_APP_INSTANCE is set', async () => {
+    process.env.NODE_APP_INSTANCE = '1';
+    const service = createService();
+
+    await service.onModuleInit();
+
+    expect(clientService.deleteAll).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -35,7 +35,7 @@ export class StratumV1Service implements OnModuleInit {
   ) {}
 
   async onModuleInit(): Promise<void> {
-    if (process.env.NODE_APP_INSTANCE == '0') {
+    if (process.env.NODE_APP_INSTANCE === undefined) {
       await this.clientService.deleteAll();
     }
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- stop reloading persisted totals when rotating ten-minute windows so each worker only tracks its local deltas
- flush pending deltas with an ON CONFLICT increment so concurrent workers add to the same (time, reason) bucket without overwriting each other
- reset the per-reason cache after each flush to avoid replaying values on the next interval