### PR TITLE
Add hourly difficulty history API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to **BlitzPool**, a lightweight and open-source Bitcoin mining pool based on the [public-pool](https://github.com/benjamin-wilson/public-pool) project – extended with powerful new features and real-world integrations.
 
-Current Version: **v1.3.3**
+Current Version: **v1.3.4**
 
 🌐 **Live Pool:** [https://blitzpool.yourdevice.ch/#/](https://blitzpool.yourdevice.ch/#/)
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ When `DB_TYPE=postgres` and `DB_RUN_MIGRATIONS=true`, BlitzPool now runs both th
 - **Local development/tests:** keep `DB_TYPE` empty or `sqlite` to continue using the bundled SQLite database at `./DB/public-pool.sqlite`. Jest tests automatically exercise both drivers where applicable.
 - You can switch between drivers by updating the env file and restarting the service. Existing SQLite installs can remain on SQLite indefinitely; no forced migration is required.
 
+If you would like the Postgres deployment to mirror SQLite's automatic schema management, set `DB_AUTO_SYNCHRONIZE=true`. The primary instance (`NODE_APP_INSTANCE=0` or unset) will invoke `dataSource.synchronize()` once at boot after migrations run. Leave the flag unset to continue relying solely on migrations.
+
 ## 🔄 Migrating existing SQLite data to Postgres
 
 Existing pools can migrate their on-disk SQLite database by following these steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "public-pool",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "public-pool",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-pool",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "",
   "author": "",
   "private": true,

--- a/src/ORM/client-difficulty-statistics/client-difficulty-statistics.entity.ts
+++ b/src/ORM/client-difficulty-statistics/client-difficulty-statistics.entity.ts
@@ -1,0 +1,22 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+import { TrackedEntity } from '../utils/TrackedEntity.entity';
+
+@Index(['address', 'clientName', 'slotTime'], { unique: true })
+@Entity()
+export class ClientDifficultyStatisticsEntity extends TrackedEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 62, type: 'varchar' })
+  address: string;
+
+  @Column({ length: 64, type: 'varchar', nullable: true })
+  clientName: string | null;
+
+  @Column({ type: 'integer' })
+  slotTime: number;
+
+  @Column({ type: 'real', default: 0 })
+  maxDifficulty: number;
+}

--- a/src/ORM/client-difficulty-statistics/client-difficulty-statistics.module.ts
+++ b/src/ORM/client-difficulty-statistics/client-difficulty-statistics.module.ts
@@ -1,0 +1,13 @@
+import { Global, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { ClientDifficultyStatisticsEntity } from './client-difficulty-statistics.entity';
+import { ClientDifficultyStatisticsService } from './client-difficulty-statistics.service';
+
+@Global()
+@Module({
+  imports: [TypeOrmModule.forFeature([ClientDifficultyStatisticsEntity])],
+  providers: [ClientDifficultyStatisticsService],
+  exports: [TypeOrmModule, ClientDifficultyStatisticsService],
+})
+export class ClientDifficultyStatisticsModule {}

--- a/src/ORM/client-difficulty-statistics/client-difficulty-statistics.service.spec.ts
+++ b/src/ORM/client-difficulty-statistics/client-difficulty-statistics.service.spec.ts
@@ -1,0 +1,93 @@
+import { DataSource } from 'typeorm';
+
+import { ClientDifficultyStatisticsEntity } from './client-difficulty-statistics.entity';
+import { ClientDifficultyStatisticsService } from './client-difficulty-statistics.service';
+
+describe('ClientDifficultyStatisticsService', () => {
+  let dataSource: DataSource;
+  let service: ClientDifficultyStatisticsService;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: 'sqlite',
+      database: ':memory:',
+      entities: [ClientDifficultyStatisticsEntity],
+      synchronize: true,
+    });
+    await dataSource.initialize();
+    service = new ClientDifficultyStatisticsService(
+      dataSource.getRepository(ClientDifficultyStatisticsEntity) as any,
+    );
+  });
+
+  afterEach(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it('stores the highest difficulty per slot and aggregates by address', async () => {
+    const base = Date.UTC(2023, 0, 1, 12, 15, 0, 0);
+
+    await service.recordShareDifficulty({
+      address: 'addr1',
+      clientName: 'workerA',
+      timestamp: base,
+      difficulty: 100,
+    });
+
+    await service.recordShareDifficulty({
+      address: 'addr1',
+      clientName: 'workerA',
+      timestamp: base + 10_000,
+      difficulty: 80,
+    });
+
+    await service.recordShareDifficulty({
+      address: 'addr1',
+      clientName: 'workerA',
+      timestamp: base + 20_000,
+      difficulty: 120,
+    });
+
+    await service.recordShareDifficulty({
+      address: 'addr1',
+      clientName: 'workerB',
+      timestamp: base + 30_000,
+      difficulty: 140,
+    });
+
+    const slotTime = Math.floor(base / (60 * 60 * 1000)) * 60 * 60 * 1000;
+    const entries = await service.getMaximaForAddress('addr1', slotTime, slotTime);
+
+    expect(entries).toEqual([
+      { slotTime, maxDifficulty: 140 },
+    ]);
+  });
+
+  it('purges records older than the configured cutoff', async () => {
+    const oldSlot = Date.UTC(2023, 0, 1, 0, 0, 0, 0);
+    const newSlot = Date.UTC(2023, 0, 2, 0, 0, 0, 0);
+
+    await service.recordShareDifficulty({
+      address: 'addr1',
+      timestamp: oldSlot,
+      difficulty: 10,
+    });
+
+    await service.recordShareDifficulty({
+      address: 'addr1',
+      timestamp: newSlot,
+      difficulty: 20,
+    });
+
+    await service.deleteOlderThan(newSlot);
+
+    const rows = await dataSource
+      .getRepository(ClientDifficultyStatisticsEntity)
+      .find({ order: { slotTime: 'ASC' } });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ slotTime: newSlot, maxDifficulty: 20 });
+  });
+});

--- a/src/ORM/client-difficulty-statistics/client-difficulty-statistics.service.ts
+++ b/src/ORM/client-difficulty-statistics/client-difficulty-statistics.service.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { ClientDifficultyStatisticsEntity } from './client-difficulty-statistics.entity';
+
+const HOUR_IN_MS = 60 * 60 * 1000;
+
+@Injectable()
+export class ClientDifficultyStatisticsService {
+  constructor(
+    @InjectRepository(ClientDifficultyStatisticsEntity)
+    private readonly repository: Repository<ClientDifficultyStatisticsEntity>,
+  ) {}
+
+  private static normalizeSlot(timestamp: number): number {
+    return Math.floor(timestamp / HOUR_IN_MS) * HOUR_IN_MS;
+  }
+
+  private static isUniqueConstraintError(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+      return false;
+    }
+
+    const code = (error as { code?: unknown }).code;
+    return code === 'SQLITE_CONSTRAINT' || code === '23505';
+  }
+
+  async recordShareDifficulty(params: {
+    address: string;
+    clientName?: string | null;
+    timestamp?: number;
+    difficulty: number;
+  }): Promise<void> {
+    if (!params.address || params.difficulty == null) {
+      return;
+    }
+
+    const timestamp = params.timestamp ?? Date.now();
+    const slotTime = ClientDifficultyStatisticsService.normalizeSlot(timestamp);
+    const clientName = params.clientName ?? null;
+
+    try {
+      await this.repository.insert({
+        address: params.address,
+        clientName,
+        slotTime,
+        maxDifficulty: params.difficulty,
+      });
+      return;
+    } catch (error) {
+      if (!ClientDifficultyStatisticsService.isUniqueConstraintError(error)) {
+        throw error;
+      }
+    }
+
+    const existing = await this.repository.findOne({
+      where: { address: params.address, clientName, slotTime },
+    });
+
+    if (!existing || params.difficulty <= existing.maxDifficulty) {
+      return;
+    }
+
+    await this.repository.update(
+      { address: params.address, clientName, slotTime },
+      { maxDifficulty: params.difficulty, updatedAt: new Date() },
+    );
+  }
+
+  async getMaximaForAddress(address: string, from: number, to: number) {
+    if (!address) {
+      return [];
+    }
+
+    return this.repository
+      .createQueryBuilder('stat')
+      .select('stat.slotTime', 'slotTime')
+      .addSelect('MAX(stat.maxDifficulty)', 'maxDifficulty')
+      .where('stat.address = :address', { address })
+      .andWhere('stat.slotTime BETWEEN :from AND :to', { from, to })
+      .groupBy('stat.slotTime')
+      .orderBy('stat.slotTime', 'ASC')
+      .getRawMany<{ slotTime: number; maxDifficulty: number }>();
+  }
+
+  async deleteOlderThan(cutoff: number): Promise<void> {
+    await this.repository
+      .createQueryBuilder()
+      .delete()
+      .from(ClientDifficultyStatisticsEntity)
+      .where('slotTime < :cutoff', { cutoff })
+      .execute();
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -32,6 +32,7 @@ import { ExternalSharesModule } from './ORM/external-shares/external-shares.modu
 import { PoolShareStatisticsModule } from './ORM/pool-share-statistics/pool-share-statistics.module';
 import { PoolRejectedStatisticsModule } from './ORM/pool-rejected-statistics/pool-rejected-statistics.module';
 import { ClientRejectedStatisticsModule } from './ORM/client-rejected-statistics/client-rejected-statistics.module';
+import { ClientDifficultyStatisticsModule } from './ORM/client-difficulty-statistics/client-difficulty-statistics.module';
 import { buildDatabaseConfig } from './config/database.config';
 
 const ORMModules = [
@@ -44,7 +45,8 @@ const ORMModules = [
     ExternalSharesModule,
     PoolShareStatisticsModule,
     PoolRejectedStatisticsModule,
-    ClientRejectedStatisticsModule
+    ClientRejectedStatisticsModule,
+    ClientDifficultyStatisticsModule,
 ]
 
 @Module({

--- a/src/config/database.config.spec.ts
+++ b/src/config/database.config.spec.ts
@@ -42,5 +42,17 @@ describe('buildDatabaseConfig', () => {
         });
 
         expect(config.migrations).toBeDefined();
+        expect((config as any).extra).toMatchObject({ autoSynchronize: false });
+    });
+
+    it('enables auto synchronize when DB_AUTO_SYNCHRONIZE=true', () => {
+        const configService = new ConfigService({
+            DB_TYPE: 'postgres',
+            DB_AUTO_SYNCHRONIZE: 'true',
+        });
+
+        const config = buildDatabaseConfig(configService);
+
+        expect((config as any).extra).toMatchObject({ autoSynchronize: true });
     });
 });

--- a/src/config/database.config.ts
+++ b/src/config/database.config.ts
@@ -31,6 +31,12 @@ function parseOptionalBoolean(value: unknown): boolean | undefined {
     }
 }
 
+export function isAutoSynchronizeEnabled(config: ConfigService): boolean {
+    const flag = parseOptionalBoolean(config.get('DB_AUTO_SYNCHRONIZE'));
+
+    return flag ?? false;
+}
+
 function resolveDriver(config: ConfigService): SupportedDriver {
     const driver = config.get<string>('DB_TYPE');
 
@@ -54,6 +60,7 @@ export function buildDatabaseConfig(config: ConfigService): TypeOrmModuleOptions
     const logging = config.get('DB_LOGGING');
     const loggingEnabled = parseOptionalBoolean(logging) ?? false;
     const synchronizeOverride = parseOptionalBoolean(config.get('DB_SYNCHRONIZE'));
+    const autoSynchronize = isAutoSynchronizeEnabled(config);
 
     if (driver === 'postgres') {
         const ssl = parseOptionalBoolean(config.get('PG_SSL'));
@@ -78,7 +85,12 @@ export function buildDatabaseConfig(config: ConfigService): TypeOrmModuleOptions
             ...(runMigrations !== undefined ? { migrationsRun: runMigrations } : {}),
         };
 
-        return options;
+        return {
+            ...options,
+            extra: {
+                autoSynchronize,
+            },
+        };
     }
 
     const sqliteOptions: TypeOrmModuleOptions = {

--- a/src/controllers/client/client.controller.diff-scores.spec.ts
+++ b/src/controllers/client/client.controller.diff-scores.spec.ts
@@ -1,0 +1,122 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+
+jest.mock('node-telegram-bot-api', () => ({}));
+
+import { ClientController } from './client.controller';
+import { ClientService } from '../../ORM/client/client.service';
+import { ClientStatisticsService } from '../../ORM/client-statistics/client-statistics.service';
+import { AddressSettingsService } from '../../ORM/address-settings/address-settings.service';
+import { ClientRejectedStatisticsService } from '../../ORM/client-rejected-statistics/client-rejected-statistics.service';
+import { StratumV1Service } from '../../services/stratum-v1.service';
+import { ClientDifficultyStatisticsService } from '../../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
+
+describe('ClientController difficulty scores', () => {
+  let app: NestFastifyApplication;
+  let clientDifficultyStatisticsService: {
+    getMaximaForAddress: jest.Mock;
+  };
+  let dateNowSpy: jest.SpyInstance<number, []>;
+
+  beforeEach(async () => {
+    clientDifficultyStatisticsService = {
+      getMaximaForAddress: jest.fn().mockResolvedValue([]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ClientController],
+      providers: [
+        { provide: ClientService, useValue: {} },
+        { provide: ClientStatisticsService, useValue: {} },
+        { provide: AddressSettingsService, useValue: {} },
+        { provide: ClientRejectedStatisticsService, useValue: {} },
+        { provide: ClientDifficultyStatisticsService, useValue: clientDifficultyStatisticsService },
+        { provide: StratumV1Service, useValue: {} },
+      ],
+    }).compile();
+
+    app = module.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+    app.setGlobalPrefix('api');
+    await app.init();
+
+    dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValue(Date.UTC(2023, 0, 31, 12, 34, 0, 0));
+  });
+
+  afterEach(async () => {
+    dateNowSpy.mockRestore();
+    await app.close();
+  });
+
+  it('returns hourly difficulty maxima for the requested range', async () => {
+    const oneHour = 60 * 60 * 1000;
+    const now = Date.now();
+    const hours = 7 * 24;
+    const startSlot = Math.floor((now - hours * oneHour) / oneHour) * oneHour;
+    const endSlot = Math.floor(now / oneHour) * oneHour;
+
+    clientDifficultyStatisticsService.getMaximaForAddress.mockResolvedValue([
+      { slotTime: startSlot, maxDifficulty: 42 },
+      { slotTime: startSlot + 2 * oneHour, maxDifficulty: 99 },
+    ]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/client/addr123/diff-scores?range=7d',
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    expect(clientDifficultyStatisticsService.getMaximaForAddress).toHaveBeenCalledWith(
+      'addr123',
+      startSlot,
+      endSlot,
+    );
+
+    const payload = JSON.parse(res.payload);
+    expect(payload.slotData[0]).toEqual({
+      time: new Date(startSlot).toISOString(),
+      difficulty: 42,
+    });
+    expect(payload.slotData[1]).toEqual({
+      time: new Date(startSlot + oneHour).toISOString(),
+      difficulty: 0,
+    });
+    expect(payload.slotData[2]).toEqual({
+      time: new Date(startSlot + 2 * oneHour).toISOString(),
+      difficulty: 99,
+    });
+    expect(payload.slotData[payload.slotData.length - 1]).toEqual({
+      time: new Date(endSlot).toISOString(),
+      difficulty: 0,
+    });
+  });
+
+  it('defaults to returning one day of data when no range is specified', async () => {
+    clientDifficultyStatisticsService.getMaximaForAddress.mockResolvedValue([]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/client/addr123/diff-scores',
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    const call =
+      clientDifficultyStatisticsService.getMaximaForAddress.mock.calls[
+        clientDifficultyStatisticsService.getMaximaForAddress.mock.calls.length - 1
+      ];
+    const [address, start, end] = call;
+    expect(address).toBe('addr123');
+    const oneHour = 60 * 60 * 1000;
+    const now = Date.now();
+    const expectedStart = Math.floor((now - 24 * oneHour) / oneHour) * oneHour;
+    const expectedEnd = Math.floor(now / oneHour) * oneHour;
+    expect(start).toBe(expectedStart);
+    expect(end).toBe(expectedEnd);
+
+    const payload = JSON.parse(res.payload);
+    expect(Array.isArray(payload.slotData)).toBe(true);
+  });
+});

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -4,6 +4,7 @@ import { AddressSettingsService } from '../../ORM/address-settings/address-setti
 import { ClientStatisticsService } from '../../ORM/client-statistics/client-statistics.service';
 import { ClientService } from '../../ORM/client/client.service';
 import { ClientRejectedStatisticsService } from '../../ORM/client-rejected-statistics/client-rejected-statistics.service';
+import { ClientDifficultyStatisticsService } from '../../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 import { eStratumErrorCode } from '../../models/enums/eStratumErrorCode';
 import { StratumV1Service } from '../../services/stratum-v1.service';
 
@@ -16,6 +17,7 @@ export class ClientController {
         private readonly clientStatisticsService: ClientStatisticsService,
         private readonly addressSettingsService: AddressSettingsService,
         private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
+        private readonly clientDifficultyStatisticsService: ClientDifficultyStatisticsService,
         private readonly stratumV1Service: StratumV1Service,
     ) { }
 
@@ -158,6 +160,43 @@ export class ClientController {
                 counts[reason] = current;
             }
             slotData.push({ time: new Date(t).toISOString(), counts });
+        }
+
+        return { slotData };
+    }
+
+    @Get(':address/diff-scores')
+    async getAddressDifficultyScores(
+        @Param('address') address: string,
+        @Query('range') range: '1d' | '7d' | '30d' = '1d'
+    ) {
+        const now = Date.now();
+        const oneHour = 60 * 60 * 1000;
+        let hours = 24;
+        switch (range) {
+            case '30d':
+                hours = 24 * 30;
+                break;
+            case '7d':
+                hours = 24 * 7;
+                break;
+            default:
+                hours = 24;
+        }
+
+        const since = now - hours * oneHour;
+        const startSlot = Math.floor(since / oneHour) * oneHour;
+        const endSlot = Math.floor(now / oneHour) * oneHour;
+
+        const rawEntries = await this.clientDifficultyStatisticsService.getMaximaForAddress(address, startSlot, endSlot);
+        const bySlot = new Map<number, number>();
+        for (const entry of rawEntries) {
+            bySlot.set(entry.slotTime, Number(entry.maxDifficulty) || 0);
+        }
+
+        const slotData: { time: string; difficulty: number }[] = [];
+        for (let t = startSlot; t <= endSlot; t += oneHour) {
+            slotData.push({ time: new Date(t).toISOString(), difficulty: bySlot.get(t) ?? 0 });
         }
 
         return { slotData };

--- a/src/controllers/client/client.controller.worker.spec.ts
+++ b/src/controllers/client/client.controller.worker.spec.ts
@@ -9,6 +9,7 @@ import { ClientStatisticsService } from '../../ORM/client-statistics/client-stat
 import { AddressSettingsService } from '../../ORM/address-settings/address-settings.service';
 import { ClientRejectedStatisticsService } from '../../ORM/client-rejected-statistics/client-rejected-statistics.service';
 import { StratumV1Service } from '../../services/stratum-v1.service';
+import { ClientDifficultyStatisticsService } from '../../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 
 describe('ClientController worker chart data', () => {
   let app: NestFastifyApplication;
@@ -44,6 +45,7 @@ describe('ClientController worker chart data', () => {
         { provide: ClientStatisticsService, useValue: clientStatisticsService },
         { provide: AddressSettingsService, useValue: {} },
         { provide: ClientRejectedStatisticsService, useValue: {} },
+        { provide: ClientDifficultyStatisticsService, useValue: {} },
         { provide: StratumV1Service, useValue: {} },
       ],
     }).compile();

--- a/src/migration/sqlite-to-postgres.ts
+++ b/src/migration/sqlite-to-postgres.ts
@@ -12,6 +12,7 @@ import { AddressSettingsEntity } from '../ORM/address-settings/address-settings.
 import { BlocksEntity } from '../ORM/blocks/blocks.entity';
 import { ClientRejectedStatisticsEntity } from '../ORM/client-rejected-statistics/client-rejected-statistics.entity';
 import { ClientStatisticsEntity } from '../ORM/client-statistics/client-statistics.entity';
+import { ClientDifficultyStatisticsEntity } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.entity';
 import { ClientEntity } from '../ORM/client/client.entity';
 import { ExternalSharesEntity } from '../ORM/external-shares/external-shares.entity';
 import { PoolRejectedStatisticsEntity } from '../ORM/pool-rejected-statistics/pool-rejected-statistics.entity';
@@ -27,6 +28,7 @@ export const MIGRATION_ENTITIES = [
     ClientEntity,
     ClientRejectedStatisticsEntity,
     ClientStatisticsEntity,
+    ClientDifficultyStatisticsEntity,
     ExternalSharesEntity,
     PoolRejectedStatisticsEntity,
     PoolShareStatisticsEntity,

--- a/src/migrations/1717430400000-AddClientDifficultyStatistics.ts
+++ b/src/migrations/1717430400000-AddClientDifficultyStatistics.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddClientDifficultyStatistics1717430400000 implements MigrationInterface {
+    name = 'AddClientDifficultyStatistics1717430400000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (queryRunner.connection.options.type !== 'postgres') {
+            return;
+        }
+
+        await queryRunner.query(`
+            CREATE TABLE "client_difficulty_statistics_entity" (
+                "deletedAt" TIMESTAMP WITH TIME ZONE,
+                "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "id" SERIAL NOT NULL,
+                "address" character varying(62) NOT NULL,
+                "clientName" character varying(64),
+                "slotTime" integer NOT NULL,
+                "maxDifficulty" real NOT NULL DEFAULT '0',
+                CONSTRAINT "PK_client_difficulty_statistics_entity_id" PRIMARY KEY ("id")
+            )
+        `);
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "IDX_client_difficulty_statistics_unique"
+            ON "client_difficulty_statistics_entity" ("address", "clientName", "slotTime")
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (queryRunner.connection.options.type !== 'postgres') {
+            return;
+        }
+
+        await queryRunner.query(`DROP INDEX "public"."IDX_client_difficulty_statistics_unique"`);
+        await queryRunner.query(`DROP TABLE "client_difficulty_statistics_entity"`);
+    }
+}

--- a/src/migrations/add-client-difficulty-statistics.spec.ts
+++ b/src/migrations/add-client-difficulty-statistics.spec.ts
@@ -1,0 +1,104 @@
+import { DataSource } from 'typeorm';
+import { DataType, newDb } from 'pg-mem';
+
+import { ClientDifficultyStatisticsEntity } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.entity';
+import { InitialSchema1700000000000 } from './1700000000000-InitialSchema';
+import { UseTimestamptzForDates1707352800000 } from './1707352800000-UseTimestamptzForDates';
+import { AddClientDifficultyStatistics1717430400000 } from './1717430400000-AddClientDifficultyStatistics';
+
+describe('AddClientDifficultyStatistics1717430400000', () => {
+    it('skips execution on sqlite connections', async () => {
+        const dataSource = new DataSource({
+            type: 'sqlite',
+            database: ':memory:',
+            migrations: [AddClientDifficultyStatistics1717430400000],
+            synchronize: true,
+        });
+
+        await dataSource.initialize();
+        await dataSource.runMigrations();
+        await dataSource.destroy();
+    });
+
+    it('creates the hourly difficulty table with a unique index in postgres', async () => {
+        const db = newDb({ autoCreateForeignKeyIndices: true });
+        db.public.registerFunction({
+            name: 'current_database',
+            returns: DataType.text,
+            implementation: () => 'pg_mem',
+        });
+        db.public.registerFunction({
+            name: 'version',
+            returns: DataType.text,
+            implementation: () => 'pg-mem',
+        });
+
+        const dataSource = db.adapters.createTypeormDataSource({
+            type: 'postgres',
+            database: 'pg-mem',
+            entities: [ClientDifficultyStatisticsEntity],
+            migrations: [
+                InitialSchema1700000000000,
+                UseTimestamptzForDates1707352800000,
+                AddClientDifficultyStatistics1717430400000,
+            ],
+            synchronize: false,
+        });
+
+        await dataSource.initialize();
+        await dataSource.runMigrations();
+
+        const [table] = (await dataSource.query(
+            `SELECT table_name
+             FROM information_schema.tables
+             WHERE table_schema = 'public'
+             AND table_name = 'client_difficulty_statistics_entity'`,
+        )) as Array<{ table_name: string }>;
+
+        expect(table?.table_name).toBe('client_difficulty_statistics_entity');
+
+        const columns = (await dataSource.query(
+            `SELECT column_name, data_type, is_nullable, column_default
+             FROM information_schema.columns
+             WHERE table_name = 'client_difficulty_statistics_entity'
+             ORDER BY ordinal_position`,
+        )) as Array<{
+            column_name: string;
+            data_type: string;
+            is_nullable: 'YES' | 'NO';
+            column_default: string | null;
+        }>;
+
+        const columnMap = new Map(columns.map((column) => [column.column_name, column]));
+        const timestamptzAliases = new Set(['timestamp with time zone', 'timestamptz']);
+
+        expect(columnMap.has('id')).toBe(true);
+        expect(columnMap.has('address')).toBe(true);
+        expect(columnMap.has('clientName')).toBe(true);
+        expect(columnMap.has('slotTime')).toBe(true);
+        expect(columnMap.has('maxDifficulty')).toBe(true);
+        expect(timestamptzAliases.has(columnMap.get('createdAt')?.data_type ?? '')).toBe(true);
+        expect(timestamptzAliases.has(columnMap.get('updatedAt')?.data_type ?? '')).toBe(true);
+        expect(timestamptzAliases.has(columnMap.get('deletedAt')?.data_type ?? '')).toBe(true);
+
+        const repository = dataSource.getRepository(ClientDifficultyStatisticsEntity);
+
+        await repository.insert({
+            address: 'addr1',
+            clientName: 'rig-1',
+            slotTime: 1700000000,
+            maxDifficulty: 42,
+        });
+
+        await expect(
+            repository.insert({
+                address: 'addr1',
+                clientName: 'rig-1',
+                slotTime: 1700000000,
+                maxDifficulty: 99,
+            }),
+        ).rejects.toMatchObject({ code: '23505' });
+
+        await dataSource.destroy();
+    });
+});

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -33,6 +33,7 @@ import { PoolShareStatisticsService } from '../ORM/pool-share-statistics/pool-sh
 import { PoolRejectedStatisticsService } from '../ORM/pool-rejected-statistics/pool-rejected-statistics.service';
 import { ClientRejectedStatisticsService } from '../ORM/client-rejected-statistics/client-rejected-statistics.service';
 import { StratumV1Service } from '../services/stratum-v1.service';
+import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 
 
 export class StratumV1Client {
@@ -87,6 +88,7 @@ export class StratumV1Client {
         private readonly poolRejectedStatisticsService: PoolRejectedStatisticsService,
         private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
         private readonly externalSharesService: ExternalSharesService,
+        private readonly clientDifficultyStatisticsService: ClientDifficultyStatisticsService,
         private readonly stratumV1Service: StratumV1Service,
     ) {
 
@@ -760,6 +762,13 @@ export class StratumV1Client {
                     await this.clientService.heartbeat(this.entity.address, this.entity.clientName, this.entity.sessionId, this.hashRate, now);
                     this.entity.updatedAt = now;
                 }
+
+                await this.clientDifficultyStatisticsService.recordShareDifficulty({
+                    address: this.clientAuthorization.address,
+                    clientName: this.clientAuthorization.worker,
+                    timestamp: now.getTime(),
+                    difficulty: submissionDifficulty,
+                });
 
                 if (now.getTime() - this.lastDifficultyCheck >= this.difficultyCheckIntervalMs) {
                     await this.checkDifficulty();

--- a/src/models/stratum-v1-client.spec.ts
+++ b/src/models/stratum-v1-client.spec.ts
@@ -26,6 +26,7 @@ function createClient(overrides: Record<string, any> = {}) {
     dummy,
     dummy,
     dummy,
+    dummy,
     stratumV1Service as any,
   );
 

--- a/src/scripts/migrate-sqlite-to-pg.spec.ts
+++ b/src/scripts/migrate-sqlite-to-pg.spec.ts
@@ -7,6 +7,7 @@ import { AddressSettingsEntity } from '../ORM/address-settings/address-settings.
 import { BlocksEntity } from '../ORM/blocks/blocks.entity';
 import { ClientRejectedStatisticsEntity } from '../ORM/client-rejected-statistics/client-rejected-statistics.entity';
 import { ClientStatisticsEntity } from '../ORM/client-statistics/client-statistics.entity';
+import { ClientDifficultyStatisticsEntity } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.entity';
 import { ClientEntity } from '../ORM/client/client.entity';
 import { ExternalSharesEntity } from '../ORM/external-shares/external-shares.entity';
 import { PoolRejectedStatisticsEntity } from '../ORM/pool-rejected-statistics/pool-rejected-statistics.entity';
@@ -14,6 +15,7 @@ import { PoolShareStatisticsEntity } from '../ORM/pool-share-statistics/pool-sha
 import { TelegramSubscriptionsEntity } from '../ORM/telegram-subscriptions/telegram-subscriptions.entity';
 import { InitialSchema1700000000000 } from '../migrations/1700000000000-InitialSchema';
 import { UseTimestamptzForDates1707352800000 } from '../migrations/1707352800000-UseTimestamptzForDates';
+import { AddClientDifficultyStatistics1717430400000 } from '../migrations/1717430400000-AddClientDifficultyStatistics';
 import {
     MIGRATION_ENTITIES,
     MigrationLogger,
@@ -90,7 +92,11 @@ describe('migrateSqliteToPostgres', () => {
             type: 'postgres',
             database: 'pg-mem',
             entities: [...MIGRATION_ENTITIES],
-            migrations: [InitialSchema1700000000000, UseTimestamptzForDates1707352800000],
+            migrations: [
+                InitialSchema1700000000000,
+                UseTimestamptzForDates1707352800000,
+                AddClientDifficultyStatistics1717430400000,
+            ],
             synchronize: false,
         });
 
@@ -137,6 +143,13 @@ describe('migrateSqliteToPostgres', () => {
             rejectedDuplicateShareDiff1: 0,
             rejectedLowDifficultyShareCount: 0,
             rejectedLowDifficultyShareDiff1: 0,
+        });
+
+        await dataSource.getRepository(ClientDifficultyStatisticsEntity).save({
+            address: client.address,
+            clientName: client.clientName,
+            slotTime: 1700000000,
+            maxDifficulty: 321.123,
         });
 
         await dataSource.getRepository(ClientRejectedStatisticsEntity).save({

--- a/src/services/app.service.spec.ts
+++ b/src/services/app.service.spec.ts
@@ -1,7 +1,7 @@
 import { AppService } from './app.service';
 
 describe('AppService.onModuleInit', () => {
-  let dataSource: { query: jest.Mock };
+  let dataSource: { query: jest.Mock; synchronize: jest.Mock; options?: { type?: string } };
   let clientService: {
     deleteAll: jest.Mock;
     killDeadClients: jest.Mock;
@@ -10,10 +10,15 @@ describe('AppService.onModuleInit', () => {
   let clientStatisticsService: { deleteOldStatistics: jest.Mock };
   let clientDifficultyStatisticsService: { deleteOlderThan: jest.Mock };
   let rpcBlockService: { deleteOldBlocks: jest.Mock };
+  let configService: { get: jest.Mock };
   let setIntervalSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    dataSource = { query: jest.fn().mockResolvedValue(undefined) };
+    dataSource = {
+      query: jest.fn().mockResolvedValue(undefined),
+      synchronize: jest.fn().mockResolvedValue(undefined),
+      options: { type: 'sqlite' },
+    };
     clientService = {
       deleteAll: jest.fn().mockResolvedValue(undefined),
       killDeadClients: jest.fn().mockResolvedValue(undefined),
@@ -27,6 +32,9 @@ describe('AppService.onModuleInit', () => {
     };
     rpcBlockService = {
       deleteOldBlocks: jest.fn().mockResolvedValue(undefined),
+    };
+    configService = {
+      get: jest.fn().mockReturnValue(undefined),
     };
     setIntervalSpy = jest
       .spyOn(global, 'setInterval')
@@ -46,6 +54,7 @@ describe('AppService.onModuleInit', () => {
       clientService as any,
       dataSource as any,
       rpcBlockService as any,
+      configService as any,
     );
   }
 
@@ -64,5 +73,18 @@ describe('AppService.onModuleInit', () => {
     await service.onModuleInit();
 
     expect(clientService.deleteAll).not.toHaveBeenCalled();
+  });
+
+  it('synchronizes the schema when enabled for postgres on the primary instance', async () => {
+    process.env.NODE_APP_INSTANCE = '0';
+    dataSource.options = { type: 'postgres' };
+    configService.get.mockImplementation((key: string) =>
+      key === 'DB_AUTO_SYNCHRONIZE' ? 'true' : undefined,
+    );
+    const service = createService();
+
+    await service.onModuleInit();
+
+    expect(dataSource.synchronize).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/app.service.spec.ts
+++ b/src/services/app.service.spec.ts
@@ -8,6 +8,7 @@ describe('AppService.onModuleInit', () => {
     deleteOldClients: jest.Mock;
   };
   let clientStatisticsService: { deleteOldStatistics: jest.Mock };
+  let clientDifficultyStatisticsService: { deleteOlderThan: jest.Mock };
   let rpcBlockService: { deleteOldBlocks: jest.Mock };
   let setIntervalSpy: jest.SpyInstance;
 
@@ -20,6 +21,9 @@ describe('AppService.onModuleInit', () => {
     };
     clientStatisticsService = {
       deleteOldStatistics: jest.fn().mockResolvedValue(undefined),
+    };
+    clientDifficultyStatisticsService = {
+      deleteOlderThan: jest.fn().mockResolvedValue(undefined),
     };
     rpcBlockService = {
       deleteOldBlocks: jest.fn().mockResolvedValue(undefined),
@@ -38,6 +42,7 @@ describe('AppService.onModuleInit', () => {
   function createService() {
     return new AppService(
       clientStatisticsService as any,
+      clientDifficultyStatisticsService as any,
       clientService as any,
       dataSource as any,
       rpcBlockService as any,

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 
+import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 import { ClientStatisticsService } from '../ORM/client-statistics/client-statistics.service';
 import { ClientService } from '../ORM/client/client.service';
 import { RpcBlockService } from '../ORM/rpc-block/rpc-block.service';
@@ -57,6 +58,7 @@ export class AppService implements OnModuleInit {
 
     constructor(
         private readonly clientStatisticsService: ClientStatisticsService,
+        private readonly clientDifficultyStatisticsService: ClientDifficultyStatisticsService,
         private readonly clientService: ClientService,
         private readonly dataSource: DataSource,
         private readonly rpcBlockService: RpcBlockService,
@@ -113,6 +115,10 @@ export class AppService implements OnModuleInit {
         console.log('Deleting statistics');
 
         await this.clientStatisticsService.deleteOldStatistics();
+        const cutoff = Math.floor(
+            (Date.now() - 30 * 24 * 60 * 60 * 1000) / (60 * 60 * 1000),
+        ) * (60 * 60 * 1000);
+        await this.clientDifficultyStatisticsService.deleteOlderThan(cutoff);
         console.log('Deleted old statistics');
         const deletedClients = await this.clientService.deleteOldClients();
         console.log(`Deleted ${deletedClients.affected} old clients`);

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { DataSource } from 'typeorm';
 
 import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
@@ -10,6 +11,7 @@ import {
     MigrationLogger,
     runAutomaticSqliteToPostgresMigration,
 } from '../migration/sqlite-to-postgres';
+import { isAutoSynchronizeEnabled } from '../config/database.config';
 
 function parseOptionalBoolean(value: string | undefined): boolean | undefined {
     if (value === undefined) {
@@ -56,14 +58,18 @@ export class AppService implements OnModuleInit {
 
     private readonly migrationLogger = new NestMigrationLogger(this.logger);
 
+    private readonly autoSynchronize: boolean;
+
     constructor(
         private readonly clientStatisticsService: ClientStatisticsService,
         private readonly clientDifficultyStatisticsService: ClientDifficultyStatisticsService,
         private readonly clientService: ClientService,
         private readonly dataSource: DataSource,
         private readonly rpcBlockService: RpcBlockService,
+        configService: ConfigService,
     ) {
 
+        this.autoSynchronize = isAutoSynchronizeEnabled(configService);
     }
 
     async onModuleInit() {
@@ -82,14 +88,21 @@ export class AppService implements OnModuleInit {
 
         await this.runAutomaticSqliteMigrationIfNeeded();
 
+        const nodeInstance = process.env.NODE_APP_INSTANCE;
+        const isPrimaryInstance = nodeInstance == null || nodeInstance === '0';
+
+        if (isPrimaryInstance && dataSourceType === 'postgres' && this.autoSynchronize) {
+            await this.dataSource.synchronize();
+        }
+
         // //6Gb
         // await this.dataSource.query(`PRAGMA mmap_size = 6000000000;`);
 
-        if (process.env.NODE_APP_INSTANCE === undefined) {
+        if (nodeInstance === undefined) {
             await this.clientService.deleteAll();
         }
 
-        if (process.env.NODE_APP_INSTANCE == null || process.env.NODE_APP_INSTANCE == '0') {
+        if (isPrimaryInstance) {
 
             setInterval(async () => {
                 await this.deleteOldStatistics();

--- a/src/services/stratum-v1.service.spec.ts
+++ b/src/services/stratum-v1.service.spec.ts
@@ -33,6 +33,7 @@ describe('StratumV1Service.onModuleInit', () => {
       {} as any,
       {} as any,
       {} as any,
+      {} as any,
     );
   }
 

--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -14,6 +14,7 @@ import { ExternalSharesService } from './external-shares.service';
 import { PoolShareStatisticsService } from '../ORM/pool-share-statistics/pool-share-statistics.service';
 import { PoolRejectedStatisticsService } from '../ORM/pool-rejected-statistics/pool-rejected-statistics.service';
 import { ClientRejectedStatisticsService } from '../ORM/client-rejected-statistics/client-rejected-statistics.service';
+import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 
 @Injectable()
 export class StratumV1Service implements OnModuleInit {
@@ -32,6 +33,7 @@ export class StratumV1Service implements OnModuleInit {
     private readonly poolRejectedStatisticsService: PoolRejectedStatisticsService,
     private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
     private readonly externalSharesService: ExternalSharesService,
+    private readonly clientDifficultyStatisticsService: ClientDifficultyStatisticsService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -66,6 +68,7 @@ export class StratumV1Service implements OnModuleInit {
         this.poolRejectedStatisticsService,
         this.clientRejectedStatisticsService,
         this.externalSharesService,
+        this.clientDifficultyStatisticsService,
         this,
       );
 

--- a/typeorm-cli.config.ts
+++ b/typeorm-cli.config.ts
@@ -8,6 +8,7 @@ import { buildDatabaseConfig } from './src/config/database.config';
 import { AddressSettingsEntity } from './src/ORM/address-settings/address-settings.entity';
 import { BlocksEntity } from './src/ORM/blocks/blocks.entity';
 import { ClientEntity } from './src/ORM/client/client.entity';
+import { ClientDifficultyStatisticsEntity } from './src/ORM/client-difficulty-statistics/client-difficulty-statistics.entity';
 import { ClientRejectedStatisticsEntity } from './src/ORM/client-rejected-statistics/client-rejected-statistics.entity';
 import { ClientStatisticsEntity } from './src/ORM/client-statistics/client-statistics.entity';
 import { ExternalSharesEntity } from './src/ORM/external-shares/external-shares.entity';
@@ -27,6 +28,7 @@ const entities = [
     ClientEntity,
     ClientRejectedStatisticsEntity,
     ClientStatisticsEntity,
+    ClientDifficultyStatisticsEntity,
     ExternalSharesEntity,
     PoolRejectedStatisticsEntity,
     PoolShareStatisticsEntity,


### PR DESCRIPTION
## Summary
- add an ORM module to persist hourly maximum share difficulty per client address and worker
- update the stratum client flow and housekeeping jobs to record and prune difficulty data
- expose /api/client/:address/diff-scores with tests covering hourly aggregation and range handling
