### PR TITLE
Fix stale best difficulty after Telegram reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to **BlitzPool**, a lightweight and open-source Bitcoin mining pool based on the [public-pool](https://github.com/benjamin-wilson/public-pool) project – extended with powerful new features and real-world integrations.
 
-Current Version: **v1.3.4**
+Current Version: **v1.3.5**
 
 🌐 **Live Pool:** [https://blitzpool.yourdevice.ch/#/](https://blitzpool.yourdevice.ch/#/)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "public-pool",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "public-pool",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-pool",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "",
   "author": "",
   "private": true,

--- a/src/ORM/address-settings/address-settings.service.ts
+++ b/src/ORM/address-settings/address-settings.service.ts
@@ -15,15 +15,23 @@ export class AddressSettingsService {
     }
 
     public async getSettings(address: string, createIfNotFound: boolean) {
-        const settings = await this.addressSettingsRepository.findOne({ where: { address } });
-        if (createIfNotFound == true && settings == null) {
+        let settings = await this.addressSettingsRepository
+            .createQueryBuilder('settings')
+            .where('settings.address = :address', { address })
+            .getOne();
+
+        if (createIfNotFound === true && settings == null) {
             // It's possible to have a race condition here so if we get a PK violation, fetch it
             try {
-                return await this.createNew(address);
+                settings = await this.createNew(address);
             } catch (e) {
-                return await this.addressSettingsRepository.findOne({ where: { address } });
+                settings = await this.addressSettingsRepository
+                    .createQueryBuilder('settings')
+                    .where('settings.address = :address', { address })
+                    .getOne();
             }
         }
+
         return settings;
     }
 


### PR DESCRIPTION
## Summary
- ensure address settings are fetched using a query builder to avoid cached entities after resets
- keep create-if-not-found path consistent so the latest best difficulty is returned