### PR TITLE
Expose current worker difficulty in client API

### DIFF
--- a/src/controllers/client/client.controller.client-info.spec.ts
+++ b/src/controllers/client/client.controller.client-info.spec.ts
@@ -1,0 +1,115 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+
+jest.mock('node-telegram-bot-api', () => ({}));
+
+import { ClientController } from './client.controller';
+import { ClientService } from '../../ORM/client/client.service';
+import { ClientStatisticsService } from '../../ORM/client-statistics/client-statistics.service';
+import { AddressSettingsService } from '../../ORM/address-settings/address-settings.service';
+import { ClientRejectedStatisticsService } from '../../ORM/client-rejected-statistics/client-rejected-statistics.service';
+import { ClientDifficultyStatisticsService } from '../../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
+import { StratumV1Service } from '../../services/stratum-v1.service';
+
+describe('ClientController getClientInfo', () => {
+  let app: NestFastifyApplication;
+  let clientService: { getByAddress: jest.Mock };
+  let clientStatisticsService: { getTotalSharesForAddress: jest.Mock };
+  let addressSettingsService: { getSettings: jest.Mock };
+  let stratumV1Service: { getCurrentDifficulties: jest.Mock };
+
+  beforeEach(async () => {
+    clientService = {
+      getByAddress: jest.fn().mockResolvedValue([
+        {
+          sessionId: 'session-1',
+          clientName: 'worker-1',
+          bestDifficulty: 12.3456,
+          hashRate: 100,
+          startTime: new Date('2023-01-01T00:00:00.000Z'),
+          updatedAt: new Date('2023-01-01T01:00:00.000Z'),
+        },
+        {
+          sessionId: null,
+          clientName: 'worker-2',
+          bestDifficulty: 1,
+          hashRate: null,
+          startTime: new Date('2023-01-02T00:00:00.000Z'),
+          updatedAt: new Date('2023-01-02T01:00:00.000Z'),
+        },
+      ]),
+    };
+    clientStatisticsService = {
+      getTotalSharesForAddress: jest.fn().mockResolvedValue(12345),
+    };
+    addressSettingsService = {
+      getSettings: jest.fn().mockResolvedValue({ bestDifficulty: 98765 }),
+    };
+    stratumV1Service = {
+      getCurrentDifficulties: jest
+        .fn()
+        .mockReturnValue(new Map([['session-1', 2048]])),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ClientController],
+      providers: [
+        { provide: ClientService, useValue: clientService },
+        { provide: ClientStatisticsService, useValue: clientStatisticsService },
+        { provide: AddressSettingsService, useValue: addressSettingsService },
+        { provide: ClientRejectedStatisticsService, useValue: {} },
+        { provide: ClientDifficultyStatisticsService, useValue: {} },
+        { provide: StratumV1Service, useValue: stratumV1Service },
+      ],
+    }).compile();
+
+    app = module.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+    app.setGlobalPrefix('api');
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns workers including current difficulty when available', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/client/btc123',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.payload);
+
+    expect(payload).toEqual({
+      bestDifficulty: 98765,
+      workersCount: 2,
+      totalShares: 12345,
+      totalHashrate: 100,
+      workers: [
+        {
+          sessionId: 'session-1',
+          name: 'worker-1',
+          bestDifficulty: '12.35',
+          hashRate: 100,
+          currentDifficulty: 2048,
+          startTime: '2023-01-01T00:00:00.000Z',
+          lastSeen: '2023-01-01T01:00:00.000Z',
+        },
+        {
+          sessionId: null,
+          name: 'worker-2',
+          bestDifficulty: '1.00',
+          hashRate: null,
+          currentDifficulty: null,
+          startTime: '2023-01-02T00:00:00.000Z',
+          lastSeen: '2023-01-02T01:00:00.000Z',
+        },
+      ],
+    });
+    expect(clientService.getByAddress).toHaveBeenCalledWith('btc123');
+    expect(stratumV1Service.getCurrentDifficulties).toHaveBeenCalledWith(
+      'btc123',
+    );
+  });
+});

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -31,6 +31,7 @@ export class ClientController {
 
         const totalShares = await this.clientStatisticsService.getTotalSharesForAddress(address);
         const totalHashrate = workers.reduce((sum, w) => sum + (w.hashRate ?? 0), 0);
+        const currentDifficulties = this.stratumV1Service.getCurrentDifficulties(address);
 
         return {
             bestDifficulty: addressSettings?.bestDifficulty,
@@ -44,6 +45,7 @@ export class ClientController {
                         name: worker.clientName,
                         bestDifficulty: worker.bestDifficulty.toFixed(2),
                         hashRate: worker.hashRate,
+                        currentDifficulty: worker.sessionId ? currentDifficulties.get(worker.sessionId) ?? null : null,
                         startTime: worker.startTime,
                         lastSeen: worker.updatedAt
                     };

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -136,6 +136,14 @@ export class StratumV1Client {
         return this.clientAuthorization?.address;
     }
 
+    public getCurrentDifficulty(): number | undefined {
+        if (!this.sessionId) {
+            return undefined;
+        }
+
+        return this.sessionDifficulty;
+    }
+
     public async destroy() {
 
         const sid = this.entity?.sessionId || this.sessionId;

--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -160,6 +160,28 @@ export class StratumV1Service implements OnModuleInit {
     }
   }
 
+  getCurrentDifficulties(address: string): Map<string, number> {
+    const clients = this.clientsByAddress.get(address);
+    if (!clients) {
+      return new Map();
+    }
+
+    const difficulties = new Map<string, number>();
+    for (const client of clients) {
+      const sessionId = client.sessionId;
+      if (!sessionId) {
+        continue;
+      }
+
+      const currentDifficulty = client.getCurrentDifficulty();
+      if (currentDifficulty != null) {
+        difficulties.set(sessionId, currentDifficulty);
+      }
+    }
+
+    return difficulties;
+  }
+
   resetClientsForAddress(address: string) {
     const clients = this.clientsByAddress.get(address);
     if (!clients) {


### PR DESCRIPTION
## Summary
- expose each worker's current session difficulty through the Stratum service
- surface the live difficulty in the GET /api/client/:address response
- add a controller test that verifies the new field and service interaction