### PR TITLE
Add Telegram /show_workers command for worker summaries

### DIFF
--- a/src/services/common-command-handlers.spec.ts
+++ b/src/services/common-command-handlers.spec.ts
@@ -1,0 +1,43 @@
+import { NumberSuffix } from '../utils/NumberSuffix';
+import { buildWorkersOverviewMessage, WorkerOverviewData } from './common-command-handlers';
+
+describe('buildWorkersOverviewMessage', () => {
+    it('formats worker overview with suffixes and plain current difficulty', () => {
+        const data: WorkerOverviewData = {
+            workersCount: 2,
+            totalHashrate: 1500,
+            totalShares: 12345,
+            bestDifficulty: 987654,
+            workers: [
+                {
+                    name: 'Alpha',
+                    hashRate: 1000,
+                    currentDifficulty: 123,
+                    bestDifficulty: '456.78',
+                },
+                {
+                    name: '',
+                    hashRate: null,
+                    currentDifficulty: null,
+                    bestDifficulty: null,
+                },
+            ],
+        };
+
+        const result = buildWorkersOverviewMessage(data, new NumberSuffix());
+
+        expect(result.de).toContain('Gesamt-Hashrate: 1.50k');
+        expect(result.en).toContain('Total hashrate: 1.50k');
+        expect(result.de).toContain('Gesamt-Shares: 12.35k');
+        expect(result.en).toContain('Total shares: 12.35k');
+        expect(result.de).toContain('Beste Difficulty: 987.65k');
+        expect(result.en).toContain('Best difficulty: 987.65k');
+        expect(result.de).toContain('Hashrate: 1.00k');
+        expect(result.de).toContain('Aktuelle Difficulty: 123');
+        expect(result.de).toContain('Beste Difficulty: 456.78');
+        expect(result.de).toContain('Worker 2');
+        expect(result.de).toContain('Aktuelle Difficulty: –');
+        expect(result.de).toContain('Beste Difficulty: –');
+        expect(result.en).toContain('Current difficulty: –');
+    });
+});

--- a/src/services/common-command-handlers.ts
+++ b/src/services/common-command-handlers.ts
@@ -8,6 +8,19 @@ export interface StatsMessages {
     en: string;
 }
 
+export interface WorkerOverviewData {
+    workersCount: number;
+    totalHashrate?: number | null;
+    totalShares?: number | null;
+    bestDifficulty?: number | string | null;
+    workers?: Array<{
+        name?: string | null;
+        hashRate?: number | null;
+        currentDifficulty?: number | null;
+        bestDifficulty?: number | string | null;
+    }> | null;
+}
+
 export async function buildStatsMessage(
     address: string,
     clientService: ClientService,
@@ -38,6 +51,74 @@ export async function buildStatsMessage(
             `- Total shares: ${numberSuffix.to(totalShares)}\n` +
             `- Last share: ${lastSeenSeconds} seconds ago\n` +
             `- Best difficulty: ${bestDifficultyG.toFixed(2)} G`,
+    };
+}
+
+function parseNumeric(value: number | string | null | undefined): number | null {
+    if (value === null || value === undefined) {
+        return null;
+    }
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function buildWorkersOverviewMessage(
+    data: WorkerOverviewData,
+    numberSuffix: NumberSuffix
+): StatsMessages {
+    const totalHashrate = parseNumeric(data.totalHashrate) ?? 0;
+    const totalShares = parseNumeric(data.totalShares) ?? 0;
+    const bestDifficultyTotal = parseNumeric(data.bestDifficulty);
+    const bestDifficultyTotalFormatted =
+        bestDifficultyTotal !== null ? numberSuffix.to(bestDifficultyTotal) : '–';
+
+    const workerLinesDe: string[] = [];
+    const workerLinesEn: string[] = [];
+
+    (data.workers ?? []).forEach((worker, idx) => {
+        const name = worker?.name?.trim() || `Worker ${idx + 1}`;
+        const hashRateValue = parseNumeric(worker?.hashRate) ?? 0;
+        const hashRateFormatted = numberSuffix.to(hashRateValue);
+        const currentDifficultyValue = parseNumeric(worker?.currentDifficulty);
+        const currentDifficultyFormatted =
+            currentDifficultyValue !== null ? `${currentDifficultyValue}` : '–';
+        const bestDifficultyValue = parseNumeric(worker?.bestDifficulty);
+        const bestDifficultyFormatted =
+            bestDifficultyValue !== null ? numberSuffix.to(bestDifficultyValue) : '–';
+
+        workerLinesDe.push(
+            `• ${name} – Hashrate: ${hashRateFormatted}, Aktuelle Difficulty: ${currentDifficultyFormatted}, Beste Difficulty: ${bestDifficultyFormatted}`
+        );
+        workerLinesEn.push(
+            `• ${name} – Hashrate: ${hashRateFormatted}, Current difficulty: ${currentDifficultyFormatted}, Best difficulty: ${bestDifficultyFormatted}`
+        );
+    });
+
+    const summaryDe = [
+        '👷 Worker-Übersicht',
+        `Gesamtanzahl: ${data.workersCount}`,
+        `Gesamt-Hashrate: ${numberSuffix.to(totalHashrate)}`,
+        `Gesamt-Shares: ${numberSuffix.to(totalShares)}`,
+        `Beste Difficulty: ${bestDifficultyTotalFormatted}`,
+    ].join('\n');
+
+    const summaryEn = [
+        '👷 Workers overview',
+        `Total workers: ${data.workersCount}`,
+        `Total hashrate: ${numberSuffix.to(totalHashrate)}`,
+        `Total shares: ${numberSuffix.to(totalShares)}`,
+        `Best difficulty: ${bestDifficultyTotalFormatted}`,
+    ].join('\n');
+
+    const workersDe = workerLinesDe.join('\n');
+    const workersEn = workerLinesEn.join('\n');
+
+    return {
+        de: workersDe ? `${summaryDe}\n\n${workersDe}` : summaryDe,
+        en: workersEn ? `${summaryEn}\n\n${workersEn}` : summaryEn,
     };
 }
 

--- a/src/services/telegram.service.show-workers.spec.ts
+++ b/src/services/telegram.service.show-workers.spec.ts
@@ -1,0 +1,98 @@
+import { ConfigService } from '@nestjs/config';
+import { TelegramService } from './telegram.service';
+import * as commonHandlers from './common-command-handlers';
+
+const onTextMock = jest.fn();
+const onMock = jest.fn();
+const setMyCommandsMock = jest.fn().mockResolvedValue(undefined);
+const sendMessageMock = jest.fn();
+
+jest.mock('node-telegram-bot-api', () => {
+    return jest.fn().mockImplementation(() => ({
+        onText: onTextMock,
+        on: onMock,
+        setMyCommands: setMyCommandsMock,
+        sendMessage: sendMessageMock,
+    }));
+});
+
+describe('TelegramService /show_workers handler', () => {
+    const configService = {
+        get: jest.fn((key: string) => (key === 'TELEGRAM_BOT_TOKEN' ? 'token' : null)),
+    } as unknown as ConfigService;
+    const telegramSubscriptionsService = {
+        getAllAddresses: jest.fn().mockResolvedValue([]),
+        getChatSubscriptions: jest.fn().mockResolvedValue([]),
+        getDefault: jest.fn(),
+        saveSubscription: jest.fn(),
+        removeSubscription: jest.fn(),
+        getSubscriptions: jest.fn(),
+    };
+    const clientService = {};
+    const addressSettingsService = {
+        getSettings: jest.fn().mockResolvedValue(null),
+    };
+    const clientStatisticsService = {};
+    const stratumV1Service = {};
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (global as any).fetch = undefined;
+    });
+
+    it('fetches worker data and builds the overview message', async () => {
+        const service = new TelegramService(
+            configService,
+            telegramSubscriptionsService as any,
+            clientService as any,
+            addressSettingsService as any,
+            clientStatisticsService as any,
+            stratumV1Service as any,
+        );
+
+        await service.onModuleInit();
+
+        const showWorkersCall = onTextMock.mock.calls.find(
+            ([regex]) => regex instanceof RegExp && regex.source.includes('\\/show_workers')
+        );
+        expect(showWorkersCall).toBeDefined();
+        const handler = showWorkersCall?.[1] as (msg: any, match: RegExpExecArray | null) => Promise<void>;
+
+        const apiData = {
+            workersCount: 1,
+            totalHashrate: 1000,
+            totalShares: 50,
+            bestDifficulty: 5000,
+            workers: [
+                { name: 'Alpha', hashRate: 1000, currentDifficulty: 2, bestDifficulty: '1000' },
+            ],
+        };
+
+        const fetchMock = jest.fn().mockResolvedValue({
+            ok: true,
+            json: jest.fn().mockResolvedValue(apiData),
+        });
+        (global as any).fetch = fetchMock;
+        process.env.API_PORT = '5555';
+
+        const address = '1BoatSLRHtKNngkdXEeobR76b53LETtpyT';
+
+        const helperSpy = jest
+            .spyOn(commonHandlers, 'buildWorkersOverviewMessage')
+            .mockReturnValue({ de: 'DE message', en: 'EN message' });
+
+        await handler(
+            { chat: { id: 42 }, text: `/show_workers ${address}` },
+            [`/show_workers ${address}`, address] as unknown as RegExpExecArray
+        );
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            `http://localhost:5555/api/client/${encodeURIComponent(address)}`
+        );
+        expect(helperSpy).toHaveBeenCalledWith(apiData, (service as any).numberSuffix);
+        expect(sendMessageMock).toHaveBeenCalledWith(42, 'DE message');
+
+        delete process.env.API_PORT;
+        helperSpy.mockRestore();
+    });
+});

--- a/src/services/telegram.service.ts
+++ b/src/services/telegram.service.ts
@@ -10,7 +10,7 @@ import { ClientService } from '../ORM/client/client.service';
 import { AddressSettingsService } from '../ORM/address-settings/address-settings.service';
 import { ClientStatisticsService } from '../ORM/client-statistics/client-statistics.service';
 import { StratumV1Service } from './stratum-v1.service';
-import { buildStatsMessage } from './common-command-handlers';
+import { buildStatsMessage, buildWorkersOverviewMessage } from './common-command-handlers';
 
 @Injectable()
 export class TelegramService implements OnModuleInit {
@@ -84,6 +84,7 @@ export class TelegramService implements OnModuleInit {
             { command: '/difficulty', description: 'Zeigt aktuelle Netzwerk-Difficulty' },
             { command: '/next_difficulty', description: 'Zeigt erwartete Änderung der Netzwerk-Difficulty' },
             { command: '/stats', description: 'Zeigt die Stats für deine Miner Adresse an' },
+            { command: '/show_workers', description: 'Zeigt Worker-Übersicht / Shows worker overview' },
             { command: '/poolhashrate', description: 'Zeigt die aktuelle Pool-Hashrate' },
             { command: '/remove', description: 'Adresse entfernen' },
             { command: '/show_addresses', description: 'Zeigt gespeicherte Adressen' },
@@ -414,6 +415,80 @@ I will decrypt it and respond just like with plain text. 🔒`
                 de: `Gespeicherte Adressen:\n${lines}\n* = Standard`,
                 en: `Stored addresses:\n${lines}\n* = default`
             });
+        });
+
+        this.bot.onText(/\/show_workers(?:\s+(.+))?/, async (msg, match) => {
+            const chatId = msg.chat.id;
+            let raw = match?.[1]?.trim();
+
+            if (!raw) {
+                const subs = await this.telegramSubscriptionsService.getChatSubscriptions(chatId);
+                if (subs.length === 0) {
+                    this.reply(chatId, {
+                        de: 'Keine Adresse gespeichert. Nutze /subscribe, um eine hinzuzufügen.',
+                        en: 'No address stored. Use /subscribe to add one.'
+                    });
+                    return;
+                }
+
+                const defaultSub = subs.find(s => s.isDefault);
+                if (subs.length === 1 || defaultSub) {
+                    raw = (defaultSub ?? subs[0]).address;
+                } else {
+                    const list = subs.map(s => `${s.isDefault ? '*' : ''}${this.formatAddress(s.address)}`).join('\n');
+                    this.reply(chatId, {
+                        de: `Mehrere Adressen gespeichert:\n${list}\nBitte Adresse angeben.`,
+                        en: `Multiple addresses stored:\n${list}\nPlease specify an address.`
+                    });
+                    return;
+                }
+            }
+
+            let address = raw;
+            const decrypted = decryptMessageIfNeeded(raw);
+            if (decrypted) {
+                console.log('Entschlüsselt (Show Workers):', decrypted);
+                address = decrypted.trim();
+            }
+
+            if (!validate(address)) {
+                this.reply(chatId, {
+                    de: 'Ungültige Adresse.',
+                    en: 'Invalid address.'
+                });
+                return;
+            }
+
+            const apiPort = process.env.API_PORT ?? '3334';
+            const url = `http://localhost:${apiPort}/api/client/${encodeURIComponent(address)}`;
+
+            try {
+                const res = await fetch(url);
+                if (!res.ok) {
+                    this.reply(chatId, {
+                        de: 'Konnte Worker-Daten nicht abrufen.',
+                        en: 'Could not fetch worker data.'
+                    });
+                    return;
+                }
+                const payload = await res.json();
+                if (!payload || !Array.isArray(payload.workers) || payload.workers.length === 0) {
+                    this.reply(chatId, {
+                        de: 'Keine Worker für diese Adresse gefunden.',
+                        en: 'No workers found for this address.'
+                    });
+                    return;
+                }
+
+                const messages = buildWorkersOverviewMessage(payload, this.numberSuffix);
+                this.reply(chatId, messages);
+            } catch (err) {
+                console.error('Fehler bei /show_workers:', err);
+                this.reply(chatId, {
+                    de: 'Fehler beim Abrufen der Worker-Daten.',
+                    en: 'Failed to retrieve worker data.'
+                });
+            }
         });
 
         this.bot.onText(/\/stats(?:\s+(.+))?/, async (msg, match) => {


### PR DESCRIPTION
## Summary
- add a localized `/show_workers` Telegram command that reuses the existing address resolution flow and fetches worker data from the API
- format totals and individual worker details via a new helper that applies number suffixes and localized messaging
- cover the formatter and new handler with Jest specs, mocking the fetch layer to ensure the helper receives API data
