### PR TITLE
Add localized hashrate units to worker overview

### DIFF
--- a/src/services/common-command-handlers.spec.ts
+++ b/src/services/common-command-handlers.spec.ts
@@ -5,13 +5,13 @@ describe('buildWorkersOverviewMessage', () => {
     it('formats worker overview with suffixes and plain current difficulty', () => {
         const data: WorkerOverviewData = {
             workersCount: 2,
-            totalHashrate: 1500,
+            totalHashrate: 1_500_000_000_000,
             totalShares: 12345,
             bestDifficulty: 987654,
             workers: [
                 {
                     name: 'Alpha',
-                    hashRate: 1000,
+                    hashRate: 3_600_000_000,
                     currentDifficulty: 123,
                     bestDifficulty: '456.78',
                 },
@@ -26,18 +26,21 @@ describe('buildWorkersOverviewMessage', () => {
 
         const result = buildWorkersOverviewMessage(data, new NumberSuffix());
 
-        expect(result.de).toContain('Gesamt-Hashrate: 1.50k');
-        expect(result.en).toContain('Total hashrate: 1.50k');
+        expect(result.de).toContain('Gesamt-Hashrate: 1.50TH/s');
+        expect(result.en).toContain('Total hashrate: 1.50TH/s');
         expect(result.de).toContain('Gesamt-Shares: 12.35k');
         expect(result.en).toContain('Total shares: 12.35k');
         expect(result.de).toContain('Beste Difficulty: 987.65k');
         expect(result.en).toContain('Best difficulty: 987.65k');
-        expect(result.de).toContain('Hashrate: 1.00k');
+        expect(result.de).toContain('Hashrate: 3.60GH/s');
+        expect(result.en).toContain('Hashrate: 3.60GH/s');
         expect(result.de).toContain('Aktuelle Difficulty: 123');
         expect(result.de).toContain('Beste Difficulty: 456.78');
         expect(result.de).toContain('Worker 2');
+        expect(result.de).toContain('Hashrate: 0.00H/s');
         expect(result.de).toContain('Aktuelle Difficulty: –');
         expect(result.de).toContain('Beste Difficulty: –');
+        expect(result.en).toContain('Hashrate: 0.00H/s');
         expect(result.en).toContain('Current difficulty: –');
     });
 });

--- a/src/services/common-command-handlers.ts
+++ b/src/services/common-command-handlers.ts
@@ -78,10 +78,12 @@ export function buildWorkersOverviewMessage(
     const workerLinesDe: string[] = [];
     const workerLinesEn: string[] = [];
 
+    const formatHashrate = (value: number): string => `${numberSuffix.to(value)}H/s`;
+
     (data.workers ?? []).forEach((worker, idx) => {
         const name = worker?.name?.trim() || `Worker ${idx + 1}`;
         const hashRateValue = parseNumeric(worker?.hashRate) ?? 0;
-        const hashRateFormatted = numberSuffix.to(hashRateValue);
+        const hashRateFormatted = formatHashrate(hashRateValue);
         const currentDifficultyValue = parseNumeric(worker?.currentDifficulty);
         const currentDifficultyFormatted =
             currentDifficultyValue !== null ? `${currentDifficultyValue}` : '–';
@@ -100,7 +102,7 @@ export function buildWorkersOverviewMessage(
     const summaryDe = [
         '👷 Worker-Übersicht',
         `Gesamtanzahl: ${data.workersCount}`,
-        `Gesamt-Hashrate: ${numberSuffix.to(totalHashrate)}`,
+        `Gesamt-Hashrate: ${formatHashrate(totalHashrate)}`,
         `Gesamt-Shares: ${numberSuffix.to(totalShares)}`,
         `Beste Difficulty: ${bestDifficultyTotalFormatted}`,
     ].join('\n');
@@ -108,7 +110,7 @@ export function buildWorkersOverviewMessage(
     const summaryEn = [
         '👷 Workers overview',
         `Total workers: ${data.workersCount}`,
-        `Total hashrate: ${numberSuffix.to(totalHashrate)}`,
+        `Total hashrate: ${formatHashrate(totalHashrate)}`,
         `Total shares: ${numberSuffix.to(totalShares)}`,
         `Best difficulty: ${bestDifficultyTotalFormatted}`,
     ].join('\n');


### PR DESCRIPTION
## Summary
- append localized H/s units to worker overview hashrate values without losing NumberSuffix suffixes
- update worker overview tests to assert TH/s and GH/s formatting in German and English

## Testing
- npm test -- common-command-handlers

------
https://chatgpt.com/codex/tasks/task_e_6900b50b49e0832e9a88c36419bd76df