### PR TITLE
blitzpool performance optimizations

### DIFF
--- a/src/ORM/client-difficulty-statistics/client-difficulty-statistics.service.spec.ts
+++ b/src/ORM/client-difficulty-statistics/client-difficulty-statistics.service.spec.ts
@@ -26,6 +26,62 @@ describe('ClientDifficultyStatisticsService', () => {
     }
   });
 
+  it('upserts the maximum difficulty per unique key', async () => {
+    const timestamp = Date.UTC(2023, 0, 1, 12, 0, 0, 0);
+    const slotTime = Math.floor(timestamp / (60 * 60 * 1000)) * 60 * 60 * 1000;
+    const repository = dataSource.getRepository(ClientDifficultyStatisticsEntity);
+
+    await service.recordShareDifficulty({
+      address: 'addr1',
+      clientName: 'workerA',
+      timestamp,
+      difficulty: 50,
+    });
+
+    let record = await repository.findOneByOrFail({
+      address: 'addr1',
+      clientName: 'workerA',
+      slotTime,
+    });
+
+    expect(record.maxDifficulty).toBe(50);
+    const firstUpdatedAt = record.updatedAt?.getTime() ?? 0;
+
+    await service.recordShareDifficulty({
+      address: 'addr1',
+      clientName: 'workerA',
+      timestamp: timestamp + 5_000,
+      difficulty: 40,
+    });
+
+    record = await repository.findOneByOrFail({
+      address: 'addr1',
+      clientName: 'workerA',
+      slotTime,
+    });
+
+    expect(record.maxDifficulty).toBe(50);
+    const secondUpdatedAt = record.updatedAt?.getTime() ?? 0;
+    expect(secondUpdatedAt).toBeGreaterThanOrEqual(firstUpdatedAt);
+
+    await service.recordShareDifficulty({
+      address: 'addr1',
+      clientName: 'workerA',
+      timestamp: timestamp + 10_000,
+      difficulty: 90,
+    });
+
+    record = await repository.findOneByOrFail({
+      address: 'addr1',
+      clientName: 'workerA',
+      slotTime,
+    });
+
+    expect(record.maxDifficulty).toBe(90);
+    const thirdUpdatedAt = record.updatedAt?.getTime() ?? 0;
+    expect(thirdUpdatedAt).toBeGreaterThanOrEqual(secondUpdatedAt);
+  });
+
   it('stores the highest difficulty per slot and aggregates by address', async () => {
     const base = Date.UTC(2023, 0, 1, 12, 15, 0, 0);
 

--- a/src/ORM/client-difficulty-statistics/client-difficulty-statistics.service.ts
+++ b/src/ORM/client-difficulty-statistics/client-difficulty-statistics.service.ts
@@ -40,32 +40,29 @@ export class ClientDifficultyStatisticsService {
     const slotTime = ClientDifficultyStatisticsService.normalizeSlot(timestamp);
     const clientName = params.clientName ?? null;
 
+    const updatedAt = new Date();
+
     try {
-      await this.repository.insert({
-        address: params.address,
-        clientName,
-        slotTime,
-        maxDifficulty: params.difficulty,
-      });
-      return;
+      await this.repository
+        .createQueryBuilder()
+        .insert()
+        .into(ClientDifficultyStatisticsEntity)
+        .values({
+          address: params.address,
+          clientName,
+          slotTime,
+          maxDifficulty: params.difficulty,
+        })
+        .onConflict(
+          '("address", "clientName", "slotTime") DO UPDATE SET "maxDifficulty" = CASE WHEN EXCLUDED."maxDifficulty" > "maxDifficulty" THEN EXCLUDED."maxDifficulty" ELSE "maxDifficulty" END, "updatedAt" = :updatedAt',
+        )
+        .setParameter('updatedAt', updatedAt)
+        .execute();
     } catch (error) {
       if (!ClientDifficultyStatisticsService.isUniqueConstraintError(error)) {
         throw error;
       }
     }
-
-    const existing = await this.repository.findOne({
-      where: { address: params.address, clientName, slotTime },
-    });
-
-    if (!existing || params.difficulty <= existing.maxDifficulty) {
-      return;
-    }
-
-    await this.repository.update(
-      { address: params.address, clientName, slotTime },
-      { maxDifficulty: params.difficulty, updatedAt: new Date() },
-    );
   }
 
   async getMaximaForAddress(address: string, from: number, to: number) {

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -532,6 +532,20 @@ export class ClientStatisticsService {
     }));
   }
 
+  public async getTotalSharesForWorker(
+    address: string,
+    workerName: string,
+  ): Promise<number> {
+    const result = await this.clientStatisticsRepository
+      .createQueryBuilder('entry')
+      .select('SUM(entry.shares)', 'total')
+      .where('entry.address = :address', { address })
+      .andWhere('entry.clientName = :workerName', { workerName })
+      .getRawOne();
+
+    return result?.total ? parseFloat(result.total) : 0;
+  }
+
   public async deleteAll() {
     return await this.clientStatisticsRepository.delete({});
   }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -27,6 +27,7 @@ import { TelegramService } from './services/telegram.service';
 import { NtfyService } from './services/ntfy.service';
 import { ExternalSharesService } from './services/external-shares.service';
 import { GeoIpService } from './services/geoip.service';
+import { ShareTotalsCacheService } from './services/share-totals-cache.service';
 import { ExternalShareController } from './controllers/external-share/external-share.controller';
 import { ExternalSharesModule } from './ORM/external-shares/external-shares.module';
 import { PoolShareStatisticsModule } from './ORM/pool-share-statistics/pool-share-statistics.module';
@@ -84,6 +85,7 @@ const ORMModules = [
         BraiinsService,
         ExternalSharesService,
         GeoIpService,
+        ShareTotalsCacheService,
     ],
 })
 export class AppModule {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,6 +28,7 @@ import { NtfyService } from './services/ntfy.service';
 import { ExternalSharesService } from './services/external-shares.service';
 import { GeoIpService } from './services/geoip.service';
 import { ShareTotalsCacheService } from './services/share-totals-cache.service';
+import { AddressSettingsCacheService } from './services/address-settings-cache.service';
 import { ExternalShareController } from './controllers/external-share/external-share.controller';
 import { ExternalSharesModule } from './ORM/external-shares/external-shares.module';
 import { PoolShareStatisticsModule } from './ORM/pool-share-statistics/pool-share-statistics.module';
@@ -86,6 +87,7 @@ const ORMModules = [
         ExternalSharesService,
         GeoIpService,
         ShareTotalsCacheService,
+        AddressSettingsCacheService,
     ],
 })
 export class AppModule {

--- a/src/controllers/client/client.controller.client-info.spec.ts
+++ b/src/controllers/client/client.controller.client-info.spec.ts
@@ -10,6 +10,7 @@ import { AddressSettingsService } from '../../ORM/address-settings/address-setti
 import { ClientRejectedStatisticsService } from '../../ORM/client-rejected-statistics/client-rejected-statistics.service';
 import { ClientDifficultyStatisticsService } from '../../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 import { StratumV1Service } from '../../services/stratum-v1.service';
+import { ShareTotalsCacheService } from '../../services/share-totals-cache.service';
 
 describe('ClientController getClientInfo', () => {
   let app: NestFastifyApplication;
@@ -17,6 +18,7 @@ describe('ClientController getClientInfo', () => {
   let clientStatisticsService: { getTotalSharesForAddress: jest.Mock };
   let addressSettingsService: { getSettings: jest.Mock };
   let stratumV1Service: { getCurrentDifficulties: jest.Mock };
+  let shareTotalsCacheService: { getAddressTotal: jest.Mock };
 
   beforeEach(async () => {
     clientService = {
@@ -52,6 +54,9 @@ describe('ClientController getClientInfo', () => {
         .fn()
         .mockReturnValue(new Map([['session-1', 2048]])),
     };
+    shareTotalsCacheService = {
+      getAddressTotal: jest.fn().mockResolvedValue(12345),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ClientController],
@@ -62,6 +67,7 @@ describe('ClientController getClientInfo', () => {
         { provide: ClientRejectedStatisticsService, useValue: {} },
         { provide: ClientDifficultyStatisticsService, useValue: {} },
         { provide: StratumV1Service, useValue: stratumV1Service },
+        { provide: ShareTotalsCacheService, useValue: shareTotalsCacheService },
       ],
     }).compile();
 
@@ -113,5 +119,6 @@ describe('ClientController getClientInfo', () => {
     expect(stratumV1Service.getCurrentDifficulties).toHaveBeenCalledWith(
       'btc123',
     );
+    expect(shareTotalsCacheService.getAddressTotal).toHaveBeenCalledWith('btc123');
   });
 });

--- a/src/controllers/client/client.controller.diff-scores.spec.ts
+++ b/src/controllers/client/client.controller.diff-scores.spec.ts
@@ -9,6 +9,7 @@ import { ClientStatisticsService } from '../../ORM/client-statistics/client-stat
 import { AddressSettingsService } from '../../ORM/address-settings/address-settings.service';
 import { ClientRejectedStatisticsService } from '../../ORM/client-rejected-statistics/client-rejected-statistics.service';
 import { StratumV1Service } from '../../services/stratum-v1.service';
+import { ShareTotalsCacheService } from '../../services/share-totals-cache.service';
 import { ClientDifficultyStatisticsService } from '../../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 
 describe('ClientController difficulty scores', () => {
@@ -32,6 +33,7 @@ describe('ClientController difficulty scores', () => {
         { provide: ClientRejectedStatisticsService, useValue: {} },
         { provide: ClientDifficultyStatisticsService, useValue: clientDifficultyStatisticsService },
         { provide: StratumV1Service, useValue: {} },
+        { provide: ShareTotalsCacheService, useValue: {} },
       ],
     }).compile();
 

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -7,6 +7,7 @@ import { ClientRejectedStatisticsService } from '../../ORM/client-rejected-stati
 import { ClientDifficultyStatisticsService } from '../../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 import { eStratumErrorCode } from '../../models/enums/eStratumErrorCode';
 import { StratumV1Service } from '../../services/stratum-v1.service';
+import { ShareTotalsCacheService } from '../../services/share-totals-cache.service';
 
 
 @Controller('client')
@@ -19,6 +20,7 @@ export class ClientController {
         private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
         private readonly clientDifficultyStatisticsService: ClientDifficultyStatisticsService,
         private readonly stratumV1Service: StratumV1Service,
+        private readonly shareTotalsCacheService: ShareTotalsCacheService,
     ) { }
 
 
@@ -29,7 +31,7 @@ export class ClientController {
 
         const addressSettings = await this.addressSettingsService.getSettings(address, false);
 
-        const totalShares = await this.clientStatisticsService.getTotalSharesForAddress(address);
+        const totalShares = await this.shareTotalsCacheService.getAddressTotal(address);
         const totalHashrate = workers.reduce((sum, w) => sum + (w.hashRate ?? 0), 0);
         const currentDifficulties = this.stratumV1Service.getCurrentDifficulties(address);
 
@@ -83,8 +85,8 @@ export class ClientController {
 
     @Get(':address/worker-shares')
     async getWorkerShares(@Param('address') address: string) {
-        const workerShares = await this.clientStatisticsService.getTotalSharesForWorkers(address);
-        return workerShares.map(ws => ({ workerName: ws.clientName, totalShares: ws.total }));
+        const workerShares = await this.shareTotalsCacheService.getWorkerTotals(address);
+        return workerShares.map(ws => ({ workerName: ws.workerName, totalShares: ws.total }));
     }
 
     @Get(':address/workers')

--- a/src/controllers/client/client.controller.worker.spec.ts
+++ b/src/controllers/client/client.controller.worker.spec.ts
@@ -10,6 +10,7 @@ import { AddressSettingsService } from '../../ORM/address-settings/address-setti
 import { ClientRejectedStatisticsService } from '../../ORM/client-rejected-statistics/client-rejected-statistics.service';
 import { StratumV1Service } from '../../services/stratum-v1.service';
 import { ClientDifficultyStatisticsService } from '../../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
+import { ShareTotalsCacheService } from '../../services/share-totals-cache.service';
 
 describe('ClientController worker chart data', () => {
   let app: NestFastifyApplication;
@@ -47,6 +48,7 @@ describe('ClientController worker chart data', () => {
         { provide: ClientRejectedStatisticsService, useValue: {} },
         { provide: ClientDifficultyStatisticsService, useValue: {} },
         { provide: StratumV1Service, useValue: {} },
+        { provide: ShareTotalsCacheService, useValue: {} },
       ],
     }).compile();
 

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -34,6 +34,7 @@ import { PoolRejectedStatisticsService } from '../ORM/pool-rejected-statistics/p
 import { ClientRejectedStatisticsService } from '../ORM/client-rejected-statistics/client-rejected-statistics.service';
 import { StratumV1Service } from '../services/stratum-v1.service';
 import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
+import { ShareTotalsCacheService } from '../services/share-totals-cache.service';
 
 
 export class StratumV1Client {
@@ -93,6 +94,7 @@ export class StratumV1Client {
         private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
         private readonly externalSharesService: ExternalSharesService,
         private readonly clientDifficultyStatisticsService: ClientDifficultyStatisticsService,
+        private readonly shareTotalsCacheService: ShareTotalsCacheService,
         private readonly stratumV1Service: StratumV1Service,
         initialDifficulty: number,
         private readonly allowSuggestedDifficulty: boolean = true,
@@ -878,6 +880,11 @@ export class StratumV1Client {
             }
             try {
                 await this.statistics.addShares(this.entity, this.sessionDifficulty);
+                await this.shareTotalsCacheService.increment(
+                    this.clientAuthorization.address,
+                    this.clientAuthorization.worker,
+                    this.sessionDifficulty,
+                );
                 const now = new Date();
                 // only update every minute
                 if (this.entity.updatedAt == null || now.getTime() - this.entity.updatedAt.getTime() > 1000 * 60) {

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -35,6 +35,7 @@ import { ClientRejectedStatisticsService } from '../ORM/client-rejected-statisti
 import { StratumV1Service } from '../services/stratum-v1.service';
 import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 import { ShareTotalsCacheService } from '../services/share-totals-cache.service';
+import { AddressSettingsCacheService } from '../services/address-settings-cache.service';
 
 
 export class StratumV1Client {
@@ -89,6 +90,7 @@ export class StratumV1Client {
         private readonly blocksService: BlocksService,
         private readonly configService: ConfigService,
         private readonly addressSettingsService: AddressSettingsService,
+        private readonly addressSettingsCacheService: AddressSettingsCacheService,
         private readonly poolShareStatisticsService: PoolShareStatisticsService,
         private readonly poolRejectedStatisticsService: PoolRejectedStatisticsService,
         private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
@@ -872,10 +874,16 @@ export class StratumV1Client {
                     blockData: blockHex
                 });
 
-                await this.notificationService.notifySubscribersBlockFound(this.clientAuthorization.address, jobTemplate.blockData.height, updatedJobBlock, result);
+                await this.notificationService.notifySubscribersBlockFound(
+                    this.clientAuthorization.address,
+                    jobTemplate.blockData.height,
+                    updatedJobBlock,
+                    result,
+                );
                 //success
                 if (result == null) {
                     await this.addressSettingsService.resetBestDifficultyAndShares();
+                    this.addressSettingsCacheService.clear();
                 }
             }
             try {
@@ -919,12 +927,19 @@ export class StratumV1Client {
                 this.entity.bestDifficulty = submissionDifficulty;
             }
 
-            const addressSettings = await this.addressSettingsService.getSettings(this.clientAuthorization.address, true);
-            const storedBestDifficulty = addressSettings?.bestDifficulty ?? 0;
+            const shouldUpdateBestDifficulty = await this.addressSettingsCacheService.shouldUpdateBestDifficulty(
+                this.clientAuthorization.address,
+                submissionDifficulty,
+            );
 
-            if (submissionDifficulty > storedBestDifficulty) {
+            if (shouldUpdateBestDifficulty) {
                 await this.notificationService.notifySubscribersBestDiff(this.clientAuthorization.address, submissionDifficulty);
                 await this.addressSettingsService.updateBestDifficulty(this.clientAuthorization.address, submissionDifficulty, this.entity.userAgent);
+                this.addressSettingsCacheService.updateBestDifficulty(
+                    this.clientAuthorization.address,
+                    submissionDifficulty,
+                    this.entity.userAgent ?? null,
+                );
             }
 
 

--- a/src/models/stratum-v1-client.spec.ts
+++ b/src/models/stratum-v1-client.spec.ts
@@ -19,6 +19,7 @@ function createClient(options: CreateClientOptions = {}) {
   } = options;
   const socket = new net.Socket();
   const dummy = {} as any;
+  const shareTotalsCacheService = { increment: jest.fn().mockResolvedValue(undefined) };
   const stratumV1JobsService = {
     newMiningJob$: {
       subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
@@ -56,6 +57,7 @@ function createClient(options: CreateClientOptions = {}) {
     dummy,
     dummy,
     dummy,
+    shareTotalsCacheService as any,
     stratumV1Service as any,
     initialDifficulty,
     allowSuggestedDifficulty,

--- a/src/models/stratum-v1-client.spec.ts
+++ b/src/models/stratum-v1-client.spec.ts
@@ -20,6 +20,12 @@ function createClient(options: CreateClientOptions = {}) {
   const socket = new net.Socket();
   const dummy = {} as any;
   const shareTotalsCacheService = { increment: jest.fn().mockResolvedValue(undefined) };
+  const addressSettingsCacheService = {
+    shouldUpdateBestDifficulty: jest.fn().mockResolvedValue(false),
+    updateBestDifficulty: jest.fn(),
+    clear: jest.fn(),
+    getBestDifficulty: jest.fn(),
+  };
   const stratumV1JobsService = {
     newMiningJob$: {
       subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
@@ -52,6 +58,7 @@ function createClient(options: CreateClientOptions = {}) {
     dummy,
     configService as any,
     dummy,
+    addressSettingsCacheService as any,
     dummy,
     dummy,
     dummy,

--- a/src/services/address-settings-cache.service.spec.ts
+++ b/src/services/address-settings-cache.service.spec.ts
@@ -1,0 +1,88 @@
+import { AddressSettingsService } from '../ORM/address-settings/address-settings.service';
+import { AddressSettingsCacheService } from './address-settings-cache.service';
+
+describe('AddressSettingsCacheService', () => {
+  let addressSettingsService: { getSettings: jest.Mock };
+  let service: AddressSettingsCacheService;
+
+  beforeEach(() => {
+    addressSettingsService = {
+      getSettings: jest.fn(),
+    };
+    service = new AddressSettingsCacheService(
+      addressSettingsService as unknown as AddressSettingsService,
+    );
+  });
+
+  it('hydrates from the underlying service on first access', async () => {
+    addressSettingsService.getSettings.mockResolvedValue({
+      bestDifficulty: 42,
+      bestDifficultyUserAgent: 'ua',
+    });
+
+    const snapshot = await service.getBestDifficulty('addr');
+
+    expect(snapshot).toEqual({ bestDifficulty: 42, bestDifficultyUserAgent: 'ua' });
+    expect(addressSettingsService.getSettings).toHaveBeenCalledTimes(1);
+    expect(addressSettingsService.getSettings).toHaveBeenCalledWith('addr', true);
+  });
+
+  it('caches subsequent lookups in memory', async () => {
+    addressSettingsService.getSettings.mockResolvedValueOnce({
+      bestDifficulty: 10,
+      bestDifficultyUserAgent: null,
+    });
+
+    await service.getBestDifficulty('addr');
+    const second = await service.getBestDifficulty('addr');
+
+    expect(second).toEqual({ bestDifficulty: 10, bestDifficultyUserAgent: null });
+    expect(addressSettingsService.getSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports whether a candidate exceeds the cached value', async () => {
+    addressSettingsService.getSettings.mockResolvedValue({
+      bestDifficulty: 15,
+      bestDifficultyUserAgent: null,
+    });
+
+    await expect(service.shouldUpdateBestDifficulty('addr', 10)).resolves.toBe(false);
+    await expect(service.shouldUpdateBestDifficulty('addr', 20)).resolves.toBe(true);
+    expect(addressSettingsService.getSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates the cache after persisting a new best difficulty', async () => {
+    addressSettingsService.getSettings.mockResolvedValue({
+      bestDifficulty: 5,
+      bestDifficultyUserAgent: null,
+    });
+
+    await service.getBestDifficulty('addr');
+    service.updateBestDifficulty('addr', 25, 'ua');
+
+    const snapshot = await service.getBestDifficulty('addr');
+    expect(snapshot).toEqual({ bestDifficulty: 25, bestDifficultyUserAgent: 'ua' });
+    expect(addressSettingsService.getSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows clearing individual entries or the whole cache', async () => {
+    addressSettingsService.getSettings.mockResolvedValue({
+      bestDifficulty: 5,
+      bestDifficultyUserAgent: null,
+    });
+
+    await service.getBestDifficulty('addr');
+    service.clear('addr');
+    addressSettingsService.getSettings.mockResolvedValue({
+      bestDifficulty: 7,
+      bestDifficultyUserAgent: 'ua',
+    });
+
+    await service.getBestDifficulty('addr');
+    expect(addressSettingsService.getSettings).toHaveBeenCalledTimes(2);
+
+    service.clear();
+    await service.getBestDifficulty('addr2');
+    expect(addressSettingsService.getSettings).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/services/address-settings-cache.service.ts
+++ b/src/services/address-settings-cache.service.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@nestjs/common';
+
+import { AddressSettingsService } from '../ORM/address-settings/address-settings.service';
+
+export interface AddressBestDifficultySnapshot {
+  bestDifficulty: number;
+  bestDifficultyUserAgent: string | null;
+}
+
+@Injectable()
+export class AddressSettingsCacheService {
+  private readonly cache = new Map<string, AddressBestDifficultySnapshot>();
+
+  constructor(
+    private readonly addressSettingsService: AddressSettingsService,
+  ) {}
+
+  async getBestDifficulty(address: string): Promise<AddressBestDifficultySnapshot> {
+    const cached = await this.ensure(address);
+    return { ...cached };
+  }
+
+  async shouldUpdateBestDifficulty(
+    address: string,
+    candidateDifficulty: number,
+  ): Promise<boolean> {
+    const cached = await this.ensure(address);
+    return candidateDifficulty > cached.bestDifficulty;
+  }
+
+  updateBestDifficulty(
+    address: string,
+    bestDifficulty: number,
+    bestDifficultyUserAgent: string | null,
+  ): void {
+    this.cache.set(address, {
+      bestDifficulty,
+      bestDifficultyUserAgent,
+    });
+  }
+
+  clear(address?: string): void {
+    if (address) {
+      this.cache.delete(address);
+      return;
+    }
+    this.cache.clear();
+  }
+
+  private async ensure(address: string): Promise<AddressBestDifficultySnapshot> {
+    let cached = this.cache.get(address);
+    if (!cached) {
+      const settings = await this.addressSettingsService.getSettings(
+        address,
+        true,
+      );
+      cached = {
+        bestDifficulty: settings?.bestDifficulty ?? 0,
+        bestDifficultyUserAgent: settings?.bestDifficultyUserAgent ?? null,
+      };
+      this.cache.set(address, cached);
+    }
+    return cached;
+  }
+}

--- a/src/services/share-totals-cache.service.spec.ts
+++ b/src/services/share-totals-cache.service.spec.ts
@@ -8,6 +8,7 @@ describe('ShareTotalsCacheService', () => {
   let clientStatisticsService: {
     getTotalSharesForAddress: jest.Mock;
     getTotalSharesForWorkers: jest.Mock;
+    getTotalSharesForWorker: jest.Mock;
   };
   let addressSettingsService: { addShares: jest.Mock };
   let configService: { get: jest.Mock };
@@ -20,6 +21,17 @@ describe('ShareTotalsCacheService', () => {
         { clientName: 'worker-1', total: 60 },
         { clientName: 'worker-2', total: 40 },
       ]),
+      getTotalSharesForWorker: jest.fn().mockImplementation(
+        async (_address: string, workerName: string) => {
+          if (workerName === 'worker-1') {
+            return 60;
+          }
+          if (workerName === 'worker-2') {
+            return 40;
+          }
+          return 0;
+        },
+      ),
     };
     addressSettingsService = {
       addShares: jest.fn().mockResolvedValue(undefined),
@@ -56,20 +68,45 @@ describe('ShareTotalsCacheService', () => {
   });
 
   it('hydrates worker totals and adds new workers when incremented', async () => {
-    const workerTotals = await service.getWorkerTotals('addr1');
-    expect(workerTotals).toEqual([
+    const workerTotalsFirst = await service.getWorkerTotals('addr1');
+    expect(workerTotalsFirst).toEqual([
       { workerName: 'worker-1', total: 60 },
       { workerName: 'worker-2', total: 40 },
     ]);
     expect(clientStatisticsService.getTotalSharesForWorkers).toHaveBeenCalledTimes(1);
+    expect(clientStatisticsService.getTotalSharesForWorker).not.toHaveBeenCalled();
+
+    const workerTotalsSecond = await service.getWorkerTotals('addr1');
+    expect(workerTotalsSecond).toEqual([
+      { workerName: 'worker-1', total: 60 },
+      { workerName: 'worker-2', total: 40 },
+    ]);
+    expect(clientStatisticsService.getTotalSharesForWorkers).toHaveBeenCalledTimes(1);
+  });
+
+  it('hydrates individual worker baselines lazily when incrementing', async () => {
+    clientStatisticsService.getTotalSharesForWorker.mockResolvedValue(5);
+    clientStatisticsService.getTotalSharesForWorkers.mockResolvedValueOnce([
+      { clientName: 'worker-1', total: 60 },
+      { clientName: 'worker-2', total: 40 },
+      { clientName: 'worker-3', total: 5 },
+    ]);
 
     await service.increment('addr1', 'worker-3', 15);
+
+    expect(clientStatisticsService.getTotalSharesForWorker).toHaveBeenCalledTimes(1);
+    expect(clientStatisticsService.getTotalSharesForWorker).toHaveBeenCalledWith(
+      'addr1',
+      'worker-3',
+    );
+    expect(clientStatisticsService.getTotalSharesForWorkers).not.toHaveBeenCalled();
+
     const updated = await service.getWorkerTotals('addr1');
     const sorted = [...updated].sort((a, b) => a.workerName.localeCompare(b.workerName));
     expect(sorted).toEqual([
       { workerName: 'worker-1', total: 60 },
       { workerName: 'worker-2', total: 40 },
-      { workerName: 'worker-3', total: 15 },
+      { workerName: 'worker-3', total: 20 },
     ]);
     expect(clientStatisticsService.getTotalSharesForWorkers).toHaveBeenCalledTimes(1);
   });

--- a/src/services/share-totals-cache.service.spec.ts
+++ b/src/services/share-totals-cache.service.spec.ts
@@ -1,0 +1,96 @@
+import { ConfigService } from '@nestjs/config';
+
+import { AddressSettingsService } from '../ORM/address-settings/address-settings.service';
+import { ClientStatisticsService } from '../ORM/client-statistics/client-statistics.service';
+import { ShareTotalsCacheService } from './share-totals-cache.service';
+
+describe('ShareTotalsCacheService', () => {
+  let clientStatisticsService: {
+    getTotalSharesForAddress: jest.Mock;
+    getTotalSharesForWorkers: jest.Mock;
+  };
+  let addressSettingsService: { addShares: jest.Mock };
+  let configService: { get: jest.Mock };
+  let service: ShareTotalsCacheService;
+
+  beforeEach(() => {
+    clientStatisticsService = {
+      getTotalSharesForAddress: jest.fn().mockResolvedValue(100),
+      getTotalSharesForWorkers: jest.fn().mockResolvedValue([
+        { clientName: 'worker-1', total: 60 },
+        { clientName: 'worker-2', total: 40 },
+      ]),
+    };
+    addressSettingsService = {
+      addShares: jest.fn().mockResolvedValue(undefined),
+    };
+    configService = {
+      get: jest.fn().mockImplementation((key: string) => {
+        if (key === 'SHARE_TOTALS_FLUSH_INTERVAL_MS') {
+          return '0';
+        }
+        return undefined;
+      }),
+    };
+
+    service = new ShareTotalsCacheService(
+      clientStatisticsService as unknown as ClientStatisticsService,
+      addressSettingsService as unknown as AddressSettingsService,
+      configService as unknown as ConfigService,
+    );
+  });
+
+  afterEach(async () => {
+    await service.onModuleDestroy();
+  });
+
+  it('hydrates address totals and applies increments', async () => {
+    const total = await service.getAddressTotal('addr1');
+    expect(total).toBe(100);
+    expect(clientStatisticsService.getTotalSharesForAddress).toHaveBeenCalledTimes(1);
+
+    await service.increment('addr1', 'worker-1', 25);
+    const updatedTotal = await service.getAddressTotal('addr1');
+    expect(updatedTotal).toBe(125);
+    expect(clientStatisticsService.getTotalSharesForAddress).toHaveBeenCalledTimes(1);
+  });
+
+  it('hydrates worker totals and adds new workers when incremented', async () => {
+    const workerTotals = await service.getWorkerTotals('addr1');
+    expect(workerTotals).toEqual([
+      { workerName: 'worker-1', total: 60 },
+      { workerName: 'worker-2', total: 40 },
+    ]);
+    expect(clientStatisticsService.getTotalSharesForWorkers).toHaveBeenCalledTimes(1);
+
+    await service.increment('addr1', 'worker-3', 15);
+    const updated = await service.getWorkerTotals('addr1');
+    const sorted = [...updated].sort((a, b) => a.workerName.localeCompare(b.workerName));
+    expect(sorted).toEqual([
+      { workerName: 'worker-1', total: 60 },
+      { workerName: 'worker-2', total: 40 },
+      { workerName: 'worker-3', total: 15 },
+    ]);
+    expect(clientStatisticsService.getTotalSharesForWorkers).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushes deltas to durable storage and resets in-memory accumulators', async () => {
+    await service.increment('addr1', 'worker-1', 30);
+    await service.increment('addr1', 'worker-2', 10);
+
+    await service.flush();
+
+    expect(addressSettingsService.addShares).toHaveBeenCalledTimes(1);
+    expect(addressSettingsService.addShares).toHaveBeenCalledWith('addr1', 40);
+
+    const totals = await service.getWorkerTotals('addr1');
+    const sorted = [...totals].sort((a, b) => a.workerName.localeCompare(b.workerName));
+    expect(sorted).toEqual([
+      { workerName: 'worker-1', total: 90 },
+      { workerName: 'worker-2', total: 50 },
+    ]);
+
+    await service.flush();
+    expect(addressSettingsService.addShares).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/share-totals-cache.service.ts
+++ b/src/services/share-totals-cache.service.ts
@@ -1,0 +1,196 @@
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { AddressSettingsService } from '../ORM/address-settings/address-settings.service';
+import { ClientStatisticsService } from '../ORM/client-statistics/client-statistics.service';
+
+interface TotalsEntry {
+  baseline: number;
+  delta: number;
+}
+
+/**
+ * Caches aggregate share totals per address and per worker.
+ *
+ * Totals are hydrated from the historical aggregates on first use and then
+ * incrementally updated as new shares arrive. A periodic flush persists the
+ * accumulated deltas back to durable storage so that cached values remain
+ * consistent across restarts. Recent deltas can be lost if the process stops
+ * unexpectedly before the next flush completes.
+ */
+@Injectable()
+export class ShareTotalsCacheService implements OnModuleDestroy {
+  private readonly addressTotals = new Map<string, TotalsEntry>();
+  private readonly workerTotals = new Map<string, Map<string, TotalsEntry>>();
+  private readonly addressHydrations = new Map<string, Promise<void>>();
+  private readonly workerHydrations = new Map<string, Promise<void>>();
+  private readonly flushIntervalMs: number;
+  private flushTimer?: NodeJS.Timeout;
+
+  constructor(
+    private readonly clientStatisticsService: ClientStatisticsService,
+    private readonly addressSettingsService: AddressSettingsService,
+    private readonly configService: ConfigService,
+  ) {
+    const configuredInterval = parseInt(
+      this.configService.get<string>('SHARE_TOTALS_FLUSH_INTERVAL_MS') ?? '',
+      10,
+    );
+    if (Number.isFinite(configuredInterval) && configuredInterval > 0) {
+      this.flushIntervalMs = configuredInterval;
+    } else if (configuredInterval === 0) {
+      this.flushIntervalMs = 0;
+    } else {
+      this.flushIntervalMs = 5 * 60 * 1000;
+    }
+    if (this.flushIntervalMs > 0) {
+      this.flushTimer = setInterval(() => {
+        void this.flush().catch((error) => {
+          console.error('ShareTotalsCacheService flush failed', error);
+        });
+      }, this.flushIntervalMs);
+      if (typeof this.flushTimer.unref === 'function') {
+        this.flushTimer.unref();
+      }
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = undefined;
+    }
+  }
+
+  public async increment(
+    address: string,
+    workerName: string | undefined,
+    difficulty: number,
+  ): Promise<void> {
+    if (!address || !Number.isFinite(difficulty) || difficulty <= 0) {
+      return;
+    }
+
+    await this.ensureAddressBaseline(address);
+    const addressEntry = this.addressTotals.get(address);
+    if (addressEntry) {
+      addressEntry.delta += difficulty;
+    }
+
+    if (workerName) {
+      await this.ensureWorkerBaseline(address);
+      let workerMap = this.workerTotals.get(address);
+      if (!workerMap) {
+        workerMap = new Map();
+        this.workerTotals.set(address, workerMap);
+      }
+      let workerEntry = workerMap.get(workerName);
+      if (!workerEntry) {
+        workerEntry = { baseline: 0, delta: 0 };
+        workerMap.set(workerName, workerEntry);
+      }
+      workerEntry.delta += difficulty;
+    }
+  }
+
+  public async getAddressTotal(address: string): Promise<number> {
+    await this.ensureAddressBaseline(address);
+    const entry = this.addressTotals.get(address);
+    if (!entry) {
+      return this.clientStatisticsService.getTotalSharesForAddress(address);
+    }
+    return entry.baseline + entry.delta;
+  }
+
+  public async getWorkerTotals(
+    address: string,
+  ): Promise<Array<{ workerName: string; total: number }>> {
+    await this.ensureWorkerBaseline(address);
+    const workerMap = this.workerTotals.get(address);
+    if (!workerMap) {
+      const totals = await this.clientStatisticsService.getTotalSharesForWorkers(
+        address,
+      );
+      return totals.map((entry) => ({
+        workerName: entry.clientName,
+        total: entry.total,
+      }));
+    }
+    const result: Array<{ workerName: string; total: number }> = [];
+    for (const [workerName, entry] of workerMap.entries()) {
+      result.push({ workerName, total: entry.baseline + entry.delta });
+    }
+    return result;
+  }
+
+  public async flush(): Promise<void> {
+    const pending: Promise<void>[] = [];
+    for (const [address, entry] of this.addressTotals.entries()) {
+      if (entry.delta <= 0) {
+        continue;
+      }
+      const delta = entry.delta;
+      entry.baseline += delta;
+      entry.delta = 0;
+      pending.push(
+        this.addressSettingsService
+          .addShares(address, delta)
+          .catch((error) => {
+            entry.baseline -= delta;
+            entry.delta += delta;
+            console.error('ShareTotalsCacheService failed to persist shares', error);
+          })
+          .then(() => void 0),
+      );
+    }
+
+    for (const workerMap of this.workerTotals.values()) {
+      for (const entry of workerMap.values()) {
+        if (entry.delta > 0) {
+          entry.baseline += entry.delta;
+          entry.delta = 0;
+        }
+      }
+    }
+
+    await Promise.all(pending);
+  }
+
+  private async ensureAddressBaseline(address: string): Promise<void> {
+    if (this.addressTotals.has(address)) {
+      return;
+    }
+    let hydration = this.addressHydrations.get(address);
+    if (!hydration) {
+      hydration = (async () => {
+        const total = await this.clientStatisticsService.getTotalSharesForAddress(
+          address,
+        );
+        this.addressTotals.set(address, { baseline: total, delta: 0 });
+      })();
+      this.addressHydrations.set(address, hydration);
+    }
+    await hydration;
+  }
+
+  private async ensureWorkerBaseline(address: string): Promise<void> {
+    if (this.workerTotals.has(address)) {
+      return;
+    }
+    let hydration = this.workerHydrations.get(address);
+    if (!hydration) {
+      hydration = (async () => {
+        const totals = await this.clientStatisticsService.getTotalSharesForWorkers(
+          address,
+        );
+        const entries = new Map<string, TotalsEntry>();
+        for (const total of totals) {
+          entries.set(total.clientName, { baseline: total.total, delta: 0 });
+        }
+        this.workerTotals.set(address, entries);
+      })();
+      this.workerHydrations.set(address, hydration);
+    }
+    await hydration;
+  }
+}

--- a/src/services/share-totals-cache.service.ts
+++ b/src/services/share-totals-cache.service.ts
@@ -24,6 +24,11 @@ export class ShareTotalsCacheService implements OnModuleDestroy {
   private readonly workerTotals = new Map<string, Map<string, TotalsEntry>>();
   private readonly addressHydrations = new Map<string, Promise<void>>();
   private readonly workerHydrations = new Map<string, Promise<void>>();
+  private readonly workerPartialHydrations = new Map<
+    string,
+    Map<string, Promise<void>>
+  >();
+  private readonly fullyHydratedAddresses = new Set<string>();
   private readonly flushIntervalMs: number;
   private flushTimer?: NodeJS.Timeout;
 
@@ -78,7 +83,7 @@ export class ShareTotalsCacheService implements OnModuleDestroy {
     }
 
     if (workerName) {
-      await this.ensureWorkerBaseline(address);
+      await this.ensureWorkerBaseline(address, workerName);
       let workerMap = this.workerTotals.get(address);
       if (!workerMap) {
         workerMap = new Map();
@@ -173,24 +178,98 @@ export class ShareTotalsCacheService implements OnModuleDestroy {
     await hydration;
   }
 
-  private async ensureWorkerBaseline(address: string): Promise<void> {
-    if (this.workerTotals.has(address)) {
+  private async ensureWorkerBaseline(
+    address: string,
+    workerName?: string,
+  ): Promise<void> {
+    if (workerName) {
+      const workerMap = this.workerTotals.get(address);
+      if (workerMap?.has(workerName)) {
+        return;
+      }
+
+      let partialHydrations = this.workerPartialHydrations.get(address);
+      if (!partialHydrations) {
+        partialHydrations = new Map();
+        this.workerPartialHydrations.set(address, partialHydrations);
+      }
+
+      let hydration = partialHydrations.get(workerName);
+      if (!hydration) {
+        hydration = (async () => {
+          const total =
+            await this.clientStatisticsService.getTotalSharesForWorker(
+              address,
+              workerName,
+            );
+          let map = this.workerTotals.get(address);
+          if (!map) {
+            map = new Map();
+            this.workerTotals.set(address, map);
+          }
+          const entry = map.get(workerName);
+          if (entry) {
+            entry.baseline = total;
+          } else {
+            map.set(workerName, { baseline: total, delta: 0 });
+          }
+        })();
+        partialHydrations.set(workerName, hydration);
+      }
+
+      try {
+        await hydration;
+      } finally {
+        partialHydrations.delete(workerName);
+        if (partialHydrations.size === 0) {
+          this.workerPartialHydrations.delete(address);
+        }
+      }
+
       return;
     }
+
+    if (this.fullyHydratedAddresses.has(address) && this.workerTotals.has(address)) {
+      return;
+    }
+
+    const pendingPartials = this.workerPartialHydrations.get(address);
+    if (pendingPartials && pendingPartials.size > 0) {
+      await Promise.all(pendingPartials.values());
+    }
+
     let hydration = this.workerHydrations.get(address);
     if (!hydration) {
       hydration = (async () => {
         const totals = await this.clientStatisticsService.getTotalSharesForWorkers(
           address,
         );
-        const entries = new Map<string, TotalsEntry>();
-        for (const total of totals) {
-          entries.set(total.clientName, { baseline: total.total, delta: 0 });
+        let map = this.workerTotals.get(address);
+        if (!map) {
+          map = new Map();
+          this.workerTotals.set(address, map);
         }
-        this.workerTotals.set(address, entries);
+        for (const total of totals) {
+          const entry = map.get(total.clientName);
+          if (entry) {
+            entry.baseline = Math.max(entry.baseline, total.total);
+          } else {
+            map.set(total.clientName, { baseline: total.total, delta: 0 });
+          }
+        }
+        this.fullyHydratedAddresses.add(address);
       })();
       this.workerHydrations.set(address, hydration);
     }
-    await hydration;
+
+    try {
+      await hydration;
+    } finally {
+      this.workerHydrations.delete(address);
+    }
+
+    if (!this.workerTotals.has(address)) {
+      this.workerTotals.set(address, new Map());
+    }
   }
 }

--- a/src/services/stratum-v1.service.spec.ts
+++ b/src/services/stratum-v1.service.spec.ts
@@ -35,6 +35,7 @@ describe('StratumV1Service.onModuleInit', () => {
       {} as any,
       {} as any,
       {} as any,
+      {} as any,
       {} as unknown as ShareTotalsCacheService,
     );
   }

--- a/src/services/stratum-v1.service.spec.ts
+++ b/src/services/stratum-v1.service.spec.ts
@@ -1,6 +1,7 @@
 jest.mock('node-telegram-bot-api', () => jest.fn());
 
 import { StratumV1Service } from './stratum-v1.service';
+import { ShareTotalsCacheService } from './share-totals-cache.service';
 
 describe('StratumV1Service.onModuleInit', () => {
   let clientService: { deleteAll: jest.Mock };
@@ -34,6 +35,7 @@ describe('StratumV1Service.onModuleInit', () => {
       {} as any,
       {} as any,
       {} as any,
+      {} as unknown as ShareTotalsCacheService,
     );
   }
 

--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -16,6 +16,7 @@ import { PoolRejectedStatisticsService } from '../ORM/pool-rejected-statistics/p
 import { ClientRejectedStatisticsService } from '../ORM/client-rejected-statistics/client-rejected-statistics.service';
 import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 import { ShareTotalsCacheService } from './share-totals-cache.service';
+import { AddressSettingsCacheService } from './address-settings-cache.service';
 
 @Injectable()
 export class StratumV1Service implements OnModuleInit {
@@ -30,6 +31,7 @@ export class StratumV1Service implements OnModuleInit {
     private readonly configService: ConfigService,
     private readonly stratumV1JobsService: StratumV1JobsService,
     private readonly addressSettingsService: AddressSettingsService,
+    private readonly addressSettingsCacheService: AddressSettingsCacheService,
     private readonly poolShareStatisticsService: PoolShareStatisticsService,
     private readonly poolRejectedStatisticsService: PoolRejectedStatisticsService,
     private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
@@ -105,6 +107,7 @@ export class StratumV1Service implements OnModuleInit {
         this.blocksService,
         this.configService,
         this.addressSettingsService,
+        this.addressSettingsCacheService,
         this.poolShareStatisticsService,
         this.poolRejectedStatisticsService,
         this.clientRejectedStatisticsService,

--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -15,6 +15,7 @@ import { PoolShareStatisticsService } from '../ORM/pool-share-statistics/pool-sh
 import { PoolRejectedStatisticsService } from '../ORM/pool-rejected-statistics/pool-rejected-statistics.service';
 import { ClientRejectedStatisticsService } from '../ORM/client-rejected-statistics/client-rejected-statistics.service';
 import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
+import { ShareTotalsCacheService } from './share-totals-cache.service';
 
 @Injectable()
 export class StratumV1Service implements OnModuleInit {
@@ -34,6 +35,7 @@ export class StratumV1Service implements OnModuleInit {
     private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
     private readonly externalSharesService: ExternalSharesService,
     private readonly clientDifficultyStatisticsService: ClientDifficultyStatisticsService,
+    private readonly shareTotalsCacheService: ShareTotalsCacheService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -108,6 +110,7 @@ export class StratumV1Service implements OnModuleInit {
         this.clientRejectedStatisticsService,
         this.externalSharesService,
         this.clientDifficultyStatisticsService,
+        this.shareTotalsCacheService,
         this,
         initialDifficulty,
         allowSuggestedDifficulty,


### PR DESCRIPTION
## Summary
- replace the manual lookup/update flow in client difficulty statistics with a single upsert that preserves the highest difficulty and refreshes the timestamp
- add unit coverage for both insert and conflict-update code paths to guard the new behaviour
