### PR TITLE
Make anomalous diff detection configurable

### DIFF
--- a/full-setup/blitzpool-example.env
+++ b/full-setup/blitzpool-example.env
@@ -17,6 +17,8 @@ STRATUM_HIGH_DIFF_START_DIFFICULTY=1000000
 #block-template interval
 BLOCK_TEMPLATE_INTERVAL=30000
 JOB_RETENTION_MS=90000
+# Toggle anomalous diff detection for rejected shares
+ANOMALOUS_DIFF_DETECTION_ENABLED=true
 # Desired number of shares per minute per worker (default: 6)
 TARGET_SHARES_PER_MINUTE=6
 # Interval for checking and adjusting miner difficulty (ms)

--- a/full-setup/blitzpool-postgres.env
+++ b/full-setup/blitzpool-postgres.env
@@ -21,6 +21,8 @@ STRATUM_HIGH_DIFF_START_DIFFICULTY=1000000
 #block-template interval
 BLOCK_TEMPLATE_INTERVAL=30000
 JOB_RETENTION_MS=90000
+# Toggle anomalous diff detection for rejected shares
+ANOMALOUS_DIFF_DETECTION_ENABLED=true
 # Desired number of shares per minute per worker (default: 6)
 TARGET_SHARES_PER_MINUTE=6
 # Interval for checking and adjusting miner difficulty (ms)

--- a/src/ORM/pool-rejected-statistics/pool-rejected-statistics.module.ts
+++ b/src/ORM/pool-rejected-statistics/pool-rejected-statistics.module.ts
@@ -1,13 +1,18 @@
 import { Global, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
+import { ConfigModule } from '@nestjs/config';
 
 import { PoolRejectedStatisticsEntity } from './pool-rejected-statistics.entity';
 import { PoolRejectedStatisticsService } from './pool-rejected-statistics.service';
 
 @Global()
 @Module({
-  imports: [TypeOrmModule.forFeature([PoolRejectedStatisticsEntity]), ScheduleModule],
+  imports: [
+    TypeOrmModule.forFeature([PoolRejectedStatisticsEntity]),
+    ScheduleModule,
+    ConfigModule,
+  ],
   providers: [PoolRejectedStatisticsService],
   exports: [TypeOrmModule, ScheduleModule, PoolRejectedStatisticsService],
 })

--- a/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
+++ b/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
@@ -3,6 +3,7 @@ import { Interval } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, MoreThan } from 'typeorm';
 import { Mutex } from 'async-mutex';
+import { ConfigService } from '@nestjs/config';
 
 import { PoolRejectedStatisticsEntity } from './pool-rejected-statistics.entity';
 
@@ -11,13 +12,23 @@ export class PoolRejectedStatisticsService {
   constructor(
     @InjectRepository(PoolRejectedStatisticsEntity)
     private poolRejectedStatisticsRepository: Repository<PoolRejectedStatisticsEntity>,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    const configValue = this.configService.get<string>(
+      'ANOMALOUS_DIFF_DETECTION_ENABLED',
+      'true',
+    );
+    this.anomalousDiffDetectionEnabled = !['false', '0', 'off', 'no'].includes(
+      configValue?.toString().toLowerCase() ?? 'true',
+    );
+  }
 
   private mutex = new Mutex();
   private currentTimeSlot: number = null;
   private lastSave: number = null;
   private counts: Map<string, number> = new Map();
   private recentDiffs: Map<string, number[]> = new Map();
+  private readonly anomalousDiffDetectionEnabled: boolean;
   private static readonly buckets = [
     { label: '<10', lower: 0, upper: 10 },
     { label: '10-1k', lower: 10, upper: 1000 },
@@ -97,6 +108,7 @@ export class PoolRejectedStatisticsService {
         this.lastSave = now;
       }
 
+      if (this.anomalousDiffDetectionEnabled) {
         const bucket = this.getBucket(diff, reason);
         const key = `${reason}:${bucket}`;
         let history = this.recentDiffs.get(key) || [];
@@ -108,7 +120,9 @@ export class PoolRejectedStatisticsService {
               history.shift();
             }
             this.recentDiffs.set(key, history);
-            console.warn(`Anomalous diff ${diff} for reason ${reason} (avg ${avg})`);
+            console.warn(
+              `Anomalous diff ${diff} for reason ${reason} (avg ${avg})`,
+            );
             return false;
           }
         }
@@ -118,6 +132,7 @@ export class PoolRejectedStatisticsService {
           history.shift();
         }
         this.recentDiffs.set(key, history);
+      }
 
       const current = this.counts.get(reason) || 0;
       this.counts.set(reason, current + diff);


### PR DESCRIPTION
## Summary
- inject ConfigService into the pool rejected statistics service and honour a new ANOMALOUS_DIFF_DETECTION_ENABLED flag
- gate anomalous diff handling logic behind the new toggle and document it in the full-setup environment files