### PR TITLE
Remove session counts from pool worker stats endpoint

### DIFF
--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -425,7 +425,6 @@ export class ClientStatisticsService {
       time: number;
       addresses: number;
       workers: number;
-      sessions: number;
     }>
   > {
     const query = this.clientStatisticsRepository
@@ -435,10 +434,6 @@ export class ClientStatisticsService {
       .addSelect(
         "COUNT(DISTINCT stat.address || '-' || stat.clientName)",
         'workers',
-      )
-      .addSelect(
-        "COUNT(DISTINCT stat.address || '-' || stat.clientName || '-' || stat.sessionId)",
-        'sessions',
       )
       .where('stat.time > :since', { since: time })
       .andWhere("stat.sessionId != 'AGG'")
@@ -451,7 +446,6 @@ export class ClientStatisticsService {
       time: Number(r.time),
       addresses: Number(r.addresses),
       workers: Number(r.workers),
-      sessions: Number(r.sessions),
     }));
   }
 

--- a/src/ORM/client/client.service.ts
+++ b/src/ORM/client/client.service.ts
@@ -141,19 +141,17 @@ export class ClientService {
         return await this.clientRepository.count();
     }
 
-    public async getActiveWorkerCounts(): Promise<{ addresses: number; workers: number; sessions: number }> {
+    public async getActiveWorkerCounts(): Promise<{ addresses: number; workers: number }> {
         const result = await this.clientRepository
             .createQueryBuilder('client')
             .select('COUNT(DISTINCT client.address)', 'addresses')
             .addSelect("COUNT(DISTINCT client.address || '-' || client.clientName)", 'workers')
-            .addSelect('COUNT(*)', 'sessions')
             .where('client.deletedAt IS NULL')
-            .getRawOne<{ addresses: string; workers: string; sessions: string }>();
+            .getRawOne<{ addresses: string; workers: string }>();
 
         return {
             addresses: Number(result?.addresses ?? 0),
             workers: Number(result?.workers ?? 0),
-            sessions: Number(result?.sessions ?? 0),
         };
     }
 

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -374,15 +374,11 @@ export class AppController {
     const entries = await this.clientStatisticsService.getActiveCountsSince(
       sinceTime,
     );
-    const slotMap = new Map<
-      number,
-      { addresses: number; workers: number; sessions: number }
-    >();
+    const slotMap = new Map<number, { addresses: number; workers: number }>();
     for (const entry of entries) {
       slotMap.set(entry.time, {
         addresses: entry.addresses,
         workers: entry.workers,
-        sessions: entry.sessions,
       });
     }
 
@@ -391,13 +387,12 @@ export class AppController {
     const endSlot = Math.floor(now / coeff) * coeff;
     const slotData: {
       time: string;
-      counts: { addresses: number; workers: number; sessions: number };
+      counts: { addresses: number; workers: number };
     }[] = [];
     for (let t = startSlot; t <= endSlot; t += coeff) {
       const counts = slotMap.get(t) || {
         addresses: 0,
         workers: 0,
-        sessions: 0,
       };
       slotData.push({
         time: new Date(t).toISOString(),


### PR DESCRIPTION
## Summary
- stop including session counts in the /api/info/workers response
- simplify worker statistics queries by removing unused session aggregations

## Testing
- npm run build *(fails: nest command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_690685e872cc832e9e60c315b3951c1b