### PR TITLE
Sync NTFY service with Telegram service features

### DIFF
--- a/src/ORM/telegram-subscriptions/telegram-subscriptions.service.ts
+++ b/src/ORM/telegram-subscriptions/telegram-subscriptions.service.ts
@@ -62,6 +62,13 @@ export class TelegramSubscriptionsService {
         );
     }
 
+    public async updateDeviceNotificationsByAddress(address: string, enabled: boolean): Promise<void> {
+        await this.telegramSubscriptions.update(
+            { address },
+            { deviceNotificationsEnabled: enabled }
+        );
+    }
+
     public async updateHourlyNotifications(
         chatId: number,
         enabled: boolean,
@@ -70,6 +77,21 @@ export class TelegramSubscriptionsService {
     ): Promise<void> {
         await this.telegramSubscriptions.update(
             { telegramChatId: chatId },
+            {
+                hourlyStatsEnabled: enabled && showStats,
+                hourlyWorkersEnabled: enabled && showWorkers
+            }
+        );
+    }
+
+    public async updateHourlyNotificationsByAddress(
+        address: string,
+        enabled: boolean,
+        showStats: boolean,
+        showWorkers: boolean
+    ): Promise<void> {
+        await this.telegramSubscriptions.update(
+            { address },
             {
                 hourlyStatsEnabled: enabled && showStats,
                 hourlyWorkersEnabled: enabled && showWorkers

--- a/src/services/ntfy.service.ts
+++ b/src/services/ntfy.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import axios from 'axios';
 import { EventSource } from 'eventsource';
@@ -8,7 +9,8 @@ import { TelegramSubscriptionsService } from '../ORM/telegram-subscriptions/tele
 import { ClientService } from '../ORM/client/client.service';
 import { AddressSettingsService } from '../ORM/address-settings/address-settings.service';
 import { ClientStatisticsService } from '../ORM/client-statistics/client-statistics.service';
-import { buildStatsMessage } from './common-command-handlers';
+import { StratumV1Service } from './stratum-v1.service';
+import { buildStatsMessage, buildWorkersOverviewMessage } from './common-command-handlers';
 
 @Injectable()
 export class NtfyService implements OnModuleInit {
@@ -23,6 +25,8 @@ export class NtfyService implements OnModuleInit {
   private eventSource?: EventSource;
   private retryTimer?: NodeJS.Timeout;
   private readonly shouldInitialize: boolean;
+  private chatLanguages: Map<string, 'de' | 'en'> = new Map();
+  private readonly deviceNotificationFormatters: Record<'de' | 'en', Intl.DateTimeFormat>;
 
   constructor(
     private readonly configService: ConfigService,
@@ -30,6 +34,8 @@ export class NtfyService implements OnModuleInit {
     private readonly clientService: ClientService,
     private readonly addressSettingsService: AddressSettingsService,
     private readonly clientStatisticsService: ClientStatisticsService,
+    @Inject(forwardRef(() => StratumV1Service))
+    private readonly stratumV1Service: StratumV1Service,
   ) {
     const pm2InstanceId =
       process.env.NODE_APP_INSTANCE ??
@@ -50,6 +56,30 @@ export class NtfyService implements OnModuleInit {
     }
 
     this.shouldInitialize = true;
+
+    // Initialize timezone formatters
+    const timezonePreference = this.configService.get<string>('NTFY_TIMEZONE')?.trim();
+    const fallbackTimeZone = 'Europe/Zurich';
+    let effectiveTimeZone = timezonePreference && timezonePreference.length > 0
+      ? timezonePreference
+      : fallbackTimeZone;
+
+    const createFormatter = (locale: string, timeZone: string) =>
+      new Intl.DateTimeFormat(locale, { dateStyle: 'short', timeStyle: 'short', timeZone });
+
+    try {
+      this.deviceNotificationFormatters = {
+        de: createFormatter('de-DE', effectiveTimeZone),
+        en: createFormatter('en-US', effectiveTimeZone),
+      };
+    } catch {
+      effectiveTimeZone = 'UTC';
+      this.deviceNotificationFormatters = {
+        de: createFormatter('de-DE', effectiveTimeZone),
+        en: createFormatter('en-US', effectiveTimeZone),
+      };
+    }
+
     this.serverUrl = this.configService.get<string>('NTFY_SERVER_URL');
     this.accessToken = this.configService.get<string>('NTFY_ACCESS_TOKEN');
     this.topicPrefix = this.configService.get<string>('NTFY_TOPIC_PREFIX');
@@ -57,6 +87,46 @@ export class NtfyService implements OnModuleInit {
       this.configService
         .get<string>('NTFY_DIFF_NOTIFICATIONS')
         ?.toLowerCase() === 'true' || false;
+  }
+
+  private formatAddress(address: string): string {
+    return `${address.slice(0, 4)}...${address.slice(-5)}`;
+  }
+
+  private getLanguage(origin: string): 'de' | 'en' {
+    return this.chatLanguages.get(origin) ?? 'de';
+  }
+
+  private async reply(origin: string, messages: { de: string; en: string }) {
+    const lang = this.getLanguage(origin);
+    await this.publish(origin, messages[lang]);
+  }
+
+  private async resolveAddressForChat(origin: string, addressParam?: string): Promise<string | null> {
+    let raw = addressParam?.trim();
+
+    if (raw) {
+      if (!validate(raw)) {
+        await this.reply(origin, {
+          de: 'Ungültige Adresse.',
+          en: 'Invalid address.'
+        });
+        return null;
+      }
+      return raw;
+    }
+
+    // For NTFY, the origin IS the address (topic-based)
+    // We don't have a subscription database like Telegram
+    if (validate(origin)) {
+      return origin;
+    }
+
+    await this.reply(origin, {
+      de: 'Bitte gib eine Adresse an.',
+      en: 'Please provide an address.'
+    });
+    return null;
   }
 
   async onModuleInit(): Promise<void> {
@@ -177,35 +247,76 @@ export class NtfyService implements OnModuleInit {
   }
 
   private async handleCommand(origin: string, text: string) {
-    if (text.startsWith('/subscribe')) {
+    if (text.startsWith('/deutsch')) {
+      this.chatLanguages.set(origin, 'de');
+      await this.reply(origin, {
+        de: 'Sprache auf Deutsch gestellt.',
+        en: 'Language switched to German.'
+      });
+    } else if (text.startsWith('/english')) {
+      this.chatLanguages.set(origin, 'en');
+      await this.reply(origin, {
+        de: 'Sprache auf Englisch gestellt.',
+        en: 'Language switched to English.'
+      });
+    } else if (text.startsWith('/subscribe')) {
       const raw = text.replace('/subscribe', '').trim();
       if (!raw) {
-        await this.publish(origin, 'Please provide an address.');
+        await this.reply(origin, {
+          de: 'Bitte gib eine Adresse an.',
+          en: 'Please provide an address.'
+        });
         return;
       }
       const address = raw;
       if (!validate(address)) {
-        await this.publish(origin, 'Invalid address.');
+        await this.reply(origin, {
+          de: 'Ungültige Adresse.',
+          en: 'Invalid address.'
+        });
         return;
       }
       this.subscribe(address);
-      await this.publish(origin, `Subscribed to ${address}.`);
+      await this.reply(origin, {
+        de: `Benachrichtigung für ${address} aktiviert.`,
+        en: `Subscribed to ${address}.`
+      });
     } else if (text.startsWith('/unsubscribe')) {
       const raw = text.replace('/unsubscribe', '').trim();
       const target = raw || origin;
       this.unsubscribe(target);
-      await this.publish(origin, `Removed ${target}.`);
+      await this.reply(origin, {
+        de: `${target} entfernt.`,
+        en: `Removed ${target}.`
+      });
     } else if (text.startsWith('/remove')) {
       const raw = text.replace('/remove', '').trim();
-      const target = raw || origin;
+      if (!raw) {
+        await this.reply(origin, {
+          de: 'Bitte gib eine Adresse an.',
+          en: 'Please provide an address.'
+        });
+        return;
+      }
+      const target = raw;
+      if (!validate(target)) {
+        await this.reply(origin, {
+          de: 'Ungültige Adresse.',
+          en: 'Invalid address.'
+        });
+        return;
+      }
       this.unsubscribe(target);
-      await this.publish(origin, `Removed ${target}.`);
+      await this.reply(origin, {
+        de: 'Adresse entfernt.',
+        en: 'Address removed.'
+      });
     } else if (text.startsWith('/show_addresses')) {
       const list = Array.from(this.subscribed);
-      await this.publish(
-        origin,
-        list.length ? list.join('\n') : 'No addresses subscribed.',
-      );
+      await this.reply(origin, {
+        de: list.length ? `Abonnierte Adressen:\n${list.join('\n')}` : 'Keine Adressen abonniert.',
+        en: list.length ? `Subscribed addresses:\n${list.join('\n')}` : 'No addresses subscribed.'
+      });
     } else if (text.startsWith('/stats')) {
       const messages = await buildStatsMessage(
         origin,
@@ -215,9 +326,54 @@ export class NtfyService implements OnModuleInit {
         this.numberSuffix,
       );
       if (!messages) {
-        await this.publish(origin, 'No active workers found for this address.');
+        await this.reply(origin, {
+          de: 'Keine aktiven Worker für diese Adresse gefunden.',
+          en: 'No active workers found for this address.'
+        });
       } else {
-        await this.publish(origin, messages.en);
+        await this.reply(origin, messages);
+      }
+    } else if (text.startsWith('/show_workers')) {
+      const raw = text.replace('/show_workers', '').trim();
+      const address = raw || origin;
+
+      if (!validate(address)) {
+        await this.reply(origin, {
+          de: 'Ungültige Adresse.',
+          en: 'Invalid address.'
+        });
+        return;
+      }
+
+      const apiPort = process.env.API_PORT ?? '3334';
+      const url = `http://localhost:${apiPort}/api/client/${encodeURIComponent(address)}`;
+
+      try {
+        const res = await fetch(url);
+        if (!res.ok) {
+          await this.reply(origin, {
+            de: 'Konnte Worker-Daten nicht abrufen.',
+            en: 'Could not fetch worker data.'
+          });
+          return;
+        }
+        const payload = await res.json();
+        if (!payload || !Array.isArray(payload.workers) || payload.workers.length === 0) {
+          await this.reply(origin, {
+            de: 'Keine Worker für diese Adresse gefunden.',
+            en: 'No workers found for this address.'
+          });
+          return;
+        }
+
+        const messages = buildWorkersOverviewMessage(payload, this.numberSuffix);
+        await this.reply(origin, messages);
+      } catch (err) {
+        console.error('NTFY /show_workers error:', err);
+        await this.reply(origin, {
+          de: 'Fehler beim Abrufen der Worker-Daten.',
+          en: 'Failed to retrieve worker data.'
+        });
       }
     } else if (text.startsWith('/poolhashrate')) {
       try {
@@ -225,9 +381,15 @@ export class NtfyService implements OnModuleInit {
         const res = await fetch(`http://localhost:${apiPort}/api/pool`);
         const data = await res.json();
         const hashrateTH = (data.totalHashRate / 1e12).toFixed(2);
-        await this.publish(origin, `Current pool hashrate: ${hashrateTH} TH/s`);
+        await this.reply(origin, {
+          de: `Aktuelle Pool-Hashrate: ${hashrateTH} TH/s`,
+          en: `Current pool hashrate: ${hashrateTH} TH/s`
+        });
       } catch (err) {
-        await this.publish(origin, 'Could not fetch pool hashrate.');
+        await this.reply(origin, {
+          de: 'Konnte die Pool-Hashrate nicht abrufen.',
+          en: 'Could not fetch pool hashrate.'
+        });
         console.error('NTFY /poolhashrate error', err);
       }
     } else if (text.startsWith('/difficulty')) {
@@ -237,9 +399,15 @@ export class NtfyService implements OnModuleInit {
         );
         const json = await res.json();
         const difficulty = (json.currentDifficulty / 1e12).toFixed(2);
-        await this.publish(origin, `Current difficulty: ${difficulty} T`);
+        await this.reply(origin, {
+          de: `Aktuelle Difficulty: ${difficulty} T`,
+          en: `Current difficulty: ${difficulty} T`
+        });
       } catch (err) {
-        await this.publish(origin, 'Could not fetch difficulty.');
+        await this.reply(origin, {
+          de: 'Konnte die Difficulty nicht abrufen.',
+          en: 'Could not fetch difficulty.'
+        });
         console.error('NTFY /difficulty error', err);
       }
     } else if (text.startsWith('/next_difficulty')) {
@@ -254,44 +422,186 @@ export class NtfyService implements OnModuleInit {
           data.estimatedRetargetDate,
         ).toLocaleString('de-CH');
         const changeText = change >= 0 ? `📈 +${change}%` : `📉 ${change}%`;
-        await this.publish(
-          origin,
-          `📊 Next difficulty adjustment:\n• Progress: ${progress}%\n• Estimated: ${estimatedDate}\n• Expected change: ${changeText}`,
-        );
+        await this.reply(origin, {
+          de: `📊 Nächste Difficulty-Anpassung:\n\n• Fortschritt: ${progress}%\n• Geschätzt: ${estimatedDate}\n• Erwartete Änderung: ${changeText}`,
+          en: `📊 Next difficulty adjustment:\n\n• Progress: ${progress}%\n• Estimated: ${estimatedDate}\n• Expected change: ${changeText}`
+        });
       } catch (err) {
-        await this.publish(
-          origin,
-          'Could not fetch next difficulty adjustment.',
-        );
+        await this.reply(origin, {
+          de: 'Konnte die nächste Difficulty-Anpassung nicht abrufen.',
+          en: 'Could not fetch next difficulty adjustment.'
+        });
         console.error('NTFY /next_difficulty error', err);
       }
     } else if (text.startsWith('/subscribe_bestdiff')) {
       const match = text.match(/\/subscribe_bestdiff\s+(on|off)/i);
       const value = match?.[1]?.toLowerCase();
       if (!value) {
-        await this.publish(origin, "Please provide 'on' or 'off'.");
+        await this.reply(origin, {
+          de: "Bitte gib 'on' oder 'off' an.",
+          en: "Please provide 'on' or 'off'."
+        });
         return;
       }
       const enable = value === 'on';
       this.bestDiffOptIn.set(origin, enable);
-      await this.publish(
-        origin,
-        `Best difficulty notifications ${enable ? 'enabled' : 'disabled'}.`,
-      );
+      await this.reply(origin, {
+        de: `Best Difficulty Benachrichtigungen ${enable ? 'aktiviert' : 'deaktiviert'}.`,
+        en: `Best difficulty notifications ${enable ? 'enabled' : 'disabled'}.`
+      });
+    } else if (text.startsWith('/bestdiff_reset')) {
+      const raw = text.replace('/bestdiff_reset', '').trim();
+      const address = await this.resolveAddressForChat(origin, raw);
+      if (!address) {
+        return;
+      }
+
+      try {
+        await this.addressSettingsService.updateBestDifficulty(address, 0, null);
+        this.bestDiffCache.delete(address);
+        await this.stratumV1Service.resetBestDifficultyForAddress(address);
+        await this.reply(origin, {
+          de: `Best Difficulty für ${this.formatAddress(address)} zurückgesetzt.`,
+          en: `Best difficulty for ${this.formatAddress(address)} reset.`
+        });
+      } catch (error) {
+        console.error('NTFY /bestdiff_reset error:', error);
+        await this.reply(origin, {
+          de: 'Fehler beim Zurücksetzen der Best Difficulty. Bitte später erneut versuchen.',
+          en: 'Failed to reset best difficulty. Please try again later.'
+        });
+      }
+    } else if (text.startsWith('/device_notifications')) {
+      const match = text.match(/\/device_notifications\s+(on|off)/i);
+      const action = match?.[1]?.toLowerCase();
+
+      if (!action || !['on', 'off'].includes(action)) {
+        await this.reply(origin, {
+          de: "Bitte gib 'on' oder 'off' an.",
+          en: "Please provide 'on' or 'off'."
+        });
+        return;
+      }
+
+      const enabled = action === 'on';
+
+      try {
+        // For NTFY we need to update via the subscription service
+        // Note: This will update for all telegram subscriptions with this address
+        await this.telegramSubscriptionsService.updateDeviceNotificationsByAddress(origin, enabled);
+        await this.reply(origin, {
+          de: `Geräte-Benachrichtigungen ${enabled ? 'aktiviert' : 'deaktiviert'}.`,
+          en: `Device notifications ${enabled ? 'enabled' : 'disabled'}.`
+        });
+      } catch (error) {
+        console.error('NTFY /device_notifications error:', error);
+        await this.reply(origin, {
+          de: 'Fehler beim Setzen der Einstellung. Bitte später erneut versuchen.',
+          en: 'Failed to update setting. Please try again later.'
+        });
+      }
+    } else if (text.startsWith('/send_hourly')) {
+      const match = text.match(/^\/send_hourly\s+(on|off)(?:\s+(show_workers|show_stats))?(?:\s+(show_workers|show_stats))?/i);
+      const action = match?.[1]?.toLowerCase();
+      const arg1 = match?.[2]?.toLowerCase();
+      const arg2 = match?.[3]?.toLowerCase();
+
+      if (!action || !['on', 'off'].includes(action)) {
+        await this.reply(origin, {
+          de: "Bitte gib 'on' oder 'off' an.\nVerwendung: /send_hourly on show_workers show_stats",
+          en: "Please provide 'on' or 'off'.\nUsage: /send_hourly on show_workers show_stats"
+        });
+        return;
+      }
+
+      const enabled = action === 'on';
+
+      if (enabled) {
+        const features = [arg1, arg2].filter(f => f);
+        const validFeatures = new Set(['show_workers', 'show_stats']);
+        const hasValidFeature = features.some(f => validFeatures.has(f));
+
+        if (features.length === 0 || !hasValidFeature) {
+          await this.reply(origin, {
+            de: "Bitte gib mindestens 'show_workers' oder 'show_stats' an.\nVerwendung: /send_hourly on show_workers show_stats",
+            en: "Please provide at least 'show_workers' or 'show_stats'.\nUsage: /send_hourly on show_workers show_stats"
+          });
+          return;
+        }
+
+        const showWorkers = features.includes('show_workers');
+        const showStats = features.includes('show_stats');
+
+        try {
+          // For NTFY we need to update via subscription service for this address
+          await this.telegramSubscriptionsService.updateHourlyNotificationsByAddress(origin, true, showStats, showWorkers);
+          const featureList = [showWorkers ? 'show_workers' : null, showStats ? 'show_stats' : null].filter(Boolean).join(' + ');
+          await this.reply(origin, {
+            de: `Stündliche Benachrichtigungen aktiviert für: ${featureList}`,
+            en: `Hourly notifications enabled for: ${featureList}`
+          });
+        } catch (error) {
+          console.error('NTFY /send_hourly error:', error);
+          await this.reply(origin, {
+            de: 'Fehler beim Aktivieren der stündlichen Benachrichtigungen. Bitte später erneut versuchen.',
+            en: 'Failed to enable hourly notifications. Please try again later.'
+          });
+        }
+      } else {
+        try {
+          await this.telegramSubscriptionsService.updateHourlyNotificationsByAddress(origin, false, false, false);
+          await this.reply(origin, {
+            de: 'Stündliche Benachrichtigungen deaktiviert.',
+            en: 'Hourly notifications disabled.'
+          });
+        } catch (error) {
+          console.error('NTFY /send_hourly error:', error);
+          await this.reply(origin, {
+            de: 'Fehler beim Deaktivieren der stündlichen Benachrichtigungen. Bitte später erneut versuchen.',
+            en: 'Failed to disable hourly notifications. Please try again later.'
+          });
+        }
+      }
     } else if (text.startsWith('/start')) {
-      await this.publish(
-        origin,
-        'Welcome to the BlitzPool notifier! Available commands:\n' +
-          '/subscribe <address> - follow another address\n' +
-          '/unsubscribe <address> - stop following an address\n' +
-          '/stats - show worker stats\n' +
-          '/poolhashrate - show current pool hashrate\n' +
-          '/difficulty - show current network difficulty\n' +
-          '/next_difficulty - show expected difficulty change\n' +
-          '/show_addresses - list subscribed addresses',
-      );
+      await this.reply(origin, {
+        de: 'Willkommen beim BlitzPool Benachrichtigungsdienst! Verfügbare Befehle:\n\n' +
+          '/subscribe <adresse> - Weitere Adresse folgen\n' +
+          '/unsubscribe <adresse> - Adresse nicht mehr folgen\n' +
+          '/remove <adresse> - Adresse entfernen\n' +
+          '/stats - Worker-Statistiken anzeigen\n' +
+          '/show_workers - Worker-Übersicht anzeigen\n' +
+          '/poolhashrate - Aktuelle Pool-Hashrate anzeigen\n' +
+          '/difficulty - Aktuelle Netzwerk-Difficulty anzeigen\n' +
+          '/next_difficulty - Erwartete Difficulty-Änderung anzeigen\n' +
+          '/subscribe_bestdiff on|off - Best-Diff Benachrichtigungen\n' +
+          '/bestdiff_reset - Best-Diff zurücksetzen\n' +
+          '/device_notifications on|off - Geräte-Benachrichtigungen\n' +
+          '/send_hourly on|off - Stündliche Updates\n' +
+          '/show_addresses - Abonnierte Adressen auflisten\n' +
+          '/deutsch - Auf Deutsch umstellen\n' +
+          '/english - Switch to English',
+        en: 'Welcome to the BlitzPool notifier! Available commands:\n\n' +
+          '/subscribe <address> - Follow another address\n' +
+          '/unsubscribe <address> - Stop following an address\n' +
+          '/remove <address> - Remove address\n' +
+          '/stats - Show worker stats\n' +
+          '/show_workers - Show worker overview\n' +
+          '/poolhashrate - Show current pool hashrate\n' +
+          '/difficulty - Show current network difficulty\n' +
+          '/next_difficulty - Show expected difficulty change\n' +
+          '/subscribe_bestdiff on|off - Best-diff notifications\n' +
+          '/bestdiff_reset - Reset best-diff counter\n' +
+          '/device_notifications on|off - Device notifications\n' +
+          '/send_hourly on|off - Hourly updates\n' +
+          '/show_addresses - List subscribed addresses\n' +
+          '/deutsch - Auf Deutsch umstellen\n' +
+          '/english - Switch to English'
+      });
     } else {
-      await this.publish(origin, 'Unknown command.');
+      await this.reply(origin, {
+        de: 'Unbekannter Befehl. Nutze /start für eine Liste der Befehle.',
+        en: 'Unknown command. Use /start for a list of commands.'
+      });
     }
   }
 
@@ -344,13 +654,105 @@ export class NtfyService implements OnModuleInit {
     if (submissionDifficulty > persistedBest) {
       this.bestDiffCache.set(address, submissionDifficulty);
       if (this.bestDiffOptIn.get(address) !== false) {
-        await this.publish(
-          address,
-          `\uD83C\uDFC6 New best difficulty!\nValue: ${this.numberSuffix.to(
-            submissionDifficulty,
-          )}`,
-        );
+        const lang = this.getLanguage(address);
+        const message = lang === 'de'
+          ? `🏆 Neue beste Difficulty!\nWert: ${this.numberSuffix.to(submissionDifficulty)}`
+          : `🏆 New best difficulty!\nValue: ${this.numberSuffix.to(submissionDifficulty)}`;
+        await this.publish(address, message);
       }
+    }
+  }
+
+  public async notifyDeviceStatusChange(params: {
+    address: string;
+    workerName?: string;
+    userAgent?: string;
+    sessionId: string;
+    isOnline: boolean;
+    timestamp: Date;
+    isReturning?: boolean;
+  }): Promise<void> {
+    if (!this.shouldInitialize || !this.serverUrl) return;
+
+    const { address, workerName, userAgent, isOnline, timestamp, isReturning } = params;
+
+    const eventTime = timestamp instanceof Date ? timestamp : new Date(timestamp);
+    const lang = this.getLanguage(address);
+    const timeFormatted = this.deviceNotificationFormatters[lang].format(eventTime);
+    const trimmedAgent = userAgent?.trim();
+    const trimmedWorker = workerName?.trim();
+
+    const userAgentDe = trimmedAgent && trimmedAgent.length > 0 ? trimmedAgent : 'unbekannt';
+    const userAgentEn = trimmedAgent && trimmedAgent.length > 0 ? trimmedAgent : 'unknown';
+    const workerDe = trimmedWorker && trimmedWorker.length > 0 ? trimmedWorker : 'unbekannt';
+    const workerEn = trimmedWorker && trimmedWorker.length > 0 ? trimmedWorker : 'unknown';
+
+    const messageDe = isOnline
+      ? `📶 Gerät ${userAgentDe} (Worker ${workerDe}) ist seit ${timeFormatted} ${isReturning ? 'wieder ' : ''}online.`
+      : `📴 Gerät ${userAgentDe} (Worker ${workerDe}) ist seit ${timeFormatted} offline.`;
+    const messageEn = isOnline
+      ? `📶 Device with ${userAgentEn} (worker ${workerEn}) ${isReturning ? 'back ' : ''}online at ${timeFormatted}.`
+      : `📴 Device with ${userAgentEn} (worker ${workerEn}) went offline at ${timeFormatted}.`;
+
+    const message = lang === 'de' ? messageDe : messageEn;
+    await this.publish(address, message);
+  }
+
+  @Interval(60 * 60 * 1000) // Run every hour
+  private async sendHourlyUpdates(): Promise<void> {
+    if (!this.shouldInitialize || !this.serverUrl) return;
+
+    try {
+      const enabledChats = await this.telegramSubscriptionsService.getHourlyEnabledChats();
+
+      for (const chat of enabledChats) {
+        try {
+          const address = chat.address;
+
+          // Send stats if enabled
+          if (chat.hourlyStatsEnabled) {
+            try {
+              const messages = await buildStatsMessage(
+                address,
+                this.clientService,
+                this.addressSettingsService,
+                this.clientStatisticsService,
+                this.numberSuffix
+              );
+              if (messages) {
+                const lang = this.getLanguage(address);
+                await this.publish(address, messages[lang]);
+              }
+            } catch (err) {
+              console.error(`NTFY: Fehler beim Senden von Stats für ${address}:`, err);
+            }
+          }
+
+          // Send workers overview if enabled
+          if (chat.hourlyWorkersEnabled) {
+            try {
+              const apiPort = process.env.API_PORT ?? '3334';
+              const url = `http://localhost:${apiPort}/api/client/${encodeURIComponent(address)}`;
+              const res = await fetch(url);
+
+              if (res.ok) {
+                const payload = await res.json();
+                if (payload && Array.isArray(payload.workers) && payload.workers.length > 0) {
+                  const messages = buildWorkersOverviewMessage(payload, this.numberSuffix);
+                  const lang = this.getLanguage(address);
+                  await this.publish(address, messages[lang]);
+                }
+              }
+            } catch (err) {
+              console.error(`NTFY: Fehler beim Senden von Workers für ${address}:`, err);
+            }
+          }
+        } catch (err) {
+          console.error(`NTFY: Fehler beim Verarbeiten von Stundlich-Updates für ${chat.address}:`, err);
+        }
+      }
+    } catch (err) {
+      console.error('NTFY: Fehler beim Ausführen der Stundlich-Benachrichtigungen:', err);
     }
   }
 }


### PR DESCRIPTION
Add comprehensive feature parity between NTFY and Telegram services:

- Add bilingual support (German/English) with language switching commands
- Add /deutsch and /english commands for language preference
- Add /bestdiff_reset command to reset best difficulty counter
- Add /device_notifications on|off command for device status alerts
- Add /show_workers command to display worker overview
- Add /send_hourly on|off command for automated hourly updates
- Add notifyDeviceStatusChange method for device online/offline notifications
- Add sendHourlyUpdates scheduled method (@Interval) for automatic stats/workers updates
- Add helper methods: formatAddress, getLanguage, reply, resolveAddressForChat
- Add timezone-aware device notification formatters
- Update all existing command messages to support bilingual responses
- Update /start help text to include all new commands
- Add updateDeviceNotificationsByAddress and updateHourlyNotificationsByAddress methods to TelegramSubscriptionsService

All commands now support both German and English with per-user language preferences.