### PR TITLE
Decouple NTFY service from Telegram service

### DIFF
--- a/src/ORM/ntfy-subscriptions/ntfy-subscriptions.entity.ts
+++ b/src/ORM/ntfy-subscriptions/ntfy-subscriptions.entity.ts
@@ -1,0 +1,29 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+import { TrackedEntity } from '../utils/TrackedEntity.entity';
+
+@Entity()
+export class NtfySubscriptionsEntity extends TrackedEntity {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Index()
+    @Column({ length: 62, type: 'varchar', unique: true })
+    address: string;
+
+    @Column({ default: 'de' })
+    language: 'de' | 'en';
+
+    @Column({ default: true })
+    bestDiffNotificationsEnabled: boolean;
+
+    @Column({ default: false })
+    deviceNotificationsEnabled: boolean;
+
+    @Column({ default: false })
+    hourlyStatsEnabled: boolean;
+
+    @Column({ default: false })
+    hourlyWorkersEnabled: boolean;
+}

--- a/src/ORM/ntfy-subscriptions/ntfy-subscriptions.module.ts
+++ b/src/ORM/ntfy-subscriptions/ntfy-subscriptions.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { NtfySubscriptionsEntity } from './ntfy-subscriptions.entity';
+import { NtfySubscriptionsService } from './ntfy-subscriptions.service';
+
+
+@Global()
+@Module({
+    imports: [TypeOrmModule.forFeature([NtfySubscriptionsEntity])],
+    providers: [NtfySubscriptionsService],
+    exports: [TypeOrmModule, NtfySubscriptionsService],
+})
+export class NtfySubscriptionsModule { }

--- a/src/ORM/ntfy-subscriptions/ntfy-subscriptions.service.ts
+++ b/src/ORM/ntfy-subscriptions/ntfy-subscriptions.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { NtfySubscriptionsEntity } from './ntfy-subscriptions.entity';
+
+
+@Injectable()
+export class NtfySubscriptionsService {
+    constructor(
+        @InjectRepository(NtfySubscriptionsEntity)
+        private ntfySubscriptions: Repository<NtfySubscriptionsEntity>
+    ) {}
+
+    async getOrCreateSubscription(address: string): Promise<NtfySubscriptionsEntity> {
+        let subscription = await this.ntfySubscriptions.findOne({ where: { address } });
+        if (!subscription) {
+            subscription = await this.ntfySubscriptions.save({
+                address,
+                language: 'de',
+                bestDiffNotificationsEnabled: true,
+                deviceNotificationsEnabled: false,
+                hourlyStatsEnabled: false,
+                hourlyWorkersEnabled: false
+            });
+        }
+        return subscription;
+    }
+
+    async updateLanguage(address: string, language: 'de' | 'en'): Promise<void> {
+        await this.getOrCreateSubscription(address);
+        await this.ntfySubscriptions.update({ address }, { language });
+    }
+
+    async updateDeviceNotifications(address: string, enabled: boolean): Promise<void> {
+        await this.getOrCreateSubscription(address);
+        await this.ntfySubscriptions.update({ address }, { deviceNotificationsEnabled: enabled });
+    }
+
+    async updateHourlyNotifications(
+        address: string,
+        enabled: boolean,
+        showStats: boolean,
+        showWorkers: boolean
+    ): Promise<void> {
+        await this.getOrCreateSubscription(address);
+        await this.ntfySubscriptions.update(
+            { address },
+            {
+                hourlyStatsEnabled: enabled && showStats,
+                hourlyWorkersEnabled: enabled && showWorkers
+            }
+        );
+    }
+
+    async getHourlyEnabledAddresses(): Promise<NtfySubscriptionsEntity[]> {
+        return await this.ntfySubscriptions
+            .createQueryBuilder('sub')
+            .where('sub.hourlyStatsEnabled = :true OR sub.hourlyWorkersEnabled = :true', { true: true })
+            .getMany();
+    }
+
+    async getLanguage(address: string): Promise<'de' | 'en'> {
+        const subscription = await this.ntfySubscriptions.findOne({ where: { address } });
+        return subscription?.language ?? 'de';
+    }
+
+    async isDeviceNotificationsEnabled(address: string): Promise<boolean> {
+        const subscription = await this.ntfySubscriptions.findOne({ where: { address } });
+        return subscription?.deviceNotificationsEnabled ?? false;
+    }
+}

--- a/src/ORM/telegram-subscriptions/telegram-subscriptions.service.ts
+++ b/src/ORM/telegram-subscriptions/telegram-subscriptions.service.ts
@@ -62,13 +62,6 @@ export class TelegramSubscriptionsService {
         );
     }
 
-    public async updateDeviceNotificationsByAddress(address: string, enabled: boolean): Promise<void> {
-        await this.telegramSubscriptions.update(
-            { address },
-            { deviceNotificationsEnabled: enabled }
-        );
-    }
-
     public async updateHourlyNotifications(
         chatId: number,
         enabled: boolean,
@@ -84,26 +77,12 @@ export class TelegramSubscriptionsService {
         );
     }
 
-    public async updateHourlyNotificationsByAddress(
-        address: string,
-        enabled: boolean,
-        showStats: boolean,
-        showWorkers: boolean
-    ): Promise<void> {
-        await this.telegramSubscriptions.update(
-            { address },
-            {
-                hourlyStatsEnabled: enabled && showStats,
-                hourlyWorkersEnabled: enabled && showWorkers
-            }
-        );
-    }
-
     public async getHourlyEnabledChats(): Promise<Array<{ telegramChatId: number; address: string; hourlyStatsEnabled: boolean; hourlyWorkersEnabled: boolean }>> {
         return await this.telegramSubscriptions
             .createQueryBuilder('sub')
             .where('sub.hourlyStatsEnabled = :true OR sub.hourlyWorkersEnabled = :true', { true: true })
             .andWhere('sub.isDefault = :true', { true: true })
+            .andWhere('sub.telegramChatId IS NOT NULL')
             .select(['sub.telegramChatId', 'sub.address', 'sub.hourlyStatsEnabled', 'sub.hourlyWorkersEnabled'])
             .getRawMany();
     }
@@ -111,6 +90,7 @@ export class TelegramSubscriptionsService {
     public async getAllAddresses(): Promise<string[]> {
         const rows = await this.telegramSubscriptions
             .createQueryBuilder('sub')
+            .where('sub.telegramChatId IS NOT NULL')
             .select('DISTINCT sub.address', 'address')
             .getRawMany();
         return rows.map(r => r.address);

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { ClientStatisticsModule } from './ORM/client-statistics/client-statistic
 import { ClientModule } from './ORM/client/client.module';
 import { RpcBlocksModule } from './ORM/rpc-block/rpc-block.module';
 import { TelegramSubscriptionsModule } from './ORM/telegram-subscriptions/telegram-subscriptions.module';
+import { NtfySubscriptionsModule } from './ORM/ntfy-subscriptions/ntfy-subscriptions.module';
 import { AppService } from './services/app.service';
 import { BitcoinRpcService } from './services/bitcoin-rpc.service';
 import { BraiinsService } from './services/braiins.service';
@@ -47,6 +48,7 @@ const ORMModules = [
     ClientModule,
     AddressSettingsModule,
     TelegramSubscriptionsModule,
+    NtfySubscriptionsModule,
     BlocksModule,
     RpcBlocksModule,
     ExternalSharesModule,

--- a/src/migrations/1732060800000-CreateNtfySubscriptions.ts
+++ b/src/migrations/1732060800000-CreateNtfySubscriptions.ts
@@ -1,0 +1,104 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateNtfySubscriptions1732060800000 implements MigrationInterface {
+    name = 'CreateNtfySubscriptions1732060800000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (queryRunner.connection.options.type !== 'postgres') {
+            return;
+        }
+
+        // 1. Create the new ntfy_subscriptions_entity table
+        await queryRunner.query(`
+            CREATE TABLE "ntfy_subscriptions_entity" (
+                "deletedAt" TIMESTAMP WITH TIME ZONE,
+                "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "id" SERIAL NOT NULL,
+                "address" character varying(62) NOT NULL,
+                "language" character varying NOT NULL DEFAULT 'de',
+                "bestDiffNotificationsEnabled" boolean NOT NULL DEFAULT true,
+                "deviceNotificationsEnabled" boolean NOT NULL DEFAULT false,
+                "hourlyStatsEnabled" boolean NOT NULL DEFAULT false,
+                "hourlyWorkersEnabled" boolean NOT NULL DEFAULT false,
+                CONSTRAINT "UQ_ntfy_subscriptions_address" UNIQUE ("address"),
+                CONSTRAINT "PK_ntfy_subscriptions_entity" PRIMARY KEY ("id")
+            )
+        `);
+
+        // 2. Create index on address
+        await queryRunner.query(`
+            CREATE INDEX "IDX_ntfy_subscriptions_address" ON "ntfy_subscriptions_entity" ("address")
+        `);
+
+        // 3. Migrate NTFY-only data (where telegramChatId IS NULL) if any exist
+        await queryRunner.query(`
+            INSERT INTO "ntfy_subscriptions_entity"
+                ("address", "language", "bestDiffNotificationsEnabled", "deviceNotificationsEnabled", "hourlyStatsEnabled", "hourlyWorkersEnabled", "createdAt", "updatedAt")
+            SELECT
+                "address",
+                'de' as "language",
+                COALESCE("bestDiffNotificationsEnabled", true) as "bestDiffNotificationsEnabled",
+                COALESCE("deviceNotificationsEnabled", false) as "deviceNotificationsEnabled",
+                COALESCE("hourlyStatsEnabled", false) as "hourlyStatsEnabled",
+                COALESCE("hourlyWorkersEnabled", false) as "hourlyWorkersEnabled",
+                COALESCE("createdAt", now()) as "createdAt",
+                COALESCE("updatedAt", now()) as "updatedAt"
+            FROM "telegram_subscriptions_entity"
+            WHERE "telegramChatId" IS NULL
+            ON CONFLICT ("address") DO NOTHING
+        `);
+
+        // 4. Delete migrated entries from telegram_subscriptions_entity
+        await queryRunner.query(`
+            DELETE FROM "telegram_subscriptions_entity"
+            WHERE "telegramChatId" IS NULL
+        `);
+
+        // 5. Make telegramChatId NOT NULL (in case it was nullable)
+        await queryRunner.query(`
+            ALTER TABLE "telegram_subscriptions_entity"
+            ALTER COLUMN "telegramChatId" SET NOT NULL
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (queryRunner.connection.options.type !== 'postgres') {
+            return;
+        }
+
+        // 1. Make telegramChatId nullable again
+        await queryRunner.query(`
+            ALTER TABLE "telegram_subscriptions_entity"
+            ALTER COLUMN "telegramChatId" DROP NOT NULL
+        `);
+
+        // 2. Migrate data back from ntfy_subscriptions_entity to telegram_subscriptions_entity
+        await queryRunner.query(`
+            INSERT INTO "telegram_subscriptions_entity"
+                ("address", "telegramChatId", "bestDiffNotificationsEnabled", "deviceNotificationsEnabled", "hourlyStatsEnabled", "hourlyWorkersEnabled", "isDefault", "createdAt", "updatedAt")
+            SELECT
+                "address",
+                NULL as "telegramChatId",
+                "bestDiffNotificationsEnabled",
+                "deviceNotificationsEnabled",
+                "hourlyStatsEnabled",
+                "hourlyWorkersEnabled",
+                false as "isDefault",
+                "createdAt",
+                "updatedAt"
+            FROM "ntfy_subscriptions_entity"
+            ON CONFLICT DO NOTHING
+        `);
+
+        // 3. Drop index
+        await queryRunner.query(`
+            DROP INDEX "IDX_ntfy_subscriptions_address"
+        `);
+
+        // 4. Drop the ntfy_subscriptions_entity table
+        await queryRunner.query(`
+            DROP TABLE "ntfy_subscriptions_entity"
+        `);
+    }
+}

--- a/src/services/ntfy.service.ts
+++ b/src/services/ntfy.service.ts
@@ -5,7 +5,7 @@ import axios from 'axios';
 import { EventSource } from 'eventsource';
 import { validate } from 'bitcoin-address-validation';
 import { NumberSuffix } from '../utils/NumberSuffix';
-import { TelegramSubscriptionsService } from '../ORM/telegram-subscriptions/telegram-subscriptions.service';
+import { NtfySubscriptionsService } from '../ORM/ntfy-subscriptions/ntfy-subscriptions.service';
 import { ClientService } from '../ORM/client/client.service';
 import { AddressSettingsService } from '../ORM/address-settings/address-settings.service';
 import { ClientStatisticsService } from '../ORM/client-statistics/client-statistics.service';
@@ -25,12 +25,11 @@ export class NtfyService implements OnModuleInit {
   private eventSource?: EventSource;
   private retryTimer?: NodeJS.Timeout;
   private readonly shouldInitialize: boolean;
-  private chatLanguages: Map<string, 'de' | 'en'> = new Map();
   private readonly deviceNotificationFormatters: Record<'de' | 'en', Intl.DateTimeFormat>;
 
   constructor(
     private readonly configService: ConfigService,
-    private readonly telegramSubscriptionsService: TelegramSubscriptionsService,
+    private readonly ntfySubscriptionsService: NtfySubscriptionsService,
     private readonly clientService: ClientService,
     private readonly addressSettingsService: AddressSettingsService,
     private readonly clientStatisticsService: ClientStatisticsService,
@@ -93,12 +92,12 @@ export class NtfyService implements OnModuleInit {
     return `${address.slice(0, 4)}...${address.slice(-5)}`;
   }
 
-  private getLanguage(origin: string): 'de' | 'en' {
-    return this.chatLanguages.get(origin) ?? 'de';
+  private async getLanguage(origin: string): Promise<'de' | 'en'> {
+    return await this.ntfySubscriptionsService.getLanguage(origin);
   }
 
   private async reply(origin: string, messages: { de: string; en: string }) {
-    const lang = this.getLanguage(origin);
+    const lang = await this.getLanguage(origin);
     await this.publish(origin, messages[lang]);
   }
 
@@ -133,13 +132,8 @@ export class NtfyService implements OnModuleInit {
     if (!this.shouldInitialize || !this.serverUrl) {
       return;
     }
-    const [telegramAddresses, clientAddresses] = await Promise.all([
-      this.telegramSubscriptionsService.getAllAddresses(),
-      this.clientService.getAllAddresses(),
-    ]);
-    const addresses = Array.from(
-      new Set([...telegramAddresses, ...clientAddresses]),
-    );
+    const clientAddresses = await this.clientService.getAllAddresses();
+    const addresses = Array.from(new Set(clientAddresses));
     for (const addr of addresses) {
       const settings = await this.addressSettingsService.getSettings(
         addr,
@@ -248,13 +242,13 @@ export class NtfyService implements OnModuleInit {
 
   private async handleCommand(origin: string, text: string) {
     if (text.startsWith('/deutsch')) {
-      this.chatLanguages.set(origin, 'de');
+      await this.ntfySubscriptionsService.updateLanguage(origin, 'de');
       await this.reply(origin, {
         de: 'Sprache auf Deutsch gestellt.',
         en: 'Language switched to German.'
       });
     } else if (text.startsWith('/english')) {
-      this.chatLanguages.set(origin, 'en');
+      await this.ntfySubscriptionsService.updateLanguage(origin, 'en');
       await this.reply(origin, {
         de: 'Sprache auf Englisch gestellt.',
         en: 'Language switched to English.'
@@ -486,9 +480,7 @@ export class NtfyService implements OnModuleInit {
       const enabled = action === 'on';
 
       try {
-        // For NTFY we need to update via the subscription service
-        // Note: This will update for all telegram subscriptions with this address
-        await this.telegramSubscriptionsService.updateDeviceNotificationsByAddress(origin, enabled);
+        await this.ntfySubscriptionsService.updateDeviceNotifications(origin, enabled);
         await this.reply(origin, {
           de: `Geräte-Benachrichtigungen ${enabled ? 'aktiviert' : 'deaktiviert'}.`,
           en: `Device notifications ${enabled ? 'enabled' : 'disabled'}.`
@@ -533,8 +525,7 @@ export class NtfyService implements OnModuleInit {
         const showStats = features.includes('show_stats');
 
         try {
-          // For NTFY we need to update via subscription service for this address
-          await this.telegramSubscriptionsService.updateHourlyNotificationsByAddress(origin, true, showStats, showWorkers);
+          await this.ntfySubscriptionsService.updateHourlyNotifications(origin, true, showStats, showWorkers);
           const featureList = [showWorkers ? 'show_workers' : null, showStats ? 'show_stats' : null].filter(Boolean).join(' + ');
           await this.reply(origin, {
             de: `Stündliche Benachrichtigungen aktiviert für: ${featureList}`,
@@ -549,7 +540,7 @@ export class NtfyService implements OnModuleInit {
         }
       } else {
         try {
-          await this.telegramSubscriptionsService.updateHourlyNotificationsByAddress(origin, false, false, false);
+          await this.ntfySubscriptionsService.updateHourlyNotifications(origin, false, false, false);
           await this.reply(origin, {
             de: 'Stündliche Benachrichtigungen deaktiviert.',
             en: 'Hourly notifications disabled.'
@@ -654,7 +645,7 @@ export class NtfyService implements OnModuleInit {
     if (submissionDifficulty > persistedBest) {
       this.bestDiffCache.set(address, submissionDifficulty);
       if (this.bestDiffOptIn.get(address) !== false) {
-        const lang = this.getLanguage(address);
+        const lang = await this.getLanguage(address);
         const message = lang === 'de'
           ? `🏆 Neue beste Difficulty!\nWert: ${this.numberSuffix.to(submissionDifficulty)}`
           : `🏆 New best difficulty!\nValue: ${this.numberSuffix.to(submissionDifficulty)}`;
@@ -703,14 +694,14 @@ export class NtfyService implements OnModuleInit {
     if (!this.shouldInitialize || !this.serverUrl) return;
 
     try {
-      const enabledChats = await this.telegramSubscriptionsService.getHourlyEnabledChats();
+      const enabledSubscriptions = await this.ntfySubscriptionsService.getHourlyEnabledAddresses();
 
-      for (const chat of enabledChats) {
+      for (const sub of enabledSubscriptions) {
         try {
-          const address = chat.address;
+          const address = sub.address;
 
           // Send stats if enabled
-          if (chat.hourlyStatsEnabled) {
+          if (sub.hourlyStatsEnabled) {
             try {
               const messages = await buildStatsMessage(
                 address,
@@ -720,7 +711,7 @@ export class NtfyService implements OnModuleInit {
                 this.numberSuffix
               );
               if (messages) {
-                const lang = this.getLanguage(address);
+                const lang = await this.getLanguage(address);
                 await this.publish(address, messages[lang]);
               }
             } catch (err) {
@@ -729,7 +720,7 @@ export class NtfyService implements OnModuleInit {
           }
 
           // Send workers overview if enabled
-          if (chat.hourlyWorkersEnabled) {
+          if (sub.hourlyWorkersEnabled) {
             try {
               const apiPort = process.env.API_PORT ?? '3334';
               const url = `http://localhost:${apiPort}/api/client/${encodeURIComponent(address)}`;
@@ -739,7 +730,7 @@ export class NtfyService implements OnModuleInit {
                 const payload = await res.json();
                 if (payload && Array.isArray(payload.workers) && payload.workers.length > 0) {
                   const messages = buildWorkersOverviewMessage(payload, this.numberSuffix);
-                  const lang = this.getLanguage(address);
+                  const lang = await this.getLanguage(address);
                   await this.publish(address, messages[lang]);
                 }
               }
@@ -748,7 +739,7 @@ export class NtfyService implements OnModuleInit {
             }
           }
         } catch (err) {
-          console.error(`NTFY: Fehler beim Verarbeiten von Stundlich-Updates für ${chat.address}:`, err);
+          console.error(`NTFY: Fehler beim Verarbeiten von Stundlich-Updates für ${sub.address}:`, err);
         }
       }
     } catch (err) {

--- a/src/services/ntfy.service.ts
+++ b/src/services/ntfy.service.ts
@@ -668,7 +668,7 @@ export class NtfyService implements OnModuleInit {
     const { address, workerName, userAgent, isOnline, timestamp, isReturning } = params;
 
     const eventTime = timestamp instanceof Date ? timestamp : new Date(timestamp);
-    const lang = this.getLanguage(address);
+    const lang = await this.getLanguage(address);
     const timeFormatted = this.deviceNotificationFormatters[lang].format(eventTime);
     const trimmedAgent = userAgent?.trim();
     const trimmedWorker = workerName?.trim();


### PR DESCRIPTION
- Created NtfySubscriptionsEntity with dedicated table for NTFY user preferences
- Created NtfySubscriptionsService to manage NTFY subscriptions independently
- Updated NTFY service to use NtfySubscriptionsService instead of TelegramSubscriptionsService
- Removed NTFY-specific methods from TelegramSubscriptionsService
- Added database migration to create ntfy_subscriptions table and migrate existing data
- Registered NtfySubscriptionsModule in app.module.ts

This change eliminates the dependency between NTFY and Telegram services, allowing each service to manage its own data independently.