### PR TITLE
Fix highScores updatedAt timestamps being incorrectly updated

### DIFF
--- a/src/ORM/address-settings/address-settings.service.ts
+++ b/src/ORM/address-settings/address-settings.service.ts
@@ -57,11 +57,14 @@ export class AddressSettingsService {
     }
 
     public async addShares(address: string, shares: number) {
+        // Explicitly preserve updatedAt to prevent TypeORM from automatically updating it
+        // We only want updatedAt to change when bestDifficulty changes, not when shares accumulate
         return await this.addressSettingsRepository
             .createQueryBuilder()
             .update(AddressSettingsEntity)
             .set({
                 shares: () => 'shares + :increment',
+                updatedAt: () => '"updatedAt"',  // Preserve current value
             })
             .where('address = :address', { address })
             .setParameters({ increment: shares })


### PR DESCRIPTION
After performance optimizations, the /api/info endpoint's highScores section showed updatedAt timestamps that appeared to have been updated recently, even though these are historical high score records.

Root Cause:
- AddressSettingsEntity extends TrackedEntity with @UpdateDateColumn
- TypeORM's @UpdateDateColumn automatically updates updatedAt when ANY field in the entity is modified
- The addShares() method increments the shares field frequently (every time a miner submits a share)
- This caused updatedAt to be updated even though bestDifficulty (the actual high score value) hadn't changed

Solution:
- Modified addShares() to explicitly preserve the updatedAt timestamp
- Added: updatedAt: () => '"updatedAt"' to the SET clause
- This generates SQL that sets updatedAt to itself, preventing automatic timestamp updates
- updatedAt will now only change when bestDifficulty is explicitly updated via updateBestDifficulty() or reset operations

Impact:
- Historical high scores will maintain their original updatedAt timestamps
- Share accumulation will not affect updatedAt
- No performance impact (just one additional field in UPDATE query)