### PR TITLE
Fix: WRONGTYPE Redis error on worker-shares endpoint

### DIFF
--- a/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
+++ b/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts
@@ -215,11 +215,14 @@ export class PoolRejectedStatisticsService implements OnModuleInit, OnModuleDest
     if (this.useRedis && this.redisClient) {
       // Redis-backed implementation with atomic claim-and-fetch
       const pattern = 'pool:rejected:*';
-      const keys = await this.redisClient.keys(pattern);
+      const allKeys = await this.redisClient.keys(pattern);
 
-      if (!keys || keys.length === 0) return;
+      if (!allKeys || allKeys.length === 0) return;
 
-      for (const key of keys) {
+      // Filter out processing locks to avoid WRONGTYPE errors
+      const dataKeys = allKeys.filter(key => !key.endsWith(':processing'));
+
+      for (const key of dataKeys) {
         // Atomically claim this key for processing using Lua script
         // This prevents multiple workers from processing the same key
         const claimScript = `

--- a/src/ORM/pool-share-statistics/pool-share-statistics.service.ts
+++ b/src/ORM/pool-share-statistics/pool-share-statistics.service.ts
@@ -114,11 +114,14 @@ export class PoolShareStatisticsService implements OnModuleInit, OnModuleDestroy
       if (this.useRedis && this.redisClient) {
         // Redis-backed implementation with atomic claim-and-fetch
         const pattern = 'pool:shares:*';
-        const keys = await this.redisClient.keys(pattern);
+        const allKeys = await this.redisClient.keys(pattern);
 
-        if (!keys || keys.length === 0) return;
+        if (!allKeys || allKeys.length === 0) return;
 
-        for (const key of keys) {
+        // Filter out processing locks to avoid WRONGTYPE errors
+        const dataKeys = allKeys.filter(key => !key.endsWith(':processing'));
+
+        for (const key of dataKeys) {
           // Atomically claim this key for processing using Lua script
           // This prevents multiple workers from processing the same key
           const claimScript = `

--- a/src/services/share-totals-cache.service.ts
+++ b/src/services/share-totals-cache.service.ts
@@ -203,10 +203,24 @@ export class ShareTotalsCacheService implements OnModuleDestroy, OnModuleInit {
     if (this.useRedis && this.redisClient) {
       // Redis-backed implementation
       const pattern = `shares:worker:${address}:*`;
-      const keys = await this.redisClient.keys(pattern);
+      const allKeys = await this.redisClient.keys(pattern);
 
-      if (!keys || keys.length === 0) {
+      if (!allKeys || allKeys.length === 0) {
         // Fallback to database if not in cache
+        const totals = await this.clientStatisticsService.getTotalSharesForWorkers(
+          address,
+        );
+        return totals.map((entry) => ({
+          workerName: entry.clientName,
+          total: entry.total,
+        }));
+      }
+
+      // Filter out non-data keys (hydration markers and locks)
+      const dataKeys = allKeys.filter(key => !key.endsWith(':hydrated') && !key.endsWith(':lock'));
+
+      if (dataKeys.length === 0) {
+        // Only found hydration/lock keys, fallback to database
         const totals = await this.clientStatisticsService.getTotalSharesForWorkers(
           address,
         );
@@ -218,7 +232,7 @@ export class ShareTotalsCacheService implements OnModuleDestroy, OnModuleInit {
 
       const result: Array<{ workerName: string; total: number }> = [];
       const prefix = `shares:worker:${address}:`;
-      for (const key of keys) {
+      for (const key of dataKeys) {
         // Extract worker name by removing the prefix (more robust than split/pop)
         const workerName = key.startsWith(prefix) ? key.substring(prefix.length) : key.split(':').pop();
         const data = await this.redisClient.hGetAll(key);
@@ -299,9 +313,12 @@ export class ShareTotalsCacheService implements OnModuleDestroy, OnModuleInit {
 
       // Also flush worker totals (update baseline, reset delta)
       const workerPattern = 'shares:worker:*';
-      const workerKeys = await this.redisClient.keys(workerPattern);
+      const allWorkerKeys = await this.redisClient.keys(workerPattern);
 
-      for (const key of workerKeys) {
+      // Filter out non-data keys (hydration markers and locks)
+      const workerDataKeys = allWorkerKeys.filter(key => !key.endsWith(':hydrated') && !key.endsWith(':lock'));
+
+      for (const key of workerDataKeys) {
         const data = await this.redisClient.hGetAll(key);
         const delta = parseFloat(data.delta) || 0;
 


### PR DESCRIPTION
## Problem

After PR #100, the `/api/client/:address/worker-shares` endpoint returned internal server errors with:
```
WRONGTYPE Operation against a key holding the wrong kind of value
```

### Root Cause

The code used Redis `keys()` patterns to find data keys, but these patterns also matched **metadata keys** (hydration markers, locks, processing flags). When the code tried to perform hash operations (`hGetAll`) on these STRING metadata keys, Redis returned WRONGTYPE errors.

**Examples:**

1. **ShareTotalsCacheService:** Pattern `shares:worker:${address}:*` matched:
   - ✅ `shares:worker:addr:worker1` (HASH with baseline/delta)
   - ❌ `shares:worker:addr:worker1:hydrated` (STRING marker)  
   - ❌ `shares:worker:addr:worker1:hydrated:lock` (STRING lock)

2. **PoolShareStatisticsService:** Pattern `pool:shares:*` matched:
   - ✅ `pool:shares:1234567890` (HASH with accepted/rejected)
   - ❌ `pool:shares:1234567890:processing` (STRING lock from PR #100)

Then calling `hGetAll()` on STRING keys → **WRONGTYPE error**

---

## Solution

Filter out metadata keys before attempting hash operations:

```typescript
const allKeys = await this.redisClient.keys(pattern);
const dataKeys = allKeys.filter(key => 
  !key.endsWith(':hydrated') && 
  !key.endsWith(':lock') && 
  !key.endsWith(':processing')
);
```

### Files Fixed

- `src/services/share-totals-cache.service.ts`
  - `getWorkerTotals()` - Filter `:hydrated` and `:lock` keys
  - `flush()` - Filter `:hydrated` and `:lock` keys
- `src/ORM/pool-share-statistics/pool-share-statistics.service.ts`
  - `flush()` - Filter `:processing` keys
- `src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts`
  - `saveCurrent()` - Filter `:processing` keys

---

## Impact

✅ **Fixes internal server error** on `/api/client/:address/worker-shares`  
✅ **Prevents WRONGTYPE errors** during flush operations  
✅ **No functional changes** - only filters metadata keys that shouldn't be processed anyway

---

## Testing

- ✅ Build passes (`npm run build`)
- ✅ All filtered keys are metadata that shouldn't be processed as data
- ✅ Fallback to database still works if no data keys found

---

## Notes

This bug was introduced by PR #98 (hydration markers/locks) and PR #100 (processing locks). The atomic locking mechanisms are correct, but the key filtering was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)