### PR TITLE
Add UnifiedPush server for bestDifficulty notifications

### DIFF
--- a/INVESTIGATION_REJECTED_SHARES_BUG.md
+++ b/INVESTIGATION_REJECTED_SHARES_BUG.md
@@ -1,0 +1,463 @@
+# CRITICAL BUG INVESTIGATION: /api/info/rejected Returns All Zeros
+
+## Problem Summary
+
+After deploying PR #100 (commit 5712711) and PR #101 (commit 73d2abb), the `/api/info/rejected` endpoint suddenly returns ALL ZEROS for rejected shares across all time ranges. Previously, this endpoint showed approximately 2M rejected shares per 10-minute slot.
+
+- `/api/info/accepted` WORKS correctly and shows proper accepted share counts
+- `/api/info/rejected` shows ALL ZEROS (impossible - miners definitely submit invalid shares)
+- System is running in Docker using `docker-compose-mainnet-pm2.yml`
+- Multiple PM2 worker processes in cluster mode
+- Redis is being used for shared state
+
+## Environment
+
+- Working Directory: `/home/mario/github_repos/blitzpool`
+- Current Branch: `fix/incorrect-rollback-stale-delta`
+- Main Branch: `blitzpool-master`
+- Docker Compose File: `docker-compose-mainnet-pm2.yml`
+- Platform: Linux 6.14.0-36-generic
+
+## Recent Commits Context
+
+```
+bb52af0 Fix: Incorrect rollback logic using stale delta causing share count inflation
+e6b7e68 Merge pull request #101 from warioishere/fix/redis-wrongtype-worker-shares
+73d2abb Fix: WRONGTYPE Redis error on worker-shares endpoint
+557d2b6 Merge pull request #100 from warioishere/fix/redis-share-count-inflation
+5712711 Fix: Critical race condition causing inflated share counts in PM2 cluster mode
+```
+
+## Key Files Involved
+
+### Services
+- `/home/mario/github_repos/blitzpool/src/ORM/pool-rejected-statistics/pool-rejected-statistics.service.ts`
+- `/home/mario/github_repos/blitzpool/src/ORM/pool-share-statistics/pool-share-statistics.service.ts`
+- `/home/mario/github_repos/blitzpool/src/models/StratumV1Client.ts` (where `addRejectedShare` is called)
+
+### Database Tables
+- `pool_rejected_statistics` - Should contain rejected share records
+- `pool_share_statistics` - Contains both accepted and rejected share counts
+
+### Redis Keys
+- `pool:rejected:*` - Should store pending rejected share data before flush
+- `pool:shares:*` - Stores pending accepted/rejected share data before flush
+
+## Investigation Steps
+
+### 1. Check Redis Keys
+
+Run these commands inside the Redis container:
+
+```bash
+# Get into Redis CLI
+docker exec -it <redis-container-name> redis-cli
+
+# List all rejected share keys
+KEYS pool:rejected:*
+
+# List all share statistics keys
+KEYS pool:shares:*
+
+# If you find any pool:rejected:* keys, inspect their data
+HGETALL pool:rejected:<timestamp>
+
+# Check if there are any processing locks
+KEYS pool:rejected:*:processing
+```
+
+**Expected behavior:**
+- Should see `pool:rejected:*` keys for current time slots
+- Keys should have HASH structure with reasons as fields and counts as values
+- Example: `{"duplicate": "123.45", "low-difficulty": "678.90"}`
+
+**Questions to answer:**
+- Are `pool:rejected:*` keys being created at all?
+- If they exist, do they have data?
+- Are they being flushed and deleted too quickly?
+
+### 2. Check Database Tables
+
+Run these SQL queries:
+
+```bash
+# Connect to PostgreSQL
+docker exec -it <postgres-container-name> psql -U <username> -d <database>
+
+# Check recent rejected share statistics
+SELECT time, reason, count, "updatedAt"
+FROM pool_rejected_statistics
+WHERE time > EXTRACT(EPOCH FROM NOW() - INTERVAL '1 hour') * 1000
+ORDER BY time DESC
+LIMIT 20;
+
+# Check recent pool share statistics (for comparison)
+SELECT time, accepted, rejected, "updatedAt"
+FROM pool_share_statistics
+WHERE time > EXTRACT(EPOCH FROM NOW() - INTERVAL '1 hour') * 1000
+ORDER BY time DESC
+LIMIT 20;
+
+# Count total rejected entries
+SELECT COUNT(*), MIN(time), MAX(time)
+FROM pool_rejected_statistics;
+
+# Sum of rejected shares in last hour
+SELECT SUM(count)
+FROM pool_rejected_statistics
+WHERE time > EXTRACT(EPOCH FROM NOW() - INTERVAL '1 hour') * 1000;
+```
+
+**Questions to answer:**
+- Are rejected shares making it to the database at all?
+- When was the last time a rejected share was recorded?
+- Is the `updatedAt` field recent?
+- Do the timestamps align with current time?
+
+### 3. Check Application Logs
+
+Search Docker logs for PoolRejectedStatisticsService activity:
+
+```bash
+# View recent logs
+docker-compose -f docker-compose-mainnet-pm2.yml logs --tail=500 --follow
+
+# Search for rejected statistics service logs
+docker-compose -f docker-compose-mainnet-pm2.yml logs | grep -i "PoolRejectedStatisticsService"
+
+# Look for startup messages
+docker-compose -f docker-compose-mainnet-pm2.yml logs | grep -i "Using Redis for shared state"
+
+# Look for flush operations
+docker-compose -f docker-compose-mainnet-pm2.yml logs | grep -i "flush"
+
+# Look for errors
+docker-compose -f docker-compose-mainnet-pm2.yml logs | grep -i "WRONGTYPE"
+docker-compose -f docker-compose-mainnet-pm2.yml logs | grep -i "Failed to flush"
+docker-compose -f docker-compose-mainnet-pm2.yml logs | grep -i "Failed to claim"
+
+# Look for anomalous diff warnings (should NOT appear if disabled)
+docker-compose -f docker-compose-mainnet-pm2.yml logs | grep -i "Anomalous diff"
+```
+
+**Questions to answer:**
+- Is PoolRejectedStatisticsService initializing correctly?
+- Are there any WRONGTYPE errors?
+- Is the flush interval running?
+- Are there any "Failed to claim key" messages?
+- Are there "Anomalous diff" warnings blocking shares?
+
+### 4. Verify Environment Variables
+
+Check if anomalous diff detection is actually disabled:
+
+```bash
+# Check environment variables in running containers
+docker-compose -f docker-compose-mainnet-pm2.yml exec <service-name> env | grep -i ANOMALOUS
+
+# Or check the docker-compose file
+cat docker-compose-mainnet-pm2.yml | grep -i ANOMALOUS
+```
+
+**Expected:**
+- `ANOMALOUS_DIFF_DETECTION_ENABLED=false` (or '0', 'off', 'no')
+
+**If it's enabled (true):**
+- This could be blocking legitimate rejected shares as "anomalous"
+- Check logs for "Anomalous diff" warnings
+
+### 5. Check PM2 Worker Status
+
+```bash
+# List PM2 processes
+docker-compose -f docker-compose-mainnet-pm2.yml exec <service-name> pm2 list
+
+# Check PM2 logs
+docker-compose -f docker-compose-mainnet-pm2.yml exec <service-name> pm2 logs --lines 100
+```
+
+**Questions to answer:**
+- Are all PM2 workers running?
+- Are there any crashed workers?
+- Are workers restarting frequently?
+
+### 6. Monitor Live Rejected Share Recording
+
+To see if rejected shares are being recorded in real-time:
+
+```bash
+# In Redis CLI, monitor commands
+docker exec -it <redis-container-name> redis-cli MONITOR
+
+# Or watch for specific keys
+watch -n 1 'docker exec <redis-container-name> redis-cli KEYS "pool:rejected:*"'
+
+# Check if shares are being rejected in Stratum logs
+docker-compose -f docker-compose-mainnet-pm2.yml logs --follow | grep -i "rejected\|duplicate\|low-difficulty"
+```
+
+**Questions to answer:**
+- Are rejected shares being submitted by miners?
+- Are the `addRejectedShare` calls being made?
+- Are Redis HINCRBY commands being executed?
+- Are keys being created?
+
+### 7. Code Comparison Analysis
+
+Compare the two services to find differences:
+
+**PoolRejectedStatisticsService (lines 144-211):**
+- `addRejectedShare(reason: string, diff: number): Promise<boolean>`
+- Has anomaly detection logic (lines 150-175)
+- Returns `false` if share is rejected as anomalous (line 166)
+- Uses `pool:rejected:${timeSlot}` Redis keys (line 179)
+- Uses `hIncrByFloat(key, reason, diff)` to increment per-reason counts (line 182)
+
+**PoolShareStatisticsService (lines 256-262):**
+- `addRejectedShare(difficulty: number)`
+- No anomaly detection
+- Uses `pool:shares:${timeSlot}` Redis keys (line 86)
+- Uses `hIncrByFloat(key, 'rejected', rejected)` to increment total rejected count (line 93)
+
+**Critical Difference:**
+- PoolRejectedStatisticsService has anomaly detection that returns `false`
+- If anomaly detection is enabled, legitimate shares might be blocked
+- Check if `ANOMALOUS_DIFF_DETECTION_ENABLED` is set correctly
+
+### 8. Check Stratum Client Code
+
+Look at where rejected shares are recorded in `/home/mario/github_repos/blitzpool/src/models/StratumV1Client.ts`:
+
+```typescript
+// Around lines 825-837 (multiple occurrences)
+const accepted = await this.poolRejectedStatisticsService.addRejectedShare(
+  reason,
+  this.sessionDifficulty,
+);
+if (accepted) {
+  await this.poolShareStatisticsService.addRejectedShare(this.sessionDifficulty);
+}
+await this.clientRejectedStatisticsService.addRejectedShare(
+  this.address,
+  reason,
+  this.sessionDifficulty,
+);
+```
+
+**Critical Logic:**
+- If `poolRejectedStatisticsService.addRejectedShare()` returns `false`, the share is NOT recorded in `poolShareStatisticsService`
+- But it IS still recorded in `clientRejectedStatisticsService`
+- This could explain why `/api/info/rejected` shows zeros but individual client stats might still work
+
+### 9. Trace the Bug Timeline
+
+**Before PR #100:**
+- Both services might have had simpler logic
+- Rejected shares were recorded correctly
+
+**After PR #100 (commit 5712711):**
+- Added atomic claim-and-fetch with Lua scripts
+- Added distributed locking with processing keys
+- Added key filtering to avoid WRONGTYPE errors
+- Changed startup cleanup to flush before deleting
+
+**After PR #101 (commit 73d2abb):**
+- Added filtering for `:processing`, `:hydrated`, `:lock` keys
+- Fixed WRONGTYPE errors by excluding metadata keys
+
+**Current (commit bb52af0):**
+- Fixed rollback logic in ShareTotalsCacheService
+- Uses `flushedDelta` instead of stale `delta`
+
+**Question:**
+- Did any of these changes break the rejected share recording?
+
+## Hypotheses to Test
+
+### Hypothesis 1: Anomaly Detection Blocking All Shares
+**Evidence needed:**
+- Check if `ANOMALOUS_DIFF_DETECTION_ENABLED=true`
+- Look for "Anomalous diff" warnings in logs
+- If found, this is the bug
+
+**Fix:**
+- Set `ANOMALOUS_DIFF_DETECTION_ENABLED=false` in environment
+- OR fix the anomaly detection logic to not block legitimate shares
+
+### Hypothesis 2: Redis Keys Being Created but Not Flushed
+**Evidence needed:**
+- `pool:rejected:*` keys exist in Redis
+- Keys have data (HGETALL shows counts)
+- But database table is empty or outdated
+
+**Possible causes:**
+- Flush interval not running
+- Lua script failing silently
+- Processing locks not being cleaned up
+- WRONGTYPE errors during flush
+
+**Fix:**
+- Debug the `saveCurrent()` method
+- Check for errors in flush logs
+- Verify Lua script is working
+
+### Hypothesis 3: Redis Keys Not Being Created At All
+**Evidence needed:**
+- No `pool:rejected:*` keys in Redis
+- Miners ARE submitting invalid shares (check Stratum logs)
+- `addRejectedShare` is being called (add debug logging)
+
+**Possible causes:**
+- Redis connection failure
+- Silent exception in `addRejectedShare`
+- Logic error preventing key creation
+
+**Fix:**
+- Add detailed logging to `addRejectedShare`
+- Verify Redis connection
+- Check for exceptions
+
+### Hypothesis 4: Key Filtering Too Aggressive
+**Evidence needed:**
+- `pool:rejected:*` keys are being filtered out during flush
+- Check if the filter pattern is excluding valid keys
+
+**Code to review:**
+```typescript
+// Line 223 in pool-rejected-statistics.service.ts
+const dataKeys = allKeys.filter(key => !key.endsWith(':processing'));
+```
+
+**Question:**
+- Are there other metadata suffixes being used?
+- Is the filter correct?
+
+### Hypothesis 5: Lua Script Returns Empty Result
+**Evidence needed:**
+- Lua script is executing
+- But returning `nil` or empty array
+- Check if multiple workers are claiming the same key
+
+**Code to review:**
+```typescript
+// Lines 228-239 in pool-rejected-statistics.service.ts
+const claimScript = `
+  local key = KEYS[1]
+  local lockKey = key .. ':processing'
+  local acquired = redis.call('SET', lockKey, '1', 'NX', 'EX', 10)
+  if acquired then
+    local data = redis.call('HGETALL', key)
+    redis.call('DEL', key)
+    return data
+  else
+    return nil
+  end
+`;
+```
+
+**Question:**
+- Is the lock expiry (10 seconds) too short?
+- Are all workers failing to acquire locks?
+
+## Expected Diagnosis Format
+
+Once investigation is complete, provide:
+
+### 1. WHERE rejected shares are being lost
+- Redis? (keys not created)
+- Flush? (keys created but not flushed)
+- Database? (flush runs but data not persisted)
+- Blocked? (anomaly detection rejecting shares)
+
+### 2. WHY it started after PR #100/#101
+- What specific change caused the regression?
+- Was it the Lua script?
+- The key filtering?
+- The processing locks?
+- Environment variable?
+
+### 3. The EXACT line of code causing the issue
+- File path (absolute)
+- Line number
+- Code snippet
+- Explanation of why it's wrong
+
+### 4. Proposed fix
+- Specific code change
+- Why this fixes it
+- Any side effects
+- Testing strategy
+
+## Additional Notes
+
+- The anomaly detection feature in PoolRejectedStatisticsService is suspicious
+- It's the main difference between the two services
+- If enabled, it could block all shares as "anomalous"
+- The logic checks if `diff > avg * 4` and returns `false` (line 166)
+- This prevents the share from being recorded in PoolShareStatisticsService
+- But the share IS still recorded in ClientRejectedStatisticsService
+- This matches the symptom: `/api/info/rejected` shows zeros but client stats might work
+
+**FIRST THING TO CHECK:**
+```bash
+# Check this immediately
+docker-compose -f docker-compose-mainnet-pm2.yml exec <service-name> env | grep ANOMALOUS_DIFF_DETECTION_ENABLED
+
+# And search logs for
+docker-compose -f docker-compose-mainnet-pm2.yml logs | grep "Anomalous diff"
+```
+
+If you see "Anomalous diff" warnings, **THAT'S THE BUG**.
+
+## Commands Reference
+
+### Docker Commands
+```bash
+# List containers
+docker-compose -f docker-compose-mainnet-pm2.yml ps
+
+# View logs
+docker-compose -f docker-compose-mainnet-pm2.yml logs --tail=500
+
+# Execute command in container
+docker-compose -f docker-compose-mainnet-pm2.yml exec <service> <command>
+
+# Restart service
+docker-compose -f docker-compose-mainnet-pm2.yml restart <service>
+```
+
+### Redis Commands
+```bash
+# Connect to Redis
+docker exec -it <redis-container> redis-cli
+
+# List keys
+KEYS pool:rejected:*
+KEYS pool:shares:*
+
+# Get hash data
+HGETALL pool:rejected:1234567890
+
+# Monitor all commands
+MONITOR
+
+# Get key type
+TYPE pool:rejected:1234567890
+```
+
+### PostgreSQL Commands
+```bash
+# Connect to PostgreSQL
+docker exec -it <postgres-container> psql -U <username> -d <database>
+
+# List tables
+\dt
+
+# Describe table
+\d pool_rejected_statistics
+
+# Query data
+SELECT * FROM pool_rejected_statistics LIMIT 10;
+```
+
+Good luck with the investigation!

--- a/TIMESLOT_ENDPOINTS_REVIEW.md
+++ b/TIMESLOT_ENDPOINTS_REVIEW.md
@@ -1,0 +1,369 @@
+# Time Slot Endpoints Review & Fix Instructions
+
+## Current Status
+
+✅ **FIXED in PR #103:**
+- `GET /info/chart` (pool-level hashrate chart)
+- `GET /client/:address/chart` (address-level hashrate chart)
+- `GET /client/:address/worker/:name/chart` (worker-level hashrate chart)
+- `GET /client/:address/worker/:name/session/:id/chart` (session-level hashrate chart)
+
+## Endpoints That ALSO Need Fixing
+
+The following endpoints use 10-minute time slots but still have **start-time labeling** and include the **incomplete current slot**:
+
+### 1. Pool-Level Statistics Endpoints
+
+#### `GET /info/accepted`
+- **File:** `src/app.controller.ts:336-372`
+- **Issue:** Uses start-time slots, includes current incomplete slot
+- **Code location:**
+  ```typescript
+  const coeff = 1000 * 60 * 10;
+  const startSlot = Math.floor(sinceTime / coeff) * coeff;
+  const endSlot = Math.floor(now / coeff) * coeff;  // ← Current slot (incomplete!)
+  for (let t = startSlot; t <= endSlot; t += coeff) {  // ← Includes incomplete slot
+    slotData.push({
+      time: new Date(t).toISOString(),  // ← Start-time label
+      counts: { accepted: slotMap.get(t) || 0 },
+    });
+  }
+  ```
+
+#### `GET /info/workers`
+- **File:** `src/app.controller.ts:374-428`
+- **Issue:** Uses start-time slots, includes current incomplete slot
+- **Special case:** Lines 419-423 override the last slot with live data from `getActiveWorkerCounts()` - this is a hack that should be removed
+- **Code location:**
+  ```typescript
+  const currentSlot = Math.floor(now / coeff) * coeff;
+  if (endSlot === currentSlot && slotData.length > 0) {
+    const liveCounts = await this.clientService.getActiveWorkerCounts();
+    slotData[slotData.length - 1].counts = liveCounts;  // ← Hack!
+  }
+  ```
+
+#### `GET /info/rejected`
+- **File:** `src/app.controller.ts:430-473`
+- **Issue:** Uses start-time slots, includes current incomplete slot
+- **Code location:**
+  ```typescript
+  const coeff = 1000 * 60 * 10;
+  const startSlot = Math.floor(sinceTime / coeff) * coeff;
+  const endSlot = Math.floor(now / coeff) * coeff;  // ← Current slot (incomplete!)
+  for (let t = startSlot; t <= endSlot; t += coeff) {  // ← Includes incomplete slot
+    const counts: Record<string, number> = {};
+    for (const reason of allReasons) {
+      counts[reason] = slotMap.get(t)?.[reason] || 0;
+    }
+    slotData.push({ time: new Date(t).toISOString(), counts });  // ← Start-time label
+  }
+  ```
+
+### 2. Address-Level Statistics Endpoints
+
+#### `GET /client/:address/workers`
+- **File:** `src/controllers/client/client.controller.ts:92-118`
+- **Issue:** Uses start-time slots, includes current incomplete slot
+- **Code location:**
+  ```typescript
+  const coeff = 1000 * 60 * 10;
+  const startSlot = Math.floor(sinceTime / coeff) * coeff;
+  const endSlot = Math.floor(now / coeff) * coeff;  // ← Current slot (incomplete!)
+  for (let t = startSlot; t <= endSlot; t += coeff) {  // ← Includes incomplete slot
+    const counts = slotMap.get(t) || { workers: 0, sessions: 0 };
+    slotData.push({ time: new Date(t).toISOString(), counts });  // ← Start-time label
+  }
+  ```
+
+#### `GET /client/:address/accepted`
+- **File:** `src/controllers/client/client.controller.ts:120-145`
+- **Issue:** Uses start-time slots, includes current incomplete slot
+- **Code location:**
+  ```typescript
+  const coeff = 1000 * 60 * 10;
+  const startSlot = Math.floor(sinceTime / coeff) * coeff;
+  const endSlot = Math.floor(now / coeff) * coeff;  // ← Current slot (incomplete!)
+  for (let t = startSlot; t <= endSlot; t += coeff) {  // ← Includes incomplete slot
+    slotData.push({
+      time: new Date(t).toISOString(),  // ← Start-time label
+      counts: { accepted: slotMap.get(t) || 0 }
+    });
+  }
+  ```
+
+#### `GET /client/:address/rejected`
+- **File:** `src/controllers/client/client.controller.ts:147-182`
+- **Issue:** Uses start-time slots, includes current incomplete slot
+- **Code location:**
+  ```typescript
+  const coeff = 1000 * 60 * 10;
+  const startSlot = Math.floor(sinceTime / coeff) * coeff;
+  const endSlot = Math.floor(now / coeff) * coeff;  // ← Current slot (incomplete!)
+  for (let t = startSlot; t <= endSlot; t += coeff) {  // ← Includes incomplete slot
+    const counts: Record<string, { count: number; diffMinusOne: number }> = {};
+    for (const reason of allReasons) {
+      const current = slotMap.get(t)?.[reason] || { count: 0, diffMinusOne: 0 };
+      counts[reason] = current;
+    }
+    slotData.push({ time: new Date(t).toISOString(), counts });  // ← Start-time label
+  }
+  ```
+
+---
+
+## How These Endpoints Get Their Data
+
+### Client Statistics (already migrated ✅)
+- **Table:** `client_statistics_entity`
+- **Time slots created in:** `src/models/StratumV1ClientStatistics.ts`
+- **Migration status:** ✅ Already updated to end-time in PR #103
+- **Time values:** All have 10 minutes added by migration
+
+### Pool Share Statistics (needs migration ⚠️)
+- **Table:** `pool_share_statistics_entity`
+- **Time slots created in:** `src/ORM/pool-share-statistics/pool-share-statistics.service.ts:70-73`
+- **Migration status:** ❌ Still using start-time
+- **Current code:**
+  ```typescript
+  private getTimeSlot(): number {
+    const coeff = 1000 * 60 * 10;
+    return Math.floor(Date.now() / coeff) * coeff;  // ← Start-time!
+  }
+  ```
+- **What needs to change:**
+  ```typescript
+  private getTimeSlot(): number {
+    const coeff = 1000 * 60 * 10;
+    return Math.floor(Date.now() / coeff) * coeff + coeff;  // ← End-time!
+  }
+  ```
+
+### Pool Rejected Statistics (needs migration ⚠️)
+- **Table:** `pool_rejected_statistics_entity`
+- **Time slots:** Needs investigation - likely similar to pool share statistics
+- **Migration status:** ❌ Needs review and update
+
+### Client Rejected Statistics (needs migration ⚠️)
+- **Table:** `client_rejected_statistics_entity`
+- **Time slots:** Needs investigation
+- **Migration status:** ❌ Needs review and update
+
+---
+
+## Fix Instructions (For Tomorrow)
+
+### Step 1: Update Migration Service
+
+**File:** `src/services/timeslot-migration.service.ts`
+
+Add migrations for the additional tables:
+
+```typescript
+// After migrating client_statistics_entity, also migrate:
+
+// 1. Pool share statistics
+await queryRunner.query(`
+  UPDATE pool_share_statistics_entity
+  SET time = time + ?
+`, [this.TIME_SLOT_DURATION_MS]);
+
+// 2. Pool rejected statistics
+await queryRunner.query(`
+  UPDATE pool_rejected_statistics_entity
+  SET time = time + ?
+`, [this.TIME_SLOT_DURATION_MS]);
+
+// 3. Client rejected statistics
+await queryRunner.query(`
+  UPDATE client_rejected_statistics_entity
+  SET time = time + ?
+`, [this.TIME_SLOT_DURATION_MS]);
+```
+
+Update the migration key to indicate all tables are migrated:
+```typescript
+private readonly MIGRATION_KEY = 'TIMESLOT_END_TIME_MIGRATION_V2_COMPLETED';
+```
+
+### Step 2: Update Time Slot Generation
+
+#### A. Pool Share Statistics
+**File:** `src/ORM/pool-share-statistics/pool-share-statistics.service.ts:70-73`
+
+```typescript
+// Current:
+private getTimeSlot(): number {
+  const coeff = 1000 * 60 * 10;
+  return Math.floor(Date.now() / coeff) * coeff;
+}
+
+// Change to:
+private getTimeSlot(): number {
+  const coeff = 1000 * 60 * 10;
+  // Time slot labeled by END time (e.g., slot "20:50" contains data from 20:40-20:50)
+  return Math.floor(Date.now() / coeff) * coeff + coeff;
+}
+```
+
+#### B. Pool Rejected Statistics
+Find where time slots are created (similar to pool share statistics) and apply same fix.
+
+#### C. Client Rejected Statistics
+Find where time slots are created and apply same fix.
+
+### Step 3: Update Display Logic in Endpoints
+
+For each endpoint listed above, apply this pattern:
+
+**Current pattern:**
+```typescript
+const coeff = 1000 * 60 * 10;
+const startSlot = Math.floor(sinceTime / coeff) * coeff;
+const endSlot = Math.floor(now / coeff) * coeff;
+for (let t = startSlot; t <= endSlot; t += coeff) {
+  slotData.push({ time: new Date(t).toISOString(), counts });
+}
+```
+
+**New pattern:**
+```typescript
+const coeff = 1000 * 60 * 10;
+const currentSlot = Math.floor(now / coeff) * coeff + coeff; // Current incomplete slot (end-time labeled)
+const startSlot = Math.floor(sinceTime / coeff) * coeff + coeff; // First complete slot
+const endSlot = currentSlot - coeff; // Last complete slot (exclude current)
+for (let t = startSlot; t <= endSlot; t += coeff) {
+  slotData.push({ time: new Date(t).toISOString(), counts: slotMap.get(t) || {...} });
+}
+```
+
+**Alternative (simpler) pattern:**
+```typescript
+const coeff = 1000 * 60 * 10;
+const currentSlot = Math.floor(now / coeff) * coeff + coeff;
+const startSlot = Math.floor(sinceTime / coeff) * coeff + coeff;
+for (let t = startSlot; t < currentSlot; t += coeff) {  // Note: t < currentSlot (not <=)
+  slotData.push({ time: new Date(t).toISOString(), counts: slotMap.get(t) || {...} });
+}
+```
+
+### Step 4: Remove Hacks
+
+#### `/info/workers` special case
+**File:** `src/app.controller.ts:419-423`
+
+**Remove this code:**
+```typescript
+const currentSlot = Math.floor(now / coeff) * coeff;
+if (endSlot === currentSlot && slotData.length > 0) {
+  const liveCounts = await this.clientService.getActiveWorkerCounts();
+  slotData[slotData.length - 1].counts = liveCounts;
+}
+```
+
+This is no longer needed because we won't be including the incomplete current slot.
+
+---
+
+## Files to Modify
+
+### Core Changes:
+1. ✅ `src/services/timeslot-migration.service.ts` - Add pool/rejected statistics migrations
+2. ⚠️ `src/ORM/pool-share-statistics/pool-share-statistics.service.ts` - Update getTimeSlot()
+3. ⚠️ Find and update pool rejected statistics time slot generation
+4. ⚠️ Find and update client rejected statistics time slot generation
+
+### Endpoint Display Logic:
+5. ⚠️ `src/app.controller.ts` - Fix `/info/accepted`, `/info/workers`, `/info/rejected`
+6. ⚠️ `src/controllers/client/client.controller.ts` - Fix `/client/:address/workers`, `/client/:address/accepted`, `/client/:address/rejected`
+
+---
+
+## Testing Checklist
+
+After applying fixes:
+
+- [ ] Migration runs successfully and updates all 4 tables
+- [ ] Pool share statistics use end-time labeling
+- [ ] Pool rejected statistics use end-time labeling
+- [ ] Client rejected statistics use end-time labeling
+- [ ] `/info/accepted` excludes current incomplete slot
+- [ ] `/info/workers` excludes current incomplete slot (and live count hack removed)
+- [ ] `/info/rejected` excludes current incomplete slot
+- [ ] `/client/:address/workers` excludes current incomplete slot
+- [ ] `/client/:address/accepted` excludes current incomplete slot
+- [ ] `/client/:address/rejected` excludes current incomplete slot
+- [ ] All endpoints show data with ~5-10 min lag (not 15-20 min)
+- [ ] No errors in logs
+
+---
+
+## Impact Estimate
+
+**Database migration:**
+- 4 tables to update (client_statistics, pool_share_statistics, pool_rejected_statistics, client_rejected_statistics)
+- Expected time: < 10 seconds for most pools
+- Migration is idempotent and safe
+
+**Load impact:**
+- Same as PR #103 (6x more chart queries)
+- No additional impact from these changes
+
+**User experience:**
+- All time-series endpoints will be consistent
+- All will show data with ~5-10 min lag instead of 15-20 min
+- More intuitive labeling across the board
+
+---
+
+## Questions to Investigate Tomorrow
+
+1. ✅ Where is `pool_rejected_statistics_entity.time` set?
+   - Search for: `poolRejectedStatisticsService` or similar
+   - Find the time slot creation logic
+
+2. ✅ Where is `client_rejected_statistics_entity.time` set?
+   - Search for: `clientRejectedStatisticsService` or similar
+   - Find the time slot creation logic
+
+3. ⚠️ Are there any other tables with `time` columns that use 10-minute slots?
+   - Run: `grep -r "1000 * 60 * 10" src/` to find all 10-minute slot calculations
+
+4. ⚠️ Do we need to update any aggregation services?
+   - Check: `src/services/aggregation.service.ts` - may need updates if it pre-computes these endpoints
+
+---
+
+## Quick Reference: The Fix Pattern
+
+**For time slot creation (where data is written):**
+```typescript
+// Change:
+const timeSlot = Math.floor(Date.now() / coeff) * coeff;
+// To:
+const timeSlot = Math.floor(Date.now() / coeff) * coeff + coeff;
+```
+
+**For endpoint display (where data is read):**
+```typescript
+// Change:
+const endSlot = Math.floor(now / coeff) * coeff;
+for (let t = startSlot; t <= endSlot; t += coeff) { ... }
+// To:
+const currentSlot = Math.floor(now / coeff) * coeff + coeff;
+for (let t = startSlot; t < currentSlot; t += coeff) { ... }
+```
+
+**For database migration:**
+```sql
+UPDATE <table_name> SET time = time + 600000;  -- Add 10 minutes
+```
+
+---
+
+## Notes
+
+- All these endpoints follow the same pattern, so the fix is repetitive but straightforward
+- The migration service already handles transactions and rollback
+- Consider doing this in a separate PR or adding to PR #103 before merging
+- User tokens are low, so this document is self-contained for tomorrow's work

--- a/UNIFIEDPUSH_SERVER_SETUP.md
+++ b/UNIFIEDPUSH_SERVER_SETUP.md
@@ -1,0 +1,800 @@
+# UnifiedPush Server Setup Guide
+
+This guide explains how to set up the UnifiedPush notification server on your stratum server (port 3334).
+
+---
+
+## Overview
+
+The UnifiedPush server component monitors best difficulty for mining addresses and sends push notifications when difficulty increases. It consists of:
+
+- **3 REST API endpoints** for managing subscriptions
+- **Background worker** that checks difficulty every 60 seconds
+- **Database tables** for storing subscriptions and tracking difficulty
+- **Optional VAPID support** for future ntfy compatibility
+
+---
+
+## Prerequisites
+
+- Node.js server with Express already running (your stratum server on port 3334)
+- SQLite database with `better-sqlite3`
+- Access to the same database that stores client mining data (`best_difficulty` column)
+
+---
+
+## Step 1: Install Dependencies
+
+```bash
+cd /path/to/your/stratum/server
+npm install web-push --save
+```
+
+**Package installed:**
+- `web-push@^3.6.7` - For optional VAPID support
+
+---
+
+## Step 2: Create Database Tables
+
+Add these tables to your SQLite database:
+
+```sql
+-- Table to store push notification subscriptions
+CREATE TABLE IF NOT EXISTS push_subscriptions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    address TEXT NOT NULL,
+    endpoint TEXT NOT NULL,
+    platform TEXT NOT NULL,
+    createdAt INTEGER NOT NULL,
+    lastNotificationAt INTEGER,
+    UNIQUE(address, endpoint)
+);
+
+-- Table to track best difficulty per address
+CREATE TABLE IF NOT EXISTS best_difficulty_tracker (
+    address TEXT PRIMARY KEY,
+    bestDifficulty REAL NOT NULL,
+    lastCheckedAt INTEGER NOT NULL
+);
+
+-- Create index for faster lookups
+CREATE INDEX IF NOT EXISTS idx_push_subscriptions_address ON push_subscriptions(address);
+```
+
+**How to run:**
+- If using a migration system: Create a new migration file
+- If using direct SQL: Run via SQLite CLI or database management tool
+- If using `database.ts`: Add to your initialization function
+
+---
+
+## Step 3: Create Repository Layer
+
+Create `repositories/push.repository.ts`:
+
+```typescript
+import Database from 'better-sqlite3';
+
+export interface PushSubscription {
+    id: number;
+    address: string;
+    endpoint: string;
+    platform: string;
+    createdAt: number;
+    lastNotificationAt: number | null;
+}
+
+export interface BestDifficultyTracker {
+    address: string;
+    bestDifficulty: number;
+    lastCheckedAt: number;
+}
+
+export class PushRepository {
+    private db: Database.Database;
+
+    constructor(db: Database.Database) {
+        this.db = db;
+    }
+
+    /**
+     * Create a new push subscription
+     */
+    create(address: string, endpoint: string, platform: string): PushSubscription {
+        const stmt = this.db.prepare(`
+            INSERT INTO push_subscriptions (address, endpoint, platform, createdAt)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(address, endpoint) DO UPDATE SET
+                platform = excluded.platform,
+                createdAt = excluded.createdAt
+            RETURNING *
+        `);
+
+        return stmt.get(address, endpoint, platform, Date.now()) as PushSubscription;
+    }
+
+    /**
+     * Delete subscription by address and endpoint
+     */
+    delete(address: string, endpoint: string): void {
+        const stmt = this.db.prepare(
+            'DELETE FROM push_subscriptions WHERE address = ? AND endpoint = ?'
+        );
+        stmt.run(address, endpoint);
+    }
+
+    /**
+     * Delete all subscriptions for an address
+     */
+    deleteByAddress(address: string): void {
+        const stmt = this.db.prepare('DELETE FROM push_subscriptions WHERE address = ?');
+        stmt.run(address);
+    }
+
+    /**
+     * Get all subscriptions for an address
+     */
+    getByAddress(address: string): PushSubscription[] {
+        const stmt = this.db.prepare('SELECT * FROM push_subscriptions WHERE address = ?');
+        return stmt.all(address) as PushSubscription[];
+    }
+
+    /**
+     * Get all unique addresses with subscriptions
+     */
+    getAddressesWithSubscriptions(): string[] {
+        const stmt = this.db.prepare('SELECT DISTINCT address FROM push_subscriptions');
+        const rows = stmt.all() as Array<{ address: string }>;
+        return rows.map(row => row.address);
+    }
+
+    /**
+     * Update last notification timestamp
+     */
+    updateLastNotification(id: number): void {
+        const stmt = this.db.prepare(
+            'UPDATE push_subscriptions SET lastNotificationAt = ? WHERE id = ?'
+        );
+        stmt.run(Date.now(), id);
+    }
+
+    /**
+     * Get best difficulty tracker for address
+     */
+    getBestDifficulty(address: string): BestDifficultyTracker | null {
+        const stmt = this.db.prepare(
+            'SELECT * FROM best_difficulty_tracker WHERE address = ?'
+        );
+        return stmt.get(address) as BestDifficultyTracker | null;
+    }
+
+    /**
+     * Update or create best difficulty tracker
+     */
+    updateBestDifficulty(address: string, difficulty: number): void {
+        const stmt = this.db.prepare(`
+            INSERT INTO best_difficulty_tracker (address, bestDifficulty, lastCheckedAt)
+            VALUES (?, ?, ?)
+            ON CONFLICT(address) DO UPDATE SET
+                bestDifficulty = excluded.bestDifficulty,
+                lastCheckedAt = excluded.lastCheckedAt
+        `);
+        stmt.run(address, difficulty, Date.now());
+    }
+}
+```
+
+---
+
+## Step 4: Create Push Notification Service
+
+Create `services/push-notification.service.ts`:
+
+```typescript
+import { PushRepository } from '../repositories/push.repository';
+import https from 'https';
+import http from 'http';
+import * as webpush from 'web-push';
+
+// Initialize VAPID if keys are configured
+const vapidPublicKey = process.env.VAPID_PUBLIC_KEY;
+const vapidPrivateKey = process.env.VAPID_PRIVATE_KEY;
+const vapidSubject = process.env.VAPID_SUBJECT || 'mailto:noreply@yourserver.com';
+
+const useVAPID = vapidPublicKey && vapidPrivateKey;
+
+if (useVAPID) {
+    webpush.setVapidDetails(vapidSubject, vapidPublicKey!, vapidPrivateKey!);
+    console.log('VAPID enabled for push notifications');
+} else {
+    console.log('VAPID disabled - using plain POST (ntfy compatible)');
+}
+
+const CHECK_INTERVAL_MS = 60000; // 60 seconds
+const MIN_NOTIFICATION_INTERVAL_MS = 300000; // 5 minutes
+let workerInterval: NodeJS.Timeout | null = null;
+
+/**
+ * Format difficulty number with suffix (T, G, M, K)
+ */
+function formatDifficulty(num: number): string {
+    if (num >= 1e12) return (num / 1e12).toFixed(2) + 'T';
+    if (num >= 1e9) return (num / 1e9).toFixed(2) + 'G';
+    if (num >= 1e6) return (num / 1e6).toFixed(2) + 'M';
+    if (num >= 1e3) return (num / 1e3).toFixed(2) + 'K';
+    return num.toString();
+}
+
+/**
+ * Send push notification using plain POST (ntfy-compatible)
+ */
+async function sendPlainPost(endpoint: string, message: string): Promise<boolean> {
+    return new Promise((resolve) => {
+        try {
+            const url = new URL(endpoint);
+            const isHttps = url.protocol === 'https:';
+            const client = isHttps ? https : http;
+
+            const options = {
+                hostname: url.hostname,
+                port: url.port || (isHttps ? 443 : 80),
+                path: url.pathname + url.search,
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'text/plain',
+                    'Content-Length': Buffer.byteLength(message)
+                }
+            };
+
+            const req = client.request(options, (res) => {
+                if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+                    resolve(true);
+                } else {
+                    console.error(`Push failed: HTTP ${res.statusCode}`);
+                    resolve(false);
+                }
+            });
+
+            req.on('error', (error) => {
+                console.error('Push error:', error.message);
+                resolve(false);
+            });
+
+            req.write(message);
+            req.end();
+        } catch (error: any) {
+            console.error('Push error:', error.message);
+            resolve(false);
+        }
+    });
+}
+
+/**
+ * Send push notification to UnifiedPush endpoint
+ * Supports both VAPID authentication (optional) and plain POST (fallback)
+ */
+async function sendPushNotification(
+    endpoint: string,
+    title: string,
+    body: string,
+    difficulty: string
+): Promise<boolean> {
+    // Message format: "title|body|difficulty"
+    const message = `${title}|${body}|${difficulty}`;
+
+    try {
+        if (useVAPID) {
+            // Use VAPID authentication (for future ntfy support)
+            await webpush.sendNotification(
+                { endpoint },
+                message,
+                {
+                    TTL: 3600,
+                    urgency: 'high'
+                }
+            );
+            console.log('Push sent (VAPID):', title);
+            return true;
+        } else {
+            // Fallback to plain POST (current ntfy support)
+            const success = await sendPlainPost(endpoint, message);
+            if (success) {
+                console.log('Push sent (plain):', title);
+            }
+            return success;
+        }
+    } catch (error: any) {
+        console.error('Push send error:', error.message);
+        return false;
+    }
+}
+
+/**
+ * Get client info from your existing API
+ * ADJUST THIS to match your actual client data structure
+ */
+async function getClientInfo(address: string): Promise<any> {
+    return new Promise((resolve) => {
+        try {
+            // IMPORTANT: Replace with your actual client data fetch logic
+            // This is just an example - adjust to your database schema
+
+            // Option 1: If you have a function to get client data
+            // const clientData = yourGetClientFunction(address);
+            // resolve(clientData);
+
+            // Option 2: If you need to query the database
+            // const stmt = db.prepare('SELECT * FROM clients WHERE address = ?');
+            // const client = stmt.get(address);
+            // resolve(client);
+
+            // Placeholder - REPLACE THIS
+            resolve(null);
+        } catch (error: any) {
+            console.error('Error getting client info:', error.message);
+            resolve(null);
+        }
+    });
+}
+
+/**
+ * Check best difficulty for all subscribed addresses
+ * Sends push notifications if difficulty has increased
+ */
+async function checkBestDifficulty(pushRepository: PushRepository): Promise<void> {
+    try {
+        const addresses = pushRepository.getAddressesWithSubscriptions();
+
+        if (addresses.length === 0) {
+            return;
+        }
+
+        console.log(`Checking best difficulty for ${addresses.length} addresses`);
+
+        for (const address of addresses) {
+            try {
+                // Get current client info
+                const clientInfo = await getClientInfo(address);
+                if (!clientInfo || !clientInfo.bestDifficulty) {
+                    continue;
+                }
+
+                const currentDifficulty = clientInfo.bestDifficulty;
+
+                // Get stored best difficulty
+                const tracker = pushRepository.getBestDifficulty(address);
+
+                // If no tracker exists, initialize it
+                if (!tracker) {
+                    pushRepository.updateBestDifficulty(address, currentDifficulty);
+                    continue;
+                }
+
+                // Check if difficulty has increased
+                if (currentDifficulty > tracker.bestDifficulty) {
+                    console.log(`Difficulty increased for ${address}: ${tracker.bestDifficulty} -> ${currentDifficulty}`);
+
+                    // Get subscriptions for this address
+                    const subscriptions = pushRepository.getByAddress(address);
+
+                    // Send push notification to all endpoints
+                    const title = 'New Best Difficulty!';
+                    const body = `Your best difficulty increased to ${formatDifficulty(currentDifficulty)}`;
+                    const difficultyStr = formatDifficulty(currentDifficulty);
+
+                    for (const subscription of subscriptions) {
+                        // Check rate limiting
+                        if (subscription.lastNotificationAt) {
+                            const timeSinceLastNotification = Date.now() - subscription.lastNotificationAt;
+                            if (timeSinceLastNotification < MIN_NOTIFICATION_INTERVAL_MS) {
+                                console.log(`Rate limited: ${address}`);
+                                continue;
+                            }
+                        }
+
+                        // Send push notification
+                        const success = await sendPushNotification(
+                            subscription.endpoint,
+                            title,
+                            body,
+                            difficultyStr
+                        );
+
+                        if (success) {
+                            pushRepository.updateLastNotification(subscription.id);
+                        }
+                    }
+
+                    // Update tracker with new best difficulty
+                    pushRepository.updateBestDifficulty(address, currentDifficulty);
+                }
+            } catch (error: any) {
+                console.error(`Error checking address ${address}:`, error.message);
+            }
+        }
+    } catch (error: any) {
+        console.error('Error in checkBestDifficulty:', error.message);
+    }
+}
+
+/**
+ * Start the push notification worker
+ */
+export function startPushNotificationWorker(pushRepository: PushRepository): void {
+    if (workerInterval) {
+        console.warn('Push worker already running');
+        return;
+    }
+
+    console.log(`Starting push notification worker (interval: ${CHECK_INTERVAL_MS}ms)`);
+
+    // Run immediately on start
+    checkBestDifficulty(pushRepository);
+
+    // Then run on interval
+    workerInterval = setInterval(() => {
+        checkBestDifficulty(pushRepository);
+    }, CHECK_INTERVAL_MS);
+}
+
+/**
+ * Stop the push notification worker
+ */
+export function stopPushNotificationWorker(): void {
+    if (workerInterval) {
+        clearInterval(workerInterval);
+        workerInterval = null;
+        console.log('Push notification worker stopped');
+    }
+}
+```
+
+---
+
+## Step 5: Create API Controller
+
+Create `controllers/push.controller.ts`:
+
+```typescript
+import { Request, Response } from 'express';
+import { PushRepository } from '../repositories/push.repository';
+
+export class PushController {
+    constructor(private pushRepository: PushRepository) {}
+
+    /**
+     * POST /push/register
+     * Register a new push subscription
+     */
+    register = (req: Request, res: Response): void => {
+        try {
+            const { address, endpoint, platform } = req.body;
+
+            // Validate input
+            if (!address || !endpoint) {
+                res.status(400).json({ error: 'Missing required fields: address, endpoint' });
+                return;
+            }
+
+            // Create subscription
+            const subscription = this.pushRepository.create(
+                address,
+                endpoint,
+                platform || 'unknown'
+            );
+
+            console.log(`Push subscription registered: ${address} -> ${endpoint}`);
+
+            res.status(201).json({
+                success: true,
+                subscription: {
+                    id: subscription.id,
+                    address: subscription.address,
+                    platform: subscription.platform,
+                    createdAt: subscription.createdAt
+                }
+            });
+        } catch (error: any) {
+            console.error('Error registering push subscription:', error);
+            res.status(500).json({ error: 'Failed to register push subscription' });
+        }
+    };
+
+    /**
+     * POST /push/unregister
+     * Unregister from push notifications
+     */
+    unregister = (req: Request, res: Response): void => {
+        try {
+            const { address, endpoint } = req.body;
+
+            // Validate input
+            if (!address) {
+                res.status(400).json({ error: 'Missing required field: address' });
+                return;
+            }
+
+            // Delete subscription(s)
+            if (endpoint) {
+                this.pushRepository.delete(address, endpoint);
+            } else {
+                this.pushRepository.deleteByAddress(address);
+            }
+
+            console.log(`Push subscription unregistered: ${address}`);
+
+            res.json({ success: true });
+        } catch (error: any) {
+            console.error('Error unregistering push subscription:', error);
+            res.status(500).json({ error: 'Failed to unregister push subscription' });
+        }
+    };
+
+    /**
+     * GET /push/status/:address
+     * Get subscription status for an address
+     */
+    getStatus = (req: Request, res: Response): void => {
+        try {
+            const { address } = req.params;
+
+            const subscriptions = this.pushRepository.getByAddress(address);
+            const tracker = this.pushRepository.getBestDifficulty(address);
+
+            res.json({
+                address,
+                subscriptionCount: subscriptions.length,
+                subscriptions: subscriptions.map(s => ({
+                    id: s.id,
+                    platform: s.platform,
+                    createdAt: s.createdAt,
+                    lastNotificationAt: s.lastNotificationAt
+                })),
+                tracker: tracker ? {
+                    bestDifficulty: tracker.bestDifficulty,
+                    lastCheckedAt: tracker.lastCheckedAt
+                } : null
+            });
+        } catch (error: any) {
+            console.error('Error getting push status:', error);
+            res.status(500).json({ error: 'Failed to get push status' });
+        }
+    };
+}
+```
+
+---
+
+## Step 6: Integrate into Express App
+
+Update your main server file (e.g., `app.ts` or `server.ts`):
+
+```typescript
+import express from 'express';
+import Database from 'better-sqlite3';
+import { PushRepository } from './repositories/push.repository';
+import { PushController } from './controllers/push.controller';
+import { startPushNotificationWorker } from './services/push-notification.service';
+
+const app = express();
+const db = new Database('your-database.db'); // Your existing database
+
+// Middleware
+app.use(express.json());
+
+// Initialize Push Repository
+const pushRepository = new PushRepository(db);
+const pushController = new PushController(pushRepository);
+
+// Push Notification Routes
+app.post('/push/register', pushController.register);
+app.post('/push/unregister', pushController.unregister);
+app.get('/push/status/:address', pushController.getStatus);
+
+// Start background worker
+startPushNotificationWorker(pushRepository);
+
+// ... rest of your server setup
+
+const PORT = process.env.PORT || 3334;
+app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+});
+```
+
+---
+
+## Step 7: Configure Environment Variables
+
+Create `.env` file in your server root:
+
+```bash
+# Optional VAPID Configuration for UnifiedPush
+# Leave commented out to use plain POST (ntfy compatible)
+# Uncomment when ntfy adds VAPID support
+
+#VAPID_PUBLIC_KEY=BD_HH99NfIBL28rZeP9zujOkB5lZxF188gfk1XRVtF-rgPR6clF81uJwQnAT1geL6O2NdBzanQeY1_ojmHfCzfo
+#VAPID_PRIVATE_KEY=PnkVfs1p_yqdkrnTY7K-oLuFFLUkfXpATophp8ZLu2A
+#VAPID_SUBJECT=mailto:admin@yourserver.com
+```
+
+**To generate VAPID keys (when needed):**
+```bash
+npx web-push generate-vapid-keys
+```
+
+---
+
+## Step 8: Update .gitignore
+
+Ensure `.env` is gitignored:
+
+```bash
+echo ".env" >> .gitignore
+```
+
+---
+
+## Critical Configuration Points
+
+### 1. Client Data Integration
+
+In `push-notification.service.ts`, you **MUST** update the `getClientInfo()` function to match your actual data structure:
+
+```typescript
+async function getClientInfo(address: string): Promise<any> {
+    // REPLACE THIS with your actual client data fetch logic
+    // Example: Query your database for client stats
+    const stmt = db.prepare('SELECT * FROM clients WHERE address = ?');
+    const client = stmt.get(address);
+
+    // Make sure it returns an object with bestDifficulty property
+    return client;
+}
+```
+
+### 2. Database Connection
+
+Make sure the `PushRepository` receives your existing database instance:
+
+```typescript
+const db = new Database('path/to/your/stratum.db');
+const pushRepository = new PushRepository(db);
+```
+
+### 3. CORS (if needed)
+
+If your UI is on a different domain, add CORS:
+
+```typescript
+import cors from 'cors';
+
+app.use(cors({
+    origin: 'https://blitzpool.yourdevice.ch',
+    credentials: true
+}));
+```
+
+---
+
+## Testing
+
+### 1. Test API Endpoints
+
+```bash
+# Register subscription
+curl -X POST http://localhost:3334/push/register \
+  -H "Content-Type: application/json" \
+  -d '{"address":"your_btc_address","endpoint":"https://ntfy.yourdevice.ch/test","platform":"android"}'
+
+# Check status
+curl http://localhost:3334/push/status/your_btc_address
+
+# Unregister
+curl -X POST http://localhost:3334/push/unregister \
+  -H "Content-Type: application/json" \
+  -d '{"address":"your_btc_address"}'
+```
+
+### 2. Test Manual Notification
+
+```bash
+curl -X POST https://ntfy.yourdevice.ch/your_topic \
+  -H "Content-Type: text/plain" \
+  -d "Test Title|Test body|1.5T"
+```
+
+---
+
+## File Structure
+
+Your server directory should look like:
+
+```
+your-stratum-server/
+├── controllers/
+│   └── push.controller.ts
+├── repositories/
+│   └── push.repository.ts
+├── services/
+│   └── push-notification.service.ts
+├── app.ts (or server.ts)
+├── database.db
+├── .env
+├── .gitignore
+└── package.json
+```
+
+---
+
+## Monitoring
+
+Add logging to track the worker:
+
+```typescript
+// In push-notification.service.ts
+console.log(`Checking best difficulty for ${addresses.length} addresses`);
+console.log(`Difficulty increased for ${address}: ${old} -> ${new}`);
+console.log(`Push sent successfully to ${endpoint}`);
+```
+
+Check logs to verify:
+- Worker is running every 60 seconds
+- Subscriptions are being checked
+- Notifications are sent when difficulty increases
+
+---
+
+## Troubleshooting
+
+### Worker Not Running
+- Check server logs for "Starting push notification worker"
+- Verify `startPushNotificationWorker()` is called in app initialization
+
+### No Notifications Sent
+- Check that `getClientInfo()` returns valid data with `bestDifficulty` property
+- Verify subscriptions exist in database: `SELECT * FROM push_subscriptions;`
+- Check rate limiting (5 min between notifications per address)
+
+### Database Errors
+- Ensure tables are created before server starts
+- Check database file permissions
+- Verify `better-sqlite3` is installed
+
+---
+
+## Next Steps
+
+After setting this up on your stratum server:
+1. Test all 3 endpoints (`/push/register`, `/push/unregister`, `/push/status/:address`)
+2. Verify background worker starts and runs
+3. Test end-to-end notification flow
+4. Monitor logs for any errors
+5. Once confirmed working, we'll remove these files from the UI repo
+
+---
+
+## Security Notes
+
+- ✅ `.env` is gitignored (VAPID keys are secret)
+- ✅ Input validation on all endpoints
+- ✅ Rate limiting prevents notification spam
+- ✅ No sensitive data in notifications (only difficulty numbers)
+- ⚠️ Consider adding authentication to endpoints in production
+- ⚠️ Consider HTTPS for all push endpoints
+
+---
+
+## Support
+
+If you encounter issues:
+1. Check server logs for errors
+2. Verify database tables exist
+3. Test endpoints individually with curl
+4. Ensure `getClientInfo()` returns correct data structure
+5. Check that addresses in subscriptions match your client database
+
+---
+
+**End of Setup Guide**

--- a/full-setup/blitzpool-example.env
+++ b/full-setup/blitzpool-example.env
@@ -34,6 +34,14 @@ NTFY_ACCESS_TOKEN=
 NTFY_TOPIC_PREFIX=
 NTFY_DIFF_NOTIFICATIONS=false
 
+#optional UnifiedPush server (VAPID support)
+# Leave commented out to use plain POST (ntfy compatible)
+# Uncomment when ntfy adds VAPID support
+# To generate keys: npx web-push generate-vapid-keys
+#VAPID_PUBLIC_KEY=
+#VAPID_PRIVATE_KEY=
+#VAPID_SUBJECT=mailto:admin@yourserver.com
+
 #optional discord bot
 #DISCORD_BOT_CLIENTID=
 #DISCORD_BOT_GUILD_ID=

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blitzpool",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "blitzpool",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
@@ -42,6 +42,7 @@
         "sqlite3": "^5.1.6",
         "tiny-secp256k1": "^2.2.3",
         "typeorm": "^0.3.17",
+        "web-push": "^3.6.7",
         "zeromq": "6.0.0-beta.19"
       },
       "devDependencies": {
@@ -3294,6 +3295,18 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -3845,6 +3858,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-equals": {
       "version": "1.0.4",
@@ -4784,6 +4803,15 @@
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -6344,6 +6372,15 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -7890,6 +7927,27 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/klaw-sync": {
@@ -11925,6 +11983,47 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/web-push/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/web-push/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -14726,6 +14825,17 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -15150,6 +15260,11 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "buffer-equals": {
       "version": "1.0.4",
@@ -15848,6 +15963,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "electron-to-chromium": {
@@ -17026,6 +17149,11 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA=="
+    },
     "http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -18173,6 +18301,25 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.4.0",
         "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "requires": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "requires": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "klaw-sync": {
@@ -21043,6 +21190,34 @@
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
+      }
+    },
+    "web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "requires": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+          "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
+        },
+        "https-proxy-agent": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+          "requires": {
+            "agent-base": "^7.1.2",
+            "debug": "4"
+          }
+        }
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "bs58": "^5.0.0",
     "cache-manager": "^5.2.3",
     "cache-manager-redis-yet": "^4.1.2",
-    "redis": "^4.6.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "discord.js": "^14.11.0",
@@ -48,12 +47,14 @@
     "node-telegram-bot-api": "^0.61.0",
     "pg": "^8.11.3",
     "prom-client": "^15.1.0",
+    "redis": "^4.6.0",
     "reflect-metadata": "^0.1.13",
     "rpc-bitcoin": "^2.0.0",
     "rxjs": "^7.2.0",
     "sqlite3": "^5.1.6",
     "tiny-secp256k1": "^2.2.3",
     "typeorm": "^0.3.17",
+    "web-push": "^3.6.7",
     "zeromq": "6.0.0-beta.19"
   },
   "devDependencies": {

--- a/src/ORM/best-difficulty-tracker/best-difficulty-tracker.entity.ts
+++ b/src/ORM/best-difficulty-tracker/best-difficulty-tracker.entity.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+import { TrackedEntity } from '../utils/TrackedEntity.entity';
+
+@Entity()
+export class BestDifficultyTrackerEntity extends TrackedEntity {
+
+    @PrimaryColumn({ length: 62, type: 'varchar' })
+    address: string;
+
+    @Column({ type: 'real' })
+    bestDifficulty: number;
+
+    @Column({ type: 'bigint' })
+    lastCheckedAt: number;
+}

--- a/src/ORM/best-difficulty-tracker/best-difficulty-tracker.module.ts
+++ b/src/ORM/best-difficulty-tracker/best-difficulty-tracker.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { BestDifficultyTrackerEntity } from './best-difficulty-tracker.entity';
+import { BestDifficultyTrackerService } from './best-difficulty-tracker.service';
+
+
+@Global()
+@Module({
+    imports: [TypeOrmModule.forFeature([BestDifficultyTrackerEntity])],
+    providers: [BestDifficultyTrackerService],
+    exports: [TypeOrmModule, BestDifficultyTrackerService],
+})
+export class BestDifficultyTrackerModule { }

--- a/src/ORM/best-difficulty-tracker/best-difficulty-tracker.service.ts
+++ b/src/ORM/best-difficulty-tracker/best-difficulty-tracker.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { BestDifficultyTrackerEntity } from './best-difficulty-tracker.entity';
+
+@Injectable()
+export class BestDifficultyTrackerService {
+
+    constructor(
+        @InjectRepository(BestDifficultyTrackerEntity)
+        private trackerRepository: Repository<BestDifficultyTrackerEntity>
+    ) {}
+
+    /**
+     * Get tracker for address
+     */
+    public async getTracker(address: string): Promise<BestDifficultyTrackerEntity | null> {
+        return await this.trackerRepository.findOne({
+            where: { address }
+        });
+    }
+
+    /**
+     * Update or create tracker (upsert)
+     */
+    public async updateTracker(address: string, bestDifficulty: number): Promise<void> {
+        const existing = await this.trackerRepository.findOne({
+            where: { address }
+        });
+
+        if (existing) {
+            existing.bestDifficulty = bestDifficulty;
+            existing.lastCheckedAt = Date.now();
+            await this.trackerRepository.save(existing);
+        } else {
+            const newTracker = this.trackerRepository.create({
+                address,
+                bestDifficulty,
+                lastCheckedAt: Date.now()
+            });
+            await this.trackerRepository.save(newTracker);
+        }
+    }
+
+    /**
+     * Get all trackers (for monitoring)
+     */
+    public async getAllTrackers(): Promise<BestDifficultyTrackerEntity[]> {
+        return await this.trackerRepository.find();
+    }
+}

--- a/src/ORM/push-subscriptions/push-subscription.entity.ts
+++ b/src/ORM/push-subscriptions/push-subscription.entity.ts
@@ -1,0 +1,24 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+import { TrackedEntity } from '../utils/TrackedEntity.entity';
+
+@Entity()
+@Index(['address', 'endpoint'], { unique: true })
+export class PushSubscriptionEntity extends TrackedEntity {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Index()
+    @Column({ length: 62, type: 'varchar' })
+    address: string;
+
+    @Column({ type: 'text' })
+    endpoint: string;
+
+    @Column({ default: 'unknown' })
+    platform: string;
+
+    @Column({ type: 'bigint', nullable: true })
+    lastNotificationAt: number;
+}

--- a/src/ORM/push-subscriptions/push-subscription.entity.ts
+++ b/src/ORM/push-subscriptions/push-subscription.entity.ts
@@ -22,7 +22,7 @@ export class PushSubscriptionEntity extends TrackedEntity {
     @Column({ type: 'bigint', nullable: true })
     lastNotificationAt: number;
 
-    @Column({ default: true })
+    @Column({ default: false })
     bestDiffNotificationsEnabled: boolean;
 
     @Column({ default: false })

--- a/src/ORM/push-subscriptions/push-subscription.entity.ts
+++ b/src/ORM/push-subscriptions/push-subscription.entity.ts
@@ -21,4 +21,10 @@ export class PushSubscriptionEntity extends TrackedEntity {
 
     @Column({ type: 'bigint', nullable: true })
     lastNotificationAt: number;
+
+    @Column({ default: false })
+    deviceNotificationsEnabled: boolean;
+
+    @Column({ default: false })
+    blockNotificationsEnabled: boolean;
 }

--- a/src/ORM/push-subscriptions/push-subscription.entity.ts
+++ b/src/ORM/push-subscriptions/push-subscription.entity.ts
@@ -22,6 +22,9 @@ export class PushSubscriptionEntity extends TrackedEntity {
     @Column({ type: 'bigint', nullable: true })
     lastNotificationAt: number;
 
+    @Column({ default: true })
+    bestDiffNotificationsEnabled: boolean;
+
     @Column({ default: false })
     deviceNotificationsEnabled: boolean;
 

--- a/src/ORM/push-subscriptions/push-subscription.module.ts
+++ b/src/ORM/push-subscriptions/push-subscription.module.ts
@@ -1,0 +1,14 @@
+import { Global, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { PushSubscriptionEntity } from './push-subscription.entity';
+import { PushSubscriptionService } from './push-subscription.service';
+
+
+@Global()
+@Module({
+    imports: [TypeOrmModule.forFeature([PushSubscriptionEntity])],
+    providers: [PushSubscriptionService],
+    exports: [TypeOrmModule, PushSubscriptionService],
+})
+export class PushSubscriptionModule { }

--- a/src/ORM/push-subscriptions/push-subscription.service.ts
+++ b/src/ORM/push-subscriptions/push-subscription.service.ts
@@ -77,4 +77,42 @@ export class PushSubscriptionService {
     public async updateLastNotification(id: number, timestamp: number): Promise<void> {
         await this.pushSubscriptionRepository.update({ id }, { lastNotificationAt: timestamp });
     }
+
+    /**
+     * Update notification preferences for a subscription
+     */
+    public async updateNotificationPreferences(
+        address: string,
+        endpoint: string,
+        deviceNotifications?: boolean,
+        blockNotifications?: boolean
+    ): Promise<void> {
+        const updates: any = {};
+        if (deviceNotifications !== undefined) {
+            updates.deviceNotificationsEnabled = deviceNotifications;
+        }
+        if (blockNotifications !== undefined) {
+            updates.blockNotificationsEnabled = blockNotifications;
+        }
+
+        await this.pushSubscriptionRepository.update({ address, endpoint }, updates);
+    }
+
+    /**
+     * Get subscriptions with device notifications enabled
+     */
+    public async getByAddressWithDeviceNotifications(address: string): Promise<PushSubscriptionEntity[]> {
+        return await this.pushSubscriptionRepository.find({
+            where: { address, deviceNotificationsEnabled: true }
+        });
+    }
+
+    /**
+     * Get subscriptions with block notifications enabled
+     */
+    public async getByAddressWithBlockNotifications(address: string): Promise<PushSubscriptionEntity[]> {
+        return await this.pushSubscriptionRepository.find({
+            where: { address, blockNotificationsEnabled: true }
+        });
+    }
 }

--- a/src/ORM/push-subscriptions/push-subscription.service.ts
+++ b/src/ORM/push-subscriptions/push-subscription.service.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { PushSubscriptionEntity } from './push-subscription.entity';
+
+@Injectable()
+export class PushSubscriptionService {
+
+    constructor(
+        @InjectRepository(PushSubscriptionEntity)
+        private pushSubscriptionRepository: Repository<PushSubscriptionEntity>
+    ) {}
+
+    /**
+     * Create or update a push subscription (upsert)
+     */
+    public async createOrUpdate(address: string, endpoint: string, platform: string): Promise<PushSubscriptionEntity> {
+        // Try to find existing subscription
+        let subscription = await this.pushSubscriptionRepository.findOne({
+            where: { address, endpoint }
+        });
+
+        if (subscription) {
+            // Update existing subscription
+            subscription.platform = platform;
+            return await this.pushSubscriptionRepository.save(subscription);
+        } else {
+            // Create new subscription
+            const newSubscription = this.pushSubscriptionRepository.create({
+                address,
+                endpoint,
+                platform
+            });
+            return await this.pushSubscriptionRepository.save(newSubscription);
+        }
+    }
+
+    /**
+     * Delete subscription by address and endpoint
+     */
+    public async delete(address: string, endpoint: string): Promise<void> {
+        await this.pushSubscriptionRepository.delete({ address, endpoint });
+    }
+
+    /**
+     * Delete all subscriptions for an address
+     */
+    public async deleteByAddress(address: string): Promise<void> {
+        await this.pushSubscriptionRepository.delete({ address });
+    }
+
+    /**
+     * Get all subscriptions for an address
+     */
+    public async getByAddress(address: string): Promise<PushSubscriptionEntity[]> {
+        return await this.pushSubscriptionRepository.find({
+            where: { address }
+        });
+    }
+
+    /**
+     * Get all unique addresses with subscriptions
+     */
+    public async getAddressesWithSubscriptions(): Promise<string[]> {
+        const result = await this.pushSubscriptionRepository
+            .createQueryBuilder('subscription')
+            .select('DISTINCT subscription.address', 'address')
+            .getRawMany();
+
+        return result.map(row => row.address);
+    }
+
+    /**
+     * Update last notification timestamp
+     */
+    public async updateLastNotification(id: number, timestamp: number): Promise<void> {
+        await this.pushSubscriptionRepository.update({ id }, { lastNotificationAt: timestamp });
+    }
+}

--- a/src/ORM/push-subscriptions/push-subscription.service.ts
+++ b/src/ORM/push-subscriptions/push-subscription.service.ts
@@ -84,10 +84,14 @@ export class PushSubscriptionService {
     public async updateNotificationPreferences(
         address: string,
         endpoint: string,
+        bestDiffNotifications?: boolean,
         deviceNotifications?: boolean,
         blockNotifications?: boolean
     ): Promise<void> {
         const updates: any = {};
+        if (bestDiffNotifications !== undefined) {
+            updates.bestDiffNotificationsEnabled = bestDiffNotifications;
+        }
         if (deviceNotifications !== undefined) {
             updates.deviceNotificationsEnabled = deviceNotifications;
         }
@@ -96,6 +100,15 @@ export class PushSubscriptionService {
         }
 
         await this.pushSubscriptionRepository.update({ address, endpoint }, updates);
+    }
+
+    /**
+     * Get subscriptions with best difficulty notifications enabled
+     */
+    public async getByAddressWithBestDiffNotifications(address: string): Promise<PushSubscriptionEntity[]> {
+        return await this.pushSubscriptionRepository.find({
+            where: { address, bestDiffNotificationsEnabled: true }
+        });
     }
 
     /**

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,8 @@ import { ClientModule } from './ORM/client/client.module';
 import { RpcBlocksModule } from './ORM/rpc-block/rpc-block.module';
 import { TelegramSubscriptionsModule } from './ORM/telegram-subscriptions/telegram-subscriptions.module';
 import { NtfySubscriptionsModule } from './ORM/ntfy-subscriptions/ntfy-subscriptions.module';
+import { PushSubscriptionModule } from './ORM/push-subscriptions/push-subscription.module';
+import { BestDifficultyTrackerModule } from './ORM/best-difficulty-tracker/best-difficulty-tracker.module';
 import { AppService } from './services/app.service';
 import { BitcoinRpcService } from './services/bitcoin-rpc.service';
 import { BraiinsService } from './services/braiins.service';
@@ -36,7 +38,9 @@ import { AggregationService } from './services/aggregation.service';
 import { MetricsService } from './services/metrics.service';
 import { WorkerPoolService } from './services/worker-pool.service';
 import { TimeslotMigrationService } from './services/timeslot-migration.service';
+import { PushNotificationService } from './services/push-notification.service';
 import { ExternalShareController } from './controllers/external-share/external-share.controller';
+import { PushController } from './controllers/push/push.controller';
 import { ExternalSharesModule } from './ORM/external-shares/external-shares.module';
 import { PoolShareStatisticsModule } from './ORM/pool-share-statistics/pool-share-statistics.module';
 import { PoolRejectedStatisticsModule } from './ORM/pool-rejected-statistics/pool-rejected-statistics.module';
@@ -50,6 +54,8 @@ const ORMModules = [
     AddressSettingsModule,
     TelegramSubscriptionsModule,
     NtfySubscriptionsModule,
+    PushSubscriptionModule,
+    BestDifficultyTrackerModule,
     BlocksModule,
     RpcBlocksModule,
     ExternalSharesModule,
@@ -113,7 +119,8 @@ const ORMModules = [
         AppController,
         ClientController,
         AddressController,
-        ExternalShareController
+        ExternalShareController,
+        PushController
     ],
     providers: [
         TimeslotMigrationService, // Must run first on startup
@@ -122,6 +129,7 @@ const ORMModules = [
         StratumV1Service,
         TelegramService,
         NtfyService,
+        PushNotificationService,
         BitcoinRpcService,
         NotificationService,
         BitcoinAddressValidator,

--- a/src/controllers/push/push.controller.ts
+++ b/src/controllers/push/push.controller.ts
@@ -1,0 +1,106 @@
+import { Controller, Get, Post, Param, Body, BadRequestException } from '@nestjs/common';
+import { PushSubscriptionService } from '../../ORM/push-subscriptions/push-subscription.service';
+import { BestDifficultyTrackerService } from '../../ORM/best-difficulty-tracker/best-difficulty-tracker.service';
+
+@Controller('push')
+export class PushController {
+    constructor(
+        private readonly pushSubscriptionService: PushSubscriptionService,
+        private readonly trackerService: BestDifficultyTrackerService,
+    ) {}
+
+    /**
+     * POST /api/push/register
+     * Register a new push subscription
+     */
+    @Post('register')
+    async register(@Body() body: { address: string; endpoint: string; platform?: string }) {
+        const { address, endpoint, platform = 'unknown' } = body;
+
+        if (!address || !endpoint) {
+            throw new BadRequestException('Missing required fields: address, endpoint');
+        }
+
+        try {
+            const subscription = await this.pushSubscriptionService.createOrUpdate(
+                address,
+                endpoint,
+                platform
+            );
+
+            console.log(`[PushController] Push subscription registered: ${address} -> ${endpoint}`);
+
+            return {
+                success: true,
+                subscription: {
+                    id: subscription.id,
+                    address: subscription.address,
+                    platform: subscription.platform,
+                    createdAt: subscription.createdAt
+                }
+            };
+        } catch (error: any) {
+            console.error('[PushController] Error registering push subscription:', error);
+            throw new BadRequestException('Failed to register push subscription');
+        }
+    }
+
+    /**
+     * POST /api/push/unregister
+     * Unregister from push notifications
+     */
+    @Post('unregister')
+    async unregister(@Body() body: { address: string; endpoint?: string }) {
+        const { address, endpoint } = body;
+
+        if (!address) {
+            throw new BadRequestException('Missing required field: address');
+        }
+
+        try {
+            if (endpoint) {
+                await this.pushSubscriptionService.delete(address, endpoint);
+                console.log(`[PushController] Push subscription unregistered: ${address} -> ${endpoint}`);
+            } else {
+                await this.pushSubscriptionService.deleteByAddress(address);
+                console.log(`[PushController] All push subscriptions unregistered for: ${address}`);
+            }
+
+            return { success: true };
+        } catch (error: any) {
+            console.error('[PushController] Error unregistering push subscription:', error);
+            throw new BadRequestException('Failed to unregister push subscription');
+        }
+    }
+
+    /**
+     * GET /api/push/status/:address
+     * Get subscription status for an address
+     */
+    @Get('status/:address')
+    async getStatus(@Param('address') address: string) {
+        try {
+            const subscriptions = await this.pushSubscriptionService.getByAddress(address);
+            const tracker = await this.trackerService.getTracker(address);
+
+            return {
+                address,
+                subscriptionCount: subscriptions.length,
+                subscriptions: subscriptions.map(s => ({
+                    id: s.id,
+                    platform: s.platform,
+                    endpoint: s.endpoint,
+                    createdAt: s.createdAt,
+                    lastNotificationAt: s.lastNotificationAt
+                })),
+                tracker: tracker ? {
+                    bestDifficulty: tracker.bestDifficulty,
+                    lastCheckedAt: tracker.lastCheckedAt
+                } : null
+            };
+        } catch (error: any) {
+            console.error('[PushController] Error getting push status:', error);
+            throw new BadRequestException('Failed to get push status');
+        }
+    }
+}

--- a/src/controllers/push/push.controller.ts
+++ b/src/controllers/push/push.controller.ts
@@ -91,7 +91,9 @@ export class PushController {
                     platform: s.platform,
                     endpoint: s.endpoint,
                     createdAt: s.createdAt,
-                    lastNotificationAt: s.lastNotificationAt
+                    lastNotificationAt: s.lastNotificationAt,
+                    deviceNotificationsEnabled: s.deviceNotificationsEnabled,
+                    blockNotificationsEnabled: s.blockNotificationsEnabled
                 })),
                 tracker: tracker ? {
                     bestDifficulty: tracker.bestDifficulty,
@@ -101,6 +103,40 @@ export class PushController {
         } catch (error: any) {
             console.error('[PushController] Error getting push status:', error);
             throw new BadRequestException('Failed to get push status');
+        }
+    }
+
+    /**
+     * POST /api/push/configure
+     * Configure notification preferences for a subscription
+     */
+    @Post('configure')
+    async configure(@Body() body: {
+        address: string;
+        endpoint: string;
+        deviceNotifications?: boolean;
+        blockNotifications?: boolean;
+    }) {
+        const { address, endpoint, deviceNotifications, blockNotifications } = body;
+
+        if (!address || !endpoint) {
+            throw new BadRequestException('Missing required fields: address, endpoint');
+        }
+
+        try {
+            await this.pushSubscriptionService.updateNotificationPreferences(
+                address,
+                endpoint,
+                deviceNotifications,
+                blockNotifications
+            );
+
+            console.log(`[PushController] Updated notification preferences for ${address} -> ${endpoint}`);
+
+            return { success: true };
+        } catch (error: any) {
+            console.error('[PushController] Error configuring push notifications:', error);
+            throw new BadRequestException('Failed to configure push notifications');
         }
     }
 }

--- a/src/controllers/push/push.controller.ts
+++ b/src/controllers/push/push.controller.ts
@@ -92,6 +92,7 @@ export class PushController {
                     endpoint: s.endpoint,
                     createdAt: s.createdAt,
                     lastNotificationAt: s.lastNotificationAt,
+                    bestDiffNotificationsEnabled: s.bestDiffNotificationsEnabled,
                     deviceNotificationsEnabled: s.deviceNotificationsEnabled,
                     blockNotificationsEnabled: s.blockNotificationsEnabled
                 })),
@@ -114,10 +115,11 @@ export class PushController {
     async configure(@Body() body: {
         address: string;
         endpoint: string;
+        bestDiffNotifications?: boolean;
         deviceNotifications?: boolean;
         blockNotifications?: boolean;
     }) {
-        const { address, endpoint, deviceNotifications, blockNotifications } = body;
+        const { address, endpoint, bestDiffNotifications, deviceNotifications, blockNotifications } = body;
 
         if (!address || !endpoint) {
             throw new BadRequestException('Missing required fields: address, endpoint');
@@ -127,6 +129,7 @@ export class PushController {
             await this.pushSubscriptionService.updateNotificationPreferences(
                 address,
                 endpoint,
+                bestDiffNotifications,
                 deviceNotifications,
                 blockNotifications
             );

--- a/src/migrations/1734192000000-CreatePushNotifications.ts
+++ b/src/migrations/1734192000000-CreatePushNotifications.ts
@@ -19,6 +19,8 @@ export class CreatePushNotifications1734192000000 implements MigrationInterface 
                 "endpoint" text NOT NULL,
                 "platform" character varying NOT NULL DEFAULT 'unknown',
                 "lastNotificationAt" bigint,
+                "deviceNotificationsEnabled" boolean NOT NULL DEFAULT false,
+                "blockNotificationsEnabled" boolean NOT NULL DEFAULT false,
                 CONSTRAINT "UQ_push_subscription_address_endpoint" UNIQUE ("address", "endpoint"),
                 CONSTRAINT "PK_push_subscription_entity" PRIMARY KEY ("id")
             )

--- a/src/migrations/1734192000000-CreatePushNotifications.ts
+++ b/src/migrations/1734192000000-CreatePushNotifications.ts
@@ -19,6 +19,7 @@ export class CreatePushNotifications1734192000000 implements MigrationInterface 
                 "endpoint" text NOT NULL,
                 "platform" character varying NOT NULL DEFAULT 'unknown',
                 "lastNotificationAt" bigint,
+                "bestDiffNotificationsEnabled" boolean NOT NULL DEFAULT true,
                 "deviceNotificationsEnabled" boolean NOT NULL DEFAULT false,
                 "blockNotificationsEnabled" boolean NOT NULL DEFAULT false,
                 CONSTRAINT "UQ_push_subscription_address_endpoint" UNIQUE ("address", "endpoint"),

--- a/src/migrations/1734192000000-CreatePushNotifications.ts
+++ b/src/migrations/1734192000000-CreatePushNotifications.ts
@@ -19,7 +19,7 @@ export class CreatePushNotifications1734192000000 implements MigrationInterface 
                 "endpoint" text NOT NULL,
                 "platform" character varying NOT NULL DEFAULT 'unknown',
                 "lastNotificationAt" bigint,
-                "bestDiffNotificationsEnabled" boolean NOT NULL DEFAULT true,
+                "bestDiffNotificationsEnabled" boolean NOT NULL DEFAULT false,
                 "deviceNotificationsEnabled" boolean NOT NULL DEFAULT false,
                 "blockNotificationsEnabled" boolean NOT NULL DEFAULT false,
                 CONSTRAINT "UQ_push_subscription_address_endpoint" UNIQUE ("address", "endpoint"),

--- a/src/migrations/1734192000000-CreatePushNotifications.ts
+++ b/src/migrations/1734192000000-CreatePushNotifications.ts
@@ -1,0 +1,66 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreatePushNotifications1734192000000 implements MigrationInterface {
+    name = 'CreatePushNotifications1734192000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (queryRunner.connection.options.type !== 'postgres') {
+            return;
+        }
+
+        // 1. Create the push_subscription_entity table
+        await queryRunner.query(`
+            CREATE TABLE "push_subscription_entity" (
+                "deletedAt" TIMESTAMP WITH TIME ZONE,
+                "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "id" SERIAL NOT NULL,
+                "address" character varying(62) NOT NULL,
+                "endpoint" text NOT NULL,
+                "platform" character varying NOT NULL DEFAULT 'unknown',
+                "lastNotificationAt" bigint,
+                CONSTRAINT "UQ_push_subscription_address_endpoint" UNIQUE ("address", "endpoint"),
+                CONSTRAINT "PK_push_subscription_entity" PRIMARY KEY ("id")
+            )
+        `);
+
+        // 2. Create index on address
+        await queryRunner.query(`
+            CREATE INDEX "IDX_push_subscription_address" ON "push_subscription_entity" ("address")
+        `);
+
+        // 3. Create the best_difficulty_tracker_entity table
+        await queryRunner.query(`
+            CREATE TABLE "best_difficulty_tracker_entity" (
+                "deletedAt" TIMESTAMP WITH TIME ZONE,
+                "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "address" character varying(62) NOT NULL,
+                "bestDifficulty" double precision NOT NULL,
+                "lastCheckedAt" bigint NOT NULL,
+                CONSTRAINT "PK_best_difficulty_tracker_entity" PRIMARY KEY ("address")
+            )
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (queryRunner.connection.options.type !== 'postgres') {
+            return;
+        }
+
+        // 1. Drop best_difficulty_tracker_entity table
+        await queryRunner.query(`
+            DROP TABLE "best_difficulty_tracker_entity"
+        `);
+
+        // 2. Drop index
+        await queryRunner.query(`
+            DROP INDEX "IDX_push_subscription_address"
+        `);
+
+        // 3. Drop push_subscription_entity table
+        await queryRunner.query(`
+            DROP TABLE "push_subscription_entity"
+        `);
+    }
+}

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -4,6 +4,7 @@ import { Block } from 'bitcoinjs-lib';
 import { DiscordService } from './discord.service';
 import { TelegramService } from './telegram.service';
 import { NtfyService } from './ntfy.service';
+import { PushNotificationService } from './push-notification.service';
 
 
 @Injectable()
@@ -14,6 +15,7 @@ export class NotificationService implements OnModuleInit {
         private readonly telegramService: TelegramService,
         private readonly discordService: DiscordService,
         private readonly ntfyService: NtfyService,
+        private readonly pushNotificationService: PushNotificationService,
     ) { }
 
     async onModuleInit(): Promise<void> {
@@ -24,6 +26,7 @@ export class NotificationService implements OnModuleInit {
         await this.discordService.notifySubscribersBlockFound(height, block, message);
         await this.telegramService.notifySubscribersBlockFound(address, height, block, message);
         await this.ntfyService.notifySubscribersBlockFound(address, height, block, message);
+        await this.pushNotificationService.notifySubscribersBlockFound(address, height, block, message);
     }
 
     public async notifySubscribersBestDiff(address: string, submissionDifficulty: number) {
@@ -42,5 +45,6 @@ export class NotificationService implements OnModuleInit {
         isReturning?: boolean;
     }): Promise<void> {
         await this.telegramService.notifyDeviceStatusChange(params);
+        await this.pushNotificationService.notifyDeviceStatusChange(params);
     }
 }

--- a/src/services/push-notification.service.ts
+++ b/src/services/push-notification.service.ts
@@ -94,9 +94,9 @@ export class PushNotificationService implements OnModuleInit {
         // Message format: "title|body|difficulty" (pipe-separated, ntfy compatible)
         const message = `${title}|${body}|${difficulty}`;
 
-        try {
-            if (this.useVAPID) {
-                // Use VAPID authentication
+        // Try VAPID first if configured
+        if (this.useVAPID) {
+            try {
                 await webpush.sendNotification(
                     { endpoint },
                     message,
@@ -105,15 +105,16 @@ export class PushNotificationService implements OnModuleInit {
                         urgency: 'high',
                     }
                 );
+                console.log('[PushNotification] Sent via VAPID');
                 return true;
-            } else {
-                // Fallback to plain POST (current ntfy support)
-                return await this.sendPlainPost(endpoint, message);
+            } catch (error: any) {
+                console.warn('[PushNotification] VAPID failed, falling back to plain POST:', error.message);
+                // Fall through to plain POST
             }
-        } catch (error: any) {
-            console.error('[PushNotification] Send error:', error.message);
-            return false;
         }
+
+        // Use plain POST (ntfy compatible) - either as primary or fallback
+        return await this.sendPlainPost(endpoint, message);
     }
 
     /**

--- a/src/services/push-notification.service.ts
+++ b/src/services/push-notification.service.ts
@@ -121,7 +121,12 @@ export class PushNotificationService implements OnModuleInit {
      * Send notifications for a specific address
      */
     private async sendNotificationsForAddress(address: string, difficulty: number): Promise<void> {
-        const subscriptions = await this.pushSubscriptionService.getByAddress(address);
+        // Only notify subscriptions with best difficulty notifications enabled
+        const subscriptions = await this.pushSubscriptionService.getByAddressWithBestDiffNotifications(address);
+
+        if (subscriptions.length === 0) {
+            return;
+        }
 
         console.log(`[PushNotification] Difficulty increased for ${address}: sending to ${subscriptions.length} endpoint(s)`);
 

--- a/src/services/push-notification.service.ts
+++ b/src/services/push-notification.service.ts
@@ -210,4 +210,114 @@ export class PushNotificationService implements OnModuleInit {
             console.error('[PushNotification] Error in checkBestDifficulty:', error.message);
         }
     }
+
+    /**
+     * Notify subscribers when a block is found
+     * Called by NotificationService when any address finds a block
+     */
+    public async notifySubscribersBlockFound(
+        address: string,
+        height: number,
+        _block: any,
+        message: string,
+    ): Promise<void> {
+        try {
+            // Only notify subscriptions with block notifications enabled
+            const subscriptions = await this.pushSubscriptionService.getByAddressWithBlockNotifications(address);
+
+            if (subscriptions.length === 0) {
+                return;
+            }
+
+            console.log(`[PushNotification] Block found by ${address}! Sending to ${subscriptions.length} endpoint(s)`);
+
+            // Extract difficulty from message if present (e.g., "valid (158T)")
+            const difficultyMatch = message.match(/\(([0-9.]+[KMGT]?)\)/);
+            const difficulty = difficultyMatch ? difficultyMatch[1] : 'Unknown';
+
+            const title = 'New Block Found!';
+            const body = `Block height ${height}`;
+            const notificationMessage = `${title}|${body}|${difficulty}`;
+
+            for (const subscription of subscriptions) {
+                try {
+                    const success = await this.sendPlainPost(subscription.endpoint, notificationMessage);
+
+                    if (success) {
+                        console.log(`[PushNotification] Block notification sent to ${subscription.platform} endpoint for ${address}`);
+                    } else {
+                        console.error(`[PushNotification] Failed to send block notification to ${subscription.endpoint}`);
+                    }
+                } catch (error: any) {
+                    console.error(`[PushNotification] Error sending block notification:`, error.message);
+                }
+            }
+        } catch (error: any) {
+            console.error('[PushNotification] Error in notifySubscribersBlockFound:', error.message);
+        }
+    }
+
+    /**
+     * Notify subscribers when a device status changes (online/offline)
+     * Called by NotificationService when a worker connects/disconnects
+     */
+    public async notifyDeviceStatusChange(params: {
+        address: string;
+        workerName?: string;
+        userAgent?: string;
+        sessionId: string;
+        isOnline: boolean;
+        timestamp: Date;
+        isReturning?: boolean;
+    }): Promise<void> {
+        try {
+            const { address, workerName, userAgent, isOnline, timestamp, isReturning } = params;
+
+            // Only notify subscriptions with device notifications enabled
+            const subscriptions = await this.pushSubscriptionService.getByAddressWithDeviceNotifications(address);
+
+            if (subscriptions.length === 0) {
+                return;
+            }
+
+            console.log(`[PushNotification] Device ${isOnline ? 'online' : 'offline'} for ${address}, sending to ${subscriptions.length} endpoint(s)`);
+
+            const worker = workerName || 'Unknown';
+            const agent = userAgent || 'Unknown';
+            const timeStr = timestamp.toLocaleString('en-US', {
+                dateStyle: 'short',
+                timeStyle: 'short',
+                timeZone: 'UTC'
+            });
+
+            let title: string;
+            let body: string;
+
+            if (isOnline) {
+                title = isReturning ? 'Device Back Online' : 'Device Online';
+                body = `${agent} (${worker}) at ${timeStr}`;
+            } else {
+                title = 'Device Offline';
+                body = `${agent} (${worker}) at ${timeStr}`;
+            }
+
+            const notificationMessage = `${title}|${body}|`;
+
+            for (const subscription of subscriptions) {
+                try {
+                    const success = await this.sendPlainPost(subscription.endpoint, notificationMessage);
+
+                    if (success) {
+                        console.log(`[PushNotification] Device status notification sent to ${subscription.platform} endpoint for ${address}`);
+                    } else {
+                        console.error(`[PushNotification] Failed to send device status notification to ${subscription.endpoint}`);
+                    }
+                } catch (error: any) {
+                    console.error(`[PushNotification] Error sending device status notification:`, error.message);
+                }
+            }
+        } catch (error: any) {
+            console.error('[PushNotification] Error in notifyDeviceStatusChange:', error.message);
+        }
+    }
 }

--- a/src/services/push-notification.service.ts
+++ b/src/services/push-notification.service.ts
@@ -1,0 +1,212 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Cron } from '@nestjs/schedule';
+import * as webpush from 'web-push';
+import axios from 'axios';
+
+import { PushSubscriptionService } from '../ORM/push-subscriptions/push-subscription.service';
+import { BestDifficultyTrackerService } from '../ORM/best-difficulty-tracker/best-difficulty-tracker.service';
+import { AddressSettingsService } from '../ORM/address-settings/address-settings.service';
+
+const CHECK_INTERVAL_SECONDS = 60; // 60 seconds
+const MIN_NOTIFICATION_INTERVAL_MS = 300000; // 5 minutes
+
+@Injectable()
+export class PushNotificationService implements OnModuleInit {
+    private isPrimaryInstance: boolean;
+    private useVAPID: boolean;
+
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly pushSubscriptionService: PushSubscriptionService,
+        private readonly trackerService: BestDifficultyTrackerService,
+        private readonly addressSettingsService: AddressSettingsService,
+    ) {
+        // Only run on PM2 instance 0 (or when not in cluster mode)
+        this.isPrimaryInstance = !process.env.NODE_APP_INSTANCE || process.env.NODE_APP_INSTANCE === '0';
+
+        // Initialize VAPID if keys are configured
+        const vapidPublicKey = this.configService.get<string>('VAPID_PUBLIC_KEY');
+        const vapidPrivateKey = this.configService.get<string>('VAPID_PRIVATE_KEY');
+        const vapidSubject = this.configService.get<string>('VAPID_SUBJECT') || 'mailto:noreply@blitzpool.com';
+
+        this.useVAPID = !!(vapidPublicKey && vapidPrivateKey);
+
+        if (this.useVAPID) {
+            webpush.setVapidDetails(vapidSubject, vapidPublicKey!, vapidPrivateKey!);
+            console.log('[PushNotification] VAPID enabled for push notifications');
+        } else {
+            console.log('[PushNotification] VAPID disabled - using plain POST (ntfy compatible)');
+        }
+    }
+
+    async onModuleInit(): Promise<void> {
+        if (!this.isPrimaryInstance) {
+            console.log('[PushNotification] Disabled on PM2 instance ' + process.env.NODE_APP_INSTANCE + ' (only runs on instance 0)');
+            return;
+        }
+
+        console.log(`[PushNotification] Worker enabled on PM2 primary instance (0)`);
+        console.log(`[PushNotification] Check interval: ${CHECK_INTERVAL_SECONDS} seconds`);
+        console.log(`[PushNotification] Rate limit: ${MIN_NOTIFICATION_INTERVAL_MS / 1000} seconds between notifications`);
+    }
+
+    /**
+     * Format difficulty number with suffix (T, G, M, K)
+     */
+    private formatDifficulty(num: number): string {
+        if (num >= 1e12) return (num / 1e12).toFixed(2) + 'T';
+        if (num >= 1e9) return (num / 1e9).toFixed(2) + 'G';
+        if (num >= 1e6) return (num / 1e6).toFixed(2) + 'M';
+        if (num >= 1e3) return (num / 1e3).toFixed(2) + 'K';
+        return num.toString();
+    }
+
+    /**
+     * Send push notification using plain POST (ntfy-compatible)
+     */
+    private async sendPlainPost(endpoint: string, message: string): Promise<boolean> {
+        try {
+            const response = await axios.post(endpoint, message, {
+                headers: {
+                    'Content-Type': 'text/plain',
+                },
+                timeout: 10000, // 10 second timeout
+            });
+
+            return response.status >= 200 && response.status < 300;
+        } catch (error: any) {
+            console.error('[PushNotification] Plain POST error:', error.message);
+            return false;
+        }
+    }
+
+    /**
+     * Send push notification to UnifiedPush endpoint
+     * Supports both VAPID authentication and plain POST (fallback)
+     */
+    private async sendPushNotification(
+        endpoint: string,
+        title: string,
+        body: string,
+        difficulty: string
+    ): Promise<boolean> {
+        // Message format: "title|body|difficulty" (pipe-separated, ntfy compatible)
+        const message = `${title}|${body}|${difficulty}`;
+
+        try {
+            if (this.useVAPID) {
+                // Use VAPID authentication
+                await webpush.sendNotification(
+                    { endpoint },
+                    message,
+                    {
+                        TTL: 3600,
+                        urgency: 'high',
+                    }
+                );
+                return true;
+            } else {
+                // Fallback to plain POST (current ntfy support)
+                return await this.sendPlainPost(endpoint, message);
+            }
+        } catch (error: any) {
+            console.error('[PushNotification] Send error:', error.message);
+            return false;
+        }
+    }
+
+    /**
+     * Send notifications for a specific address
+     */
+    private async sendNotificationsForAddress(address: string, difficulty: number): Promise<void> {
+        const subscriptions = await this.pushSubscriptionService.getByAddress(address);
+
+        console.log(`[PushNotification] Difficulty increased for ${address}: sending to ${subscriptions.length} endpoint(s)`);
+
+        const title = 'New Best Difficulty!';
+        const body = `Your best difficulty increased to ${this.formatDifficulty(difficulty)}`;
+        const difficultyStr = this.formatDifficulty(difficulty);
+
+        for (const subscription of subscriptions) {
+            // Check rate limiting
+            if (subscription.lastNotificationAt) {
+                const timeSinceLastNotification = Date.now() - subscription.lastNotificationAt;
+                if (timeSinceLastNotification < MIN_NOTIFICATION_INTERVAL_MS) {
+                    console.log(`[PushNotification] Rate limited: ${address} (${Math.round((MIN_NOTIFICATION_INTERVAL_MS - timeSinceLastNotification) / 1000)}s remaining)`);
+                    continue;
+                }
+            }
+
+            // Send push notification
+            const success = await this.sendPushNotification(
+                subscription.endpoint,
+                title,
+                body,
+                difficultyStr
+            );
+
+            if (success) {
+                await this.pushSubscriptionService.updateLastNotification(subscription.id, Date.now());
+                console.log(`[PushNotification] Notification sent to ${subscription.platform} endpoint for ${address}`);
+            } else {
+                console.error(`[PushNotification] Failed to send notification to ${subscription.endpoint}`);
+            }
+        }
+    }
+
+    /**
+     * Check best difficulty for all subscribed addresses
+     * Runs every 60 seconds
+     */
+    @Cron('*/60 * * * * *')
+    async checkBestDifficulty(): Promise<void> {
+        if (!this.isPrimaryInstance) {
+            return;
+        }
+
+        try {
+            const addresses = await this.pushSubscriptionService.getAddressesWithSubscriptions();
+
+            if (addresses.length === 0) {
+                return;
+            }
+
+            console.log(`[PushNotification] Checking best difficulty for ${addresses.length} address(es)`);
+
+            for (const address of addresses) {
+                try {
+                    // Get current bestDifficulty from AddressSettingsService
+                    const settings = await this.addressSettingsService.getSettings(address, false);
+                    if (!settings) {
+                        continue;
+                    }
+
+                    const currentDifficulty = settings.bestDifficulty ?? 0;
+
+                    // Get tracker
+                    const tracker = await this.trackerService.getTracker(address);
+
+                    // Initialize tracker if it doesn't exist
+                    if (!tracker) {
+                        await this.trackerService.updateTracker(address, currentDifficulty);
+                        console.log(`[PushNotification] Initialized tracker for ${address} with difficulty ${this.formatDifficulty(currentDifficulty)}`);
+                        continue;
+                    }
+
+                    // Check if difficulty has increased
+                    if (currentDifficulty > tracker.bestDifficulty) {
+                        console.log(`[PushNotification] Difficulty increased for ${address}: ${this.formatDifficulty(tracker.bestDifficulty)} -> ${this.formatDifficulty(currentDifficulty)}`);
+
+                        await this.sendNotificationsForAddress(address, currentDifficulty);
+                        await this.trackerService.updateTracker(address, currentDifficulty);
+                    }
+                } catch (error: any) {
+                    console.error(`[PushNotification] Error checking address ${address}:`, error.message);
+                }
+            }
+        } catch (error: any) {
+            console.error('[PushNotification] Error in checkBestDifficulty:', error.message);
+        }
+    }
+}

--- a/src/services/timeslot-migration.service.ts
+++ b/src/services/timeslot-migration.service.ts
@@ -105,14 +105,30 @@ export class TimeslotMigrationService implements OnModuleInit {
 
       // Perform the migration: add 10 minutes to all time values
       // This changes labeling from start-time to end-time
+      // IMPORTANT: Update in DESCENDING order to avoid UNIQUE constraint violations
       for (const table of tables) {
         if (tableCounts[table] > 0) {
           console.log(`[TimeslotMigration] Migrating ${table}...`);
-          await queryRunner.query(`
-            UPDATE ${table}
-            SET time = time + ?
-          `, [this.TIME_SLOT_DURATION_MS]);
-          console.log(`[TimeslotMigration] ✓ Updated ${tableCounts[table].toLocaleString()} records in ${table}`);
+
+          // Get all time values in descending order
+          const timeValues = await queryRunner.query(
+            `SELECT DISTINCT time FROM ${table} ORDER BY time DESC`
+          );
+
+          // Update each time value individually, starting from highest
+          let updated = 0;
+          for (const row of timeValues) {
+            const oldTime = row.time;
+            const newTime = oldTime + this.TIME_SLOT_DURATION_MS;
+
+            await queryRunner.query(
+              `UPDATE ${table} SET time = ? WHERE time = ?`,
+              [newTime, oldTime]
+            );
+            updated++;
+          }
+
+          console.log(`[TimeslotMigration] ✓ Updated ${updated.toLocaleString()} unique time slots in ${table}`);
         }
       }
 


### PR DESCRIPTION
## Summary
Implements a UnifiedPush-compatible notification server that monitors address-wide bestDifficulty values and sends push notifications when they increase.

## Features
- **Background Worker**: Runs every 60 seconds on PM2 instance 0 only
- **Monitoring**: Tracks address-wide `bestDifficulty` from `AddressSettingsEntity`
- **Notifications**: Sends to all registered endpoints when difficulty increases
- **Rate Limiting**: 5 minutes between notifications per subscription
- **Protocol Support**: VAPID (optional) + plain POST fallback (ntfy compatible)

## API Endpoints
All endpoints prefixed with `/api/push`:
- `POST /api/push/register` - Register subscription
- `POST /api/push/unregister` - Unregister subscription
- `GET /api/push/status/:address` - Get subscription status

## Files Added
- Migration: `src/migrations/1734192000000-CreatePushNotifications.ts`
- Entities: `PushSubscriptionEntity`, `BestDifficultyTrackerEntity`
- Services: `PushSubscriptionService`, `BestDifficultyTrackerService`, `PushNotificationService`
- Modules: `PushSubscriptionModule`, `BestDifficultyTrackerModule`
- Controller: `PushController`
- Package: `web-push@^3.6.7` for VAPID support

## Configuration
Optional VAPID configuration in `.env`:
```bash
# Generate keys: npx web-push generate-vapid-keys
VAPID_PUBLIC_KEY=your_public_key
VAPID_PRIVATE_KEY=your_private_key
VAPID_SUBJECT=mailto:admin@yourserver.com
```

## Test Plan
- [x] Database migration creates tables successfully
- [x] Build compiles without errors
- [x] PM2 worker runs on instance 0 only
- [x] POST /api/push/register creates subscription
- [x] GET /api/push/status/:address returns correct data
- [x] Notification sent when bestDifficulty increases
- [x] Rate limiting works (5 min cooldown)
- [x] Plain POST notifications work (VAPID disabled)

## Testing Instructions
1. Start the application (migration runs automatically)
2. Register a test subscription:
   ```bash
   curl -X POST http://localhost:3334/api/push/register \
     -H "Content-Type: application/json" \
     -d '{"address":"bc1q...","endpoint":"https://ntfy.example.com/topic","platform":"android"}'
   ```
3. Check status:
   ```bash
   curl http://localhost:3334/api/push/status/bc1q...
   ```
4. Submit a share with high difficulty and wait up to 60 seconds for notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)