### PR TITLE
Add client data deletion endpoints

### DIFF
--- a/src/ORM/address-settings/address-settings.service.ts
+++ b/src/ORM/address-settings/address-settings.service.ts
@@ -146,4 +146,8 @@ export class AddressSettingsService {
             bestDifficulty: 0
         });
     }
+
+    public async deleteForAddress(address: string) {
+        return await this.addressSettingsRepository.delete({ address });
+    }
 }

--- a/src/ORM/best-difficulty-tracker/best-difficulty-tracker.service.ts
+++ b/src/ORM/best-difficulty-tracker/best-difficulty-tracker.service.ts
@@ -64,4 +64,11 @@ export class BestDifficultyTrackerService {
             await this.trackerRepository.save(existing);
         }
     }
+
+    /**
+     * Delete tracker for address
+     */
+    public async deleteTracker(address: string): Promise<void> {
+        await this.trackerRepository.delete({ address });
+    }
 }

--- a/src/ORM/client-difficulty-statistics/client-difficulty-statistics.service.ts
+++ b/src/ORM/client-difficulty-statistics/client-difficulty-statistics.service.ts
@@ -107,4 +107,8 @@ export class ClientDifficultyStatisticsService {
       .where('slotTime < :cutoff', { cutoff })
       .execute();
   }
+
+  async deleteForAddress(address: string): Promise<void> {
+    await this.repository.delete({ address });
+  }
 }

--- a/src/ORM/client-rejected-statistics/client-rejected-statistics.service.ts
+++ b/src/ORM/client-rejected-statistics/client-rejected-statistics.service.ts
@@ -84,4 +84,29 @@ export class ClientRejectedStatisticsService implements OnModuleInit {
       order: { time: 'ASC' },
     });
   }
+
+  public async deleteForAddress(address: string) {
+    return await this.clientRejectedStatisticsRepository.delete({ address });
+  }
+
+  /**
+   * Clear all Redis cache keys for an address (used for delete operations)
+   */
+  public async clearRedisKeysForAddress(address: string): Promise<void> {
+    if (!this.redisClient) {
+      return;
+    }
+
+    try {
+      // Delete all client rejected share keys for this address
+      const pattern = `client:rejected:${address}:*`;
+      const keys = await this.redisClient.keys(pattern);
+
+      if (keys && keys.length > 0) {
+        await this.redisClient.del(...keys);
+      }
+    } catch (error) {
+      console.error(`[ClientRejectedStatisticsService] Failed to clear Redis keys for address ${address}:`, error);
+    }
+  }
 }

--- a/src/ORM/client-statistics/client-statistics.service.ts
+++ b/src/ORM/client-statistics/client-statistics.service.ts
@@ -840,4 +840,29 @@ export class ClientStatisticsService implements OnModuleInit {
   public async deleteAll() {
     return await this.clientStatisticsRepository.delete({});
   }
+
+  public async deleteForAddress(address: string) {
+    return await this.clientStatisticsRepository.delete({ address });
+  }
+
+  /**
+   * Clear all Redis cache keys for an address (used for delete operations)
+   */
+  public async clearRedisKeysForAddress(address: string): Promise<void> {
+    if (!this.redisClient) {
+      return;
+    }
+
+    try {
+      // Delete all client share keys for this address
+      const pattern = `client:shares:${address}:*`;
+      const keys = await this.redisClient.keys(pattern);
+
+      if (keys && keys.length > 0) {
+        await this.redisClient.del(...keys);
+      }
+    } catch (error) {
+      console.error(`[ClientStatisticsService] Failed to clear Redis keys for address ${address}:`, error);
+    }
+  }
 }

--- a/src/ORM/client/client.service.ts
+++ b/src/ORM/client/client.service.ts
@@ -250,4 +250,13 @@ export class ClientService {
         return rows.map(r => r.address);
     }
 
+    public async hardDeleteForAddress(address: string): Promise<void> {
+        await this.clientRepository
+            .createQueryBuilder()
+            .delete()
+            .from(ClientEntity)
+            .where('address = :address', { address })
+            .execute();
+    }
+
 }

--- a/src/controllers/client/client.controller.ts
+++ b/src/controllers/client/client.controller.ts
@@ -120,6 +120,114 @@ export class ClientController {
         return { status: 'reset' };
     }
 
+    @Post(':address/delete-stats')
+    async deleteStats(@Param('address') address: string) {
+        console.log(`[ClientController] Starting delete-stats for address ${address}`);
+
+        // Clear all cache keys for this address (including worker-specific caches)
+        // Try to get Redis client to use keys() for pattern matching
+        try {
+            const store: any = this.cacheManager.store;
+            if (store && store.client) {
+                const redisClient = store.client;
+                // Find all cache keys containing this address
+                const patterns = [
+                    `CLIENT_INFO_${address}*`,
+                    `CLIENT_CHART_${address}*`,
+                    `CLIENT_CHART_LIVE_${address}*`,
+                    `CLIENT_WORKER_SHARES_${address}*`,
+                    `CLIENT_WORKERS_${address}*`,
+                    `CLIENT_ACCEPTED_${address}*`,
+                    `CLIENT_REJECTED_${address}*`,
+                    `CLIENT_DIFF_SCORES_${address}*`,
+                    `CLIENT_WORKER_GROUP_${address}*`,
+                    `CLIENT_WORKER_SESSION_${address}*`,
+                ];
+
+                for (const pattern of patterns) {
+                    const keys = await redisClient.keys(pattern);
+                    if (keys && keys.length > 0) {
+                        await redisClient.del(...keys);
+                    }
+                }
+                console.log(`[ClientController] Cache keys cleared for ${address}`);
+            }
+        } catch (error) {
+            console.error(`[ClientController] Error clearing cache keys:`, error);
+            // Fallback: clear known cache keys
+            const cacheKeys = [
+                `CLIENT_INFO_${address}`,
+                `CLIENT_CHART_${address}_1d`,
+                `CLIENT_CHART_${address}_3d`,
+                `CLIENT_CHART_${address}_7d`,
+                `CLIENT_CHART_LIVE_${address}_1h`,
+                `CLIENT_CHART_LIVE_${address}_6h`,
+                `CLIENT_CHART_LIVE_${address}_12h`,
+                `CLIENT_CHART_LIVE_${address}_24h`,
+                `CLIENT_WORKER_SHARES_${address}`,
+                `CLIENT_WORKERS_${address}_1d`,
+                `CLIENT_WORKERS_${address}_3d`,
+                `CLIENT_WORKERS_${address}_7d`,
+                `CLIENT_ACCEPTED_${address}_1d`,
+                `CLIENT_ACCEPTED_${address}_3d`,
+                `CLIENT_ACCEPTED_${address}_7d`,
+                `CLIENT_REJECTED_${address}_1d`,
+                `CLIENT_REJECTED_${address}_3d`,
+                `CLIENT_REJECTED_${address}_7d`,
+                `CLIENT_DIFF_SCORES_${address}_1d`,
+                `CLIENT_DIFF_SCORES_${address}_7d`,
+                `CLIENT_DIFF_SCORES_${address}_30d`,
+            ];
+            await Promise.all(cacheKeys.map(key => this.cacheManager.del(key)));
+        }
+
+        // Clear Redis keys for statistics
+        await this.clientStatisticsService.clearRedisKeysForAddress(address);
+        await this.clientRejectedStatisticsService.clearRedisKeysForAddress(address);
+        await this.shareTotalsCacheService.clearAddressData(address);
+        console.log(`[ClientController] Redis keys cleared for ${address}`);
+
+        // Delete statistics from database
+        await this.clientStatisticsService.deleteForAddress(address);
+        console.log(`[ClientController] Client statistics deleted for ${address}`);
+
+        await this.clientRejectedStatisticsService.deleteForAddress(address);
+        console.log(`[ClientController] Client rejected statistics deleted for ${address}`);
+
+        await this.clientDifficultyStatisticsService.deleteForAddress(address);
+        console.log(`[ClientController] Client difficulty statistics deleted for ${address}`);
+
+        // Reset best difficulty tracking
+        await this.stratumV1Service.resetBestDifficultyForAddress(address);
+        await this.addressSettingsService.updateBestDifficulty(address, 0, null);
+        await this.trackerService.resetTracker(address);
+        console.log(`[ClientController] Best difficulty tracking reset for ${address}`);
+
+        return { status: 'stats-deleted', address };
+    }
+
+    @Post(':address/delete-all')
+    async deleteAll(@Param('address') address: string) {
+        console.log(`[ClientController] Starting delete-all for address ${address}`);
+
+        // First delete all statistics (reuse delete-stats logic)
+        await this.deleteStats(address);
+
+        // Delete client records (hard delete)
+        await this.clientService.hardDeleteForAddress(address);
+        console.log(`[ClientController] Client records deleted for ${address}`);
+
+        // Delete address settings
+        await this.addressSettingsService.deleteForAddress(address);
+        console.log(`[ClientController] Address settings deleted for ${address}`);
+
+        // Delete tracker
+        await this.trackerService.deleteTracker(address);
+        console.log(`[ClientController] Tracker deleted for ${address}`);
+
+        return { status: 'all-deleted', address };
+    }
+
     @Get(':address/chart')
     async getClientInfoChart(
         @Param('address') address: string,

--- a/src/services/share-totals-cache.service.ts
+++ b/src/services/share-totals-cache.service.ts
@@ -194,4 +194,29 @@ export class ShareTotalsCacheService implements OnModuleInit {
 
     return result;
   }
+
+  /**
+   * Clear all Redis cache keys for an address (used for delete operations)
+   */
+  public async clearAddressData(address: string): Promise<void> {
+    if (!this.useRedis || !this.redisClient) {
+      return;
+    }
+
+    try {
+      // Delete address total key
+      const addressKey = this.getAddressKey(address);
+      await this.redisClient.del(addressKey);
+
+      // Delete all worker keys for this address
+      const workerPattern = `shares:worker:${address}:*`;
+      const workerKeys = await this.redisClient.keys(workerPattern);
+
+      if (workerKeys && workerKeys.length > 0) {
+        await this.redisClient.del(...workerKeys);
+      }
+    } catch (error) {
+      console.error(`[ShareTotalsCacheService] Failed to clear data for address ${address}:`, error);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Add `POST /api/client/:btcaddress/delete-stats` endpoint to delete all statistics while keeping the address registered
- Add `POST /api/client/:btcaddress/delete-all` endpoint to completely remove the address and all associated data from the database

## Changes
### New Service Methods
- `ClientStatisticsService.deleteForAddress()` and `clearRedisKeysForAddress()`
- `ClientRejectedStatisticsService.deleteForAddress()` and `clearRedisKeysForAddress()`
- `ClientDifficultyStatisticsService.deleteForAddress()`
- `ClientService.hardDeleteForAddress()`
- `AddressSettingsService.deleteForAddress()`
- `BestDifficultyTrackerService.deleteTracker()`
- `ShareTotalsCacheService.clearAddressData()`

### New Endpoints
#### `/api/client/:btcaddress/delete-stats`
- Clears all cache keys (including worker-specific caches)
- Clears Redis keys for statistics
- Deletes client statistics, rejected statistics, and difficulty statistics from database
- Resets best difficulty tracking to 0
- Keeps the address registered in the system

#### `/api/client/:btcaddress/delete-all`
- Performs all operations from delete-stats
- Hard deletes all client/worker records
- Deletes address settings
- Deletes best difficulty tracker
- Completely removes the address from the system

## Test plan
- [x] Test delete-stats endpoint with a valid BTC address
- [x] Verify statistics are deleted but address remains
- [x] Test delete-all endpoint with a valid BTC address
- [x] Verify all data is completely removed
- [x] Verify cache invalidation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)