### PR TITLE
Add PPLNS engine with coinbase payouts

### DIFF
--- a/full-setup/blitzpool-example.env
+++ b/full-setup/blitzpool-example.env
@@ -96,6 +96,32 @@ NETWORK=mainnet
 # Discovery endpoint: GET /api/info/sv2-pool-fees (explains full process + examples)
 # If DEV_FEE_ADDRESS is empty, miners can use any coinbase outputs (no validation)
 
+# ============================================================================
+# PPLNS POOL MODE (Optional - runs alongside solo mining)
+# ============================================================================
+
+# Enable PPLNS by setting a dedicated port. Solo mining on existing ports
+# remains unchanged. Miners connecting to the PPLNS port receive proportional
+# coinbase payouts based on their share contribution (OCEAN/DATUM model).
+
+# PPLNS port (leave commented out to disable PPLNS entirely)
+#PPLNS_PORT=3340
+# Starting difficulty for PPLNS port (defaults to STRATUM_START_DIFFICULTY)
+#PPLNS_START_DIFFICULTY=16384
+# Target shares per minute for PPLNS port (defaults to TARGET_SHARES_PER_MINUTE)
+#PPLNS_TARGET_SHARES_PER_MINUTE=6
+
+# Pool fee for PPLNS payouts (separate from solo DEV_FEE)
+# This address receives the pool fee directly in the coinbase transaction
+#PPLNS_FEE_ADDRESS=bc1q...
+#PPLNS_FEE_PERCENT=2
+
+# Notes:
+# - PPLNS window size = 4 * network_difficulty (diff1-equivalent shares)
+# - Miners below dust limit (546 sats) accumulate balance across blocks
+# - Block payout processing runs on PM2 instance 0 only
+# - API endpoints: GET /pplns/status, /pplns/distribution, /pplns/:address, /pplns/:address/history
+
 API_SECURE=false
 POOL_IDENTIFIER="blitzpool"
 

--- a/src/ORM/pplns-balance/pplns-balance.entity.ts
+++ b/src/ORM/pplns-balance/pplns-balance.entity.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('pplns_balance')
+export class PplnsBalanceEntity {
+
+    @PrimaryColumn({ type: 'varchar', length: 62 })
+    address: string;
+
+    @Column({ type: 'bigint', default: 0, transformer: { from: (v: string) => Number(v), to: (v: number) => v } })
+    pendingSats: number;
+
+    @Column({ type: 'bigint', default: 0, transformer: { from: (v: string) => Number(v), to: (v: number) => v } })
+    totalPaidSats: number;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/src/ORM/pplns-balance/pplns-balance.service.ts
+++ b/src/ORM/pplns-balance/pplns-balance.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MoreThan, Repository } from 'typeorm';
+import { PplnsBalanceEntity } from './pplns-balance.entity';
+
+@Injectable()
+export class PplnsBalanceService {
+
+    constructor(
+        @InjectRepository(PplnsBalanceEntity)
+        private readonly repo: Repository<PplnsBalanceEntity>,
+    ) {}
+
+    async addPending(address: string, sats: number): Promise<void> {
+        const existing = await this.repo.findOneBy({ address });
+        if (existing) {
+            existing.pendingSats += sats;
+            await this.repo.save(existing);
+        } else {
+            await this.repo.save(this.repo.create({
+                address,
+                pendingSats: sats,
+                totalPaidSats: 0,
+            }));
+        }
+    }
+
+    async getPending(address: string): Promise<number> {
+        const entity = await this.repo.findOneBy({ address });
+        return entity?.pendingSats ?? 0;
+    }
+
+    async getBalance(address: string): Promise<PplnsBalanceEntity | null> {
+        return this.repo.findOneBy({ address });
+    }
+
+    async getAllWithPending(): Promise<PplnsBalanceEntity[]> {
+        return this.repo.find({ where: { pendingSats: MoreThan(0) } });
+    }
+
+    async markPaid(address: string, sats: number): Promise<void> {
+        const entity = await this.repo.findOneBy({ address });
+        if (!entity) return;
+        entity.pendingSats = Math.max(0, entity.pendingSats - sats);
+        entity.totalPaidSats += sats;
+        await this.repo.save(entity);
+    }
+
+    async getAll(): Promise<PplnsBalanceEntity[]> {
+        return this.repo.find();
+    }
+}

--- a/src/ORM/pplns-balance/pplns-payout-history.entity.ts
+++ b/src/ORM/pplns-balance/pplns-payout-history.entity.ts
@@ -1,0 +1,26 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('pplns_payout_history')
+export class PplnsPayoutHistoryEntity {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ type: 'int' })
+    blockHeight: number;
+
+    @Column({ type: 'varchar', length: 62 })
+    address: string;
+
+    @Column({ type: 'bigint', default: 0, transformer: { from: (v: string) => Number(v), to: (v: number) => v } })
+    paidSats: number;
+
+    @Column({ type: 'real', default: 0 })
+    percent: number;
+
+    @Column({ type: 'boolean', default: true })
+    inCoinbase: boolean;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -50,6 +50,11 @@ import { WorkerResetBroadcastService } from './services/worker-reset-broadcast.s
 import { TemplateDistributionService } from './services/template-distribution.service';
 import { DownstreamReportService } from './services/downstream-report.service';
 import { JobDeclarationService } from './services/job-declaration.service';
+import { PplnsService } from './services/pplns.service';
+import { PplnsBalanceService } from './ORM/pplns-balance/pplns-balance.service';
+import { PplnsBalanceEntity } from './ORM/pplns-balance/pplns-balance.entity';
+import { PplnsPayoutHistoryEntity } from './ORM/pplns-balance/pplns-payout-history.entity';
+import { PplnsController } from './controllers/pplns/pplns.controller';
 import { DownstreamReportController } from './controllers/downstream-report/downstream-report.controller';
 import { ExternalShareController } from './controllers/external-share/external-share.controller';
 import { PushController } from './controllers/push/push.controller';
@@ -126,6 +131,7 @@ const ORMModules = [
         }),
         ScheduleModule.forRoot(),
         HttpModule,
+        TypeOrmModule.forFeature([PplnsBalanceEntity, PplnsPayoutHistoryEntity]),
         ...ORMModules
     ],
     controllers: [
@@ -135,7 +141,8 @@ const ORMModules = [
         DownstreamReportController,
         ExternalShareController,
         PushController,
-        InfoController
+        InfoController,
+        PplnsController
     ],
     providers: [
         // TimeslotMigrationService, // Disabled - migration incomplete, leaving data in mixed state
@@ -168,6 +175,8 @@ const ORMModules = [
         TemplateDistributionService,
         StratumV2Service,
         JobDeclarationService,
+        PplnsService,
+        PplnsBalanceService,
     ],
 })
 export class AppModule {

--- a/src/controllers/pplns/pplns.controller.ts
+++ b/src/controllers/pplns/pplns.controller.ts
@@ -1,0 +1,52 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { PplnsService } from '../../services/pplns.service';
+
+@Controller('pplns')
+export class PplnsController {
+
+    constructor(private readonly pplnsService: PplnsService) {}
+
+    /**
+     * GET /pplns/status
+     * Pool-wide PPLNS status: window stats, miner count, fee config.
+     */
+    @Get('status')
+    async getStatus() {
+        const windowStats = await this.pplnsService.getWindowStats();
+        return {
+            enabled: this.pplnsService.isEnabled(),
+            ...windowStats,
+        };
+    }
+
+    /**
+     * GET /pplns/distribution
+     * Current share distribution across all miners in the PPLNS window.
+     */
+    @Get('distribution')
+    async getDistribution() {
+        return this.pplnsService.getCurrentDistribution();
+    }
+
+    /**
+     * GET /pplns/:address
+     * PPLNS status for a specific miner address.
+     */
+    @Get(':address')
+    async getAddressStatus(@Param('address') address: string) {
+        return this.pplnsService.getAddressStatus(address);
+    }
+
+    /**
+     * GET /pplns/:address/history?limit=50
+     * Payout history for a specific miner address.
+     */
+    @Get(':address/history')
+    async getPayoutHistory(
+        @Param('address') address: string,
+        @Query('limit') limitStr?: string,
+    ) {
+        const limit = Math.min(parseInt(limitStr ?? '50', 10) || 50, 200);
+        return this.pplnsService.getPayoutHistory(address, limit);
+    }
+}

--- a/src/migrations/1769980000000-AddPplnsBalance.ts
+++ b/src/migrations/1769980000000-AddPplnsBalance.ts
@@ -1,0 +1,97 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class AddPplnsBalance1769980000000 implements MigrationInterface {
+    name = 'AddPplnsBalance1769980000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'pplns_balance',
+                columns: [
+                    {
+                        name: 'address',
+                        type: 'varchar',
+                        length: '62',
+                        isPrimary: true,
+                    },
+                    {
+                        name: 'pendingSats',
+                        type: 'bigint',
+                        default: '0',
+                    },
+                    {
+                        name: 'totalPaidSats',
+                        type: 'bigint',
+                        default: '0',
+                    },
+                    {
+                        name: 'updatedAt',
+                        type: 'timestamp',
+                        default: 'CURRENT_TIMESTAMP',
+                    },
+                ],
+            }),
+            true,
+        );
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'pplns_payout_history',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'integer',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    {
+                        name: 'blockHeight',
+                        type: 'int',
+                    },
+                    {
+                        name: 'address',
+                        type: 'varchar',
+                        length: '62',
+                    },
+                    {
+                        name: 'paidSats',
+                        type: 'bigint',
+                        default: '0',
+                    },
+                    {
+                        name: 'percent',
+                        type: 'real',
+                        default: '0',
+                    },
+                    {
+                        name: 'inCoinbase',
+                        type: 'boolean',
+                        default: true,
+                    },
+                    {
+                        name: 'createdAt',
+                        type: 'timestamp',
+                        default: 'CURRENT_TIMESTAMP',
+                    },
+                ],
+            }),
+            true,
+        );
+
+        await queryRunner.createIndex(
+            'pplns_payout_history',
+            new TableIndex({ columnNames: ['address'] }),
+        );
+
+        await queryRunner.createIndex(
+            'pplns_payout_history',
+            new TableIndex({ columnNames: ['blockHeight'] }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('pplns_payout_history', true);
+        await queryRunner.dropTable('pplns_balance', true);
+    }
+}

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -37,6 +37,8 @@ import { StratumV1Service } from '../services/stratum-v1.service';
 import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 import { ShareTotalsCacheService } from '../services/share-totals-cache.service';
 import { AddressSettingsCacheService } from '../services/address-settings-cache.service';
+import { PplnsService } from '../services/pplns.service';
+import { PayoutMode } from './interfaces/unified-stratum.interfaces';
 
 
 export class StratumV1Client {
@@ -111,6 +113,8 @@ export class StratumV1Client {
         private readonly allowSuggestedDifficulty: boolean = true,
         private readonly targetSharesPerMinute: number = 6,
         private readonly redisClient?: any,
+        private readonly payoutMode: PayoutMode = 'solo',
+        private readonly pplnsService?: PplnsService,
     ) {
         this.initialDifficulty = Number.isFinite(initialDifficulty)
             ? initialDifficulty
@@ -712,37 +716,50 @@ export class StratumV1Client {
         }
 
         let payoutInformation;
-        const devFeeAddress = this.configService.get('DEV_FEE_ADDRESS');
-        const devFeePercent = parseFloat(
-            this.configService.get('DEV_FEE_PERCENT') ?? '1.5',
-        );
 
         if (this.entity && this.clientAuthorization) {
             this.hashRate = this.statistics.hashRate;
         }
 
-        if (!this.clientAuthorization) {
-            if (!devFeeAddress) {
+        if (this.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
+            // PPLNS: Shared coinbase with proportional payouts
+            this.pplnsService.setNetworkDifficulty(jobTemplate.blockData.networkDifficulty);
+            payoutInformation = await this.pplnsService.getPayoutDistribution(jobTemplate.blockData.coinbasevalue);
+            this.noFee = false;
+            if (!payoutInformation || payoutInformation.length === 0) {
+                // Fallback: no miners in window yet, skip job
                 return;
             }
-            this.noFee = false;
-            payoutInformation = [
-                { address: devFeeAddress, percent: 100 },
-            ];
         } else {
-            this.noFee = devFeeAddress == null || devFeeAddress.length < 1;
-            if (this.noFee) {
+            // Solo: Existing behavior
+            const devFeeAddress = this.configService.get('DEV_FEE_ADDRESS');
+            const devFeePercent = parseFloat(
+                this.configService.get('DEV_FEE_PERCENT') ?? '1.5',
+            );
+
+            if (!this.clientAuthorization) {
+                if (!devFeeAddress) {
+                    return;
+                }
+                this.noFee = false;
                 payoutInformation = [
-                    { address: this.clientAuthorization.address, percent: 100 },
+                    { address: devFeeAddress, percent: 100 },
                 ];
             } else {
-                payoutInformation = [
-                    { address: devFeeAddress, percent: devFeePercent },
-                    {
-                        address: this.clientAuthorization.address,
-                        percent: 100 - devFeePercent,
-                    },
-                ];
+                this.noFee = devFeeAddress == null || devFeeAddress.length < 1;
+                if (this.noFee) {
+                    payoutInformation = [
+                        { address: this.clientAuthorization.address, percent: 100 },
+                    ];
+                } else {
+                    payoutInformation = [
+                        { address: devFeeAddress, percent: devFeePercent },
+                        {
+                            address: this.clientAuthorization.address,
+                            percent: 100 - devFeePercent,
+                        },
+                    ];
+                }
             }
         }
 
@@ -962,6 +979,14 @@ export class StratumV1Client {
                 if (result === 'SUCCESS!') {
                     await this.addressSettingsService.resetBestDifficultyAndShares();
                     await this.addressSettingsCacheService.clear();
+
+                    // Process PPLNS payouts (update pending balances)
+                    if (this.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
+                        await this.pplnsService.onBlockFound(
+                            jobTemplate.blockData.height,
+                            jobTemplate.blockData.coinbasevalue,
+                        );
+                    }
                 }
             }
             try {
@@ -970,6 +995,14 @@ export class StratumV1Client {
 
                 // Persist to Redis atomically (stateless service)
                 await this.clientStatisticsService.addAcceptedShare(this.entity, this.sessionDifficulty);
+
+                // Record share in PPLNS window if on PPLNS port
+                if (this.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
+                    await this.pplnsService.recordShare(
+                        this.clientAuthorization.address,
+                        this.sessionDifficulty,
+                    );
+                }
 
                 this.shareTotalsCacheService.increment(
                     this.clientAuthorization.address,

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -723,7 +723,7 @@ export class StratumV1Client {
 
         if (this.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
             // PPLNS: Shared coinbase with proportional payouts
-            this.pplnsService.setNetworkDifficulty(jobTemplate.blockData.networkDifficulty);
+            // Network difficulty is synced centrally via PplnsService's job subscription
             payoutInformation = await this.pplnsService.getPayoutDistribution(jobTemplate.blockData.coinbasevalue);
             this.noFee = false;
             if (!payoutInformation || payoutInformation.length === 0) {

--- a/src/models/StratumV2Client.ts
+++ b/src/models/StratumV2Client.ts
@@ -22,6 +22,7 @@ import { ClientRejectedStatisticsService } from '../ORM/client-rejected-statisti
 import { ExternalSharesService } from '../services/external-shares.service';
 import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 import { ShareTotalsCacheService } from '../services/share-totals-cache.service';
+import { PplnsService } from '../services/pplns.service';
 import { ClientEntity } from '../ORM/client/client.entity';
 import { MiningJob } from './MiningJob';
 import { StratumV1ClientStatistics } from './StratumV1ClientStatistics';
@@ -210,6 +211,7 @@ export class StratumV2Client {
     private readonly shareTotalsCacheService: ShareTotalsCacheService,
     private readonly extranonceManager?: Sv2ExtranonceManager,
     private readonly templateDistributionService?: TemplateDistributionService,
+    private readonly pplnsService?: PplnsService,
   ) {
     this.sessionId = this.generateSessionId();
     this.sessionStart = new Date();
@@ -1167,7 +1169,8 @@ export class StratumV2Client {
       const stored = this.templateDistributionService.getLatestTemplate();
       if (stored) {
         // Build payout information and create a proper MiningJob with real coinbase outputs
-        const payoutInformation = this.buildPayoutInformation();
+        const payoutInformation = await this.buildPayoutInformationAsync(stored.jobTemplate.blockData.coinbasevalue)
+          ?? this.buildPayoutInformation();
         if (!payoutInformation) return;
 
         const jobIdStr = this.stratumV1JobsService.getNextId();
@@ -1276,7 +1279,8 @@ export class StratumV2Client {
     }
 
     // Build payout information and create a proper MiningJob with real coinbase outputs
-    const payoutInformation = this.buildPayoutInformation();
+    const payoutInformation = await this.buildPayoutInformationAsync(jobTemplate.blockData.coinbasevalue)
+      ?? this.buildPayoutInformation();
     if (!payoutInformation) return;
 
     const jobIdStr = this.stratumV1JobsService.getNextId();
@@ -1550,6 +1554,14 @@ export class StratumV2Client {
       if (result === 'SUCCESS!') {
         await this.addressSettingsService.resetBestDifficultyAndShares();
         await this.addressSettingsCacheService.clear();
+
+        // Process PPLNS payouts (update pending balances)
+        if (this.portConfig.payoutMode === 'pplns' && this.pplnsService?.isEnabled() && jobTemplate) {
+          await this.pplnsService.onBlockFound(
+            jobTemplate.blockData.height,
+            jobTemplate.blockData.coinbasevalue,
+          );
+        }
       }
     }
 
@@ -1557,6 +1569,11 @@ export class StratumV2Client {
       this.statistics.updateHashRate(jobDifficulty);
       this.hashRate = this.statistics.hashRate;
       await this.clientStatisticsService.addAcceptedShare(this.entity!, jobDifficulty);
+
+      // Record share in PPLNS window if on PPLNS port
+      if (this.portConfig.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
+        await this.pplnsService.recordShare(this.address!, jobDifficulty);
+      }
 
       this.shareTotalsCacheService.increment(
         this.address!,
@@ -1784,13 +1801,23 @@ export class StratumV2Client {
 
   // ── Send Mining Job ───────────────────────────────────────────────
 
-  private buildPayoutInformation(): { address: string; percent: number }[] | null {
-    const devFeeAddress = this.configService.get('DEV_FEE_ADDRESS');
-    const devFeePercent = parseFloat(this.configService.get('DEV_FEE_PERCENT') ?? '1.5');
-
+  private buildPayoutInformation(blockRewardSats?: number): { address: string; percent: number }[] | null {
     if (this.entity && this.address) {
       this.hashRate = this.statistics.hashRate;
     }
+
+    // PPLNS mode: shared coinbase with proportional payouts
+    if (this.portConfig.payoutMode === 'pplns' && this.pplnsService?.isEnabled() && blockRewardSats) {
+      // Note: getPayoutDistribution is async but buildPayoutInformation is sync.
+      // We rely on the cached distribution from the last job update cycle.
+      // For the initial call, the caller should use getPayoutDistributionAsync() instead.
+      this.noFee = false;
+      return null; // Signal caller to use async path
+    }
+
+    // Solo mode: existing behavior
+    const devFeeAddress = this.configService.get('DEV_FEE_ADDRESS');
+    const devFeePercent = parseFloat(this.configService.get('DEV_FEE_PERCENT') ?? '1.5');
 
     if (!this.address) {
       if (!devFeeAddress) return null;
@@ -1808,13 +1835,25 @@ export class StratumV2Client {
     ];
   }
 
+  private async buildPayoutInformationAsync(blockRewardSats: number): Promise<{ address: string; percent: number }[] | null> {
+    if (this.portConfig.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
+      const distribution = await this.pplnsService.getPayoutDistribution(blockRewardSats);
+      if (distribution && distribution.length > 0) {
+        this.noFee = false;
+        return distribution;
+      }
+    }
+    return this.buildPayoutInformation();
+  }
+
   private async sendNewMiningJob(jobTemplate: IJobTemplate, sendPrevHash: boolean, channelId?: number): Promise<void> {
     const targetChannelId = channelId ?? this.primaryChannelId;
     if (targetChannelId == null) return;
     const channel = this.channels.get(targetChannelId);
     if (!channel) return;
 
-    const payoutInformation = this.buildPayoutInformation();
+    const payoutInformation = await this.buildPayoutInformationAsync(jobTemplate.blockData.coinbasevalue)
+      ?? this.buildPayoutInformation();
     if (!payoutInformation) return;
 
     const job = new MiningJob(

--- a/src/models/interfaces/unified-stratum.interfaces.ts
+++ b/src/models/interfaces/unified-stratum.interfaces.ts
@@ -6,6 +6,13 @@ import { Socket } from 'net';
 export type ProtocolVersion = 'v1' | 'v2';
 
 /**
+ * Payout mode for a stratum port.
+ * - 'solo': Each miner gets their own coinbase (existing behavior)
+ * - 'pplns': Shared coinbase with proportional payouts based on PPLNS window
+ */
+export type PayoutMode = 'solo' | 'pplns';
+
+/**
  * Configuration passed when starting a stratum port.
  */
 export interface StratumPortConfig {
@@ -13,6 +20,7 @@ export interface StratumPortConfig {
   initialDifficulty: number;
   allowSuggestedDifficulty: boolean;
   targetSharesPerMinute: number;
+  payoutMode?: PayoutMode;
 }
 
 /**

--- a/src/services/pplns-integration.spec.ts
+++ b/src/services/pplns-integration.spec.ts
@@ -1,0 +1,401 @@
+jest.mock('node-telegram-bot-api', () => jest.fn());
+
+/**
+ * PPLNS Integration Test
+ *
+ * Simulates the complete PPLNS flow end-to-end:
+ *   1. Multiple miners submit shares over time
+ *   2. PPLNS distribution is calculated
+ *   3. Real MiningJob is created with the distribution
+ *   4. Coinbase transaction is verified (correct outputs, amounts, addresses)
+ *   5. Block found triggers payout processing
+ *   6. Pending balances and payout history are verified
+ *   7. Multi-block accumulation tested for sub-dust miners
+ */
+
+import * as bitcoinjs from 'bitcoinjs-lib';
+import { MiningJob } from '../models/MiningJob';
+import { IJobTemplate } from './stratum-v1-jobs.service';
+import { PplnsService } from './pplns.service';
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+const BLOCK_REWARD = 312_500_000; // 3.125 BTC
+const NETWORK = bitcoinjs.networks.regtest;
+
+// Regtest addresses (valid bech32 for regtest)
+const FEE_ADDR   = 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080';
+const MINER_A    = 'bcrt1qrp33g0q5b5698ahp5jnf0y5ems7p06sscnrvss';  // fictional but valid format... actually let me use proper ones
+// Actually for regtest we need bcrt1... addresses. Let me generate valid ones.
+// These are valid regtest P2WPKH addresses (20-byte witness program)
+const ADDR_FEE    = 'bcrt1q4zy2q8q4autcujjuxy653c9fe3g2qe2gr84xqz';
+const ADDR_MINER1 = 'bcrt1q4vctecss7yxdgd6pmg3cw2auggx834nwvqyt8j';
+const ADDR_MINER2 = 'bcrt1qkhpva0cdzl849uzmcuucmmswdaf8ry6qcmnsyy';
+const ADDR_MINER3 = 'bcrt1q2nuvcnjft64gwd0767aqxl7wl88g7h9fjrjjgx';
+
+function createMockJobTemplate(height = 800_000): IJobTemplate {
+  const block = new bitcoinjs.Block();
+  block.version = 0x20000000;
+  block.prevHash = Buffer.alloc(32, 0xaa);
+  block.merkleRoot = Buffer.alloc(32, 0xbb);
+  block.timestamp = Math.floor(Date.now() / 1000);
+  block.bits = 0x1d00ffff;
+  block.nonce = 0;
+  block.transactions = [new bitcoinjs.Transaction()]; // dummy coinbase for witnessCommit
+  block.transactions[0].version = 2;
+  block.transactions[0].addInput(Buffer.alloc(32, 0), 0xffffffff, 0xffffffff);
+  block.transactions[0].addOutput(Buffer.alloc(22, 0), 0);
+  block.transactions[0].ins[0].witness = [Buffer.alloc(32, 0)];
+  block.witnessCommit = bitcoinjs.Block.calculateMerkleRoot(block.transactions, true);
+
+  return {
+    block,
+    merkle_branch: [],
+    blockData: {
+      id: '1',
+      creation: Date.now(),
+      coinbasevalue: BLOCK_REWARD,
+      networkDifficulty: 100_000,
+      height,
+      clearJobs: false,
+    },
+  };
+}
+
+// ── Mock infrastructure (same as unit tests) ────────────────────
+
+function createMockRedis() {
+  const store = new Map<string, string>();
+  let zset: { score: number; value: string }[] = [];
+
+  return {
+    incr: jest.fn(async (key: string) => {
+      const val = parseInt(store.get(key) ?? '0', 10) + 1;
+      store.set(key, val.toString());
+      return val;
+    }),
+    get: jest.fn(async (key: string) => store.get(key) ?? null),
+    set: jest.fn(async (key: string, value: string) => { store.set(key, value); }),
+    incrByFloat: jest.fn(async (key: string, amount: number) => {
+      const val = parseFloat(store.get(key) ?? '0') + amount;
+      store.set(key, val.toString());
+      return val;
+    }),
+    zAdd: jest.fn(async (_key: string, entry: { score: number; value: string }) => {
+      zset.push(entry);
+      zset.sort((a, b) => a.score - b.score);
+    }),
+    zRange: jest.fn(async (_key: string, start: number, end: number) => {
+      if (end === -1) end = zset.length - 1;
+      return zset.slice(start, end + 1).map(e => e.value);
+    }),
+    zRemRangeByRank: jest.fn(async (_key: string, start: number, end: number) => {
+      zset.splice(start, end - start + 1);
+    }),
+    zCard: jest.fn(async () => zset.length),
+  };
+}
+
+function createMockBalanceService() {
+  const balances = new Map<string, { pendingSats: number; totalPaidSats: number }>();
+  return {
+    addPending: jest.fn(async (address: string, sats: number) => {
+      const existing = balances.get(address);
+      if (existing) { existing.pendingSats += sats; }
+      else { balances.set(address, { pendingSats: sats, totalPaidSats: 0 }); }
+    }),
+    getPending: jest.fn(async (address: string) => balances.get(address)?.pendingSats ?? 0),
+    getBalance: jest.fn(async (address: string) => balances.get(address) ?? null),
+    getAllWithPending: jest.fn(async () =>
+      Array.from(balances.entries())
+        .filter(([, b]) => b.pendingSats > 0)
+        .map(([address, b]) => ({ address, ...b })),
+    ),
+    markPaid: jest.fn(async (address: string, sats: number) => {
+      const existing = balances.get(address);
+      if (existing) {
+        existing.pendingSats = Math.max(0, existing.pendingSats - sats);
+        existing.totalPaidSats += sats;
+      }
+    }),
+    _get: (address: string) => balances.get(address),
+  };
+}
+
+function createMockPayoutHistoryRepo() {
+  const saved: any[] = [];
+  return {
+    create: jest.fn((data: any) => data),
+    save: jest.fn(async (entity: any) => { saved.push(entity); return entity; }),
+    find: jest.fn(async () => saved),
+    _getSaved: () => saved,
+  };
+}
+
+function createPplnsService(feeAddress: string, feePercent: string) {
+  const redis = createMockRedis();
+  const balanceService = createMockBalanceService();
+  const payoutHistoryRepo = createMockPayoutHistoryRepo();
+  const configService = {
+    get: jest.fn((key: string) => {
+      const config: Record<string, string> = {
+        PPLNS_FEE_ADDRESS: feeAddress,
+        PPLNS_FEE_PERCENT: feePercent,
+        PPLNS_PORT: '3340',
+      };
+      return config[key];
+    }),
+  };
+  const stratumV1JobsService = {
+    newMiningJob$: { subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })) },
+  };
+
+  const service = new PplnsService(
+    configService as any,
+    { store: { client: redis } } as any,
+    balanceService as any,
+    payoutHistoryRepo as any,
+    stratumV1JobsService as any,
+  );
+
+  (service as any).redis = redis;
+  (service as any).enabled = true;
+
+  return { service, redis, balanceService, payoutHistoryRepo };
+}
+
+// ═════════════════════════════════════════════════════════════════
+// INTEGRATION TESTS
+// ═════════════════════════════════════════════════════════════════
+
+describe('PPLNS Integration', () => {
+
+  describe('Full flow: shares → distribution → coinbase → block found', () => {
+
+    it('should create a valid coinbase with correct outputs for 3 miners', async () => {
+      const { service } = createPplnsService(ADDR_FEE, '2');
+      service.setNetworkDifficulty(100_000);
+
+      // 1. Record shares: A=50%, B=30%, C=20%
+      await service.recordShare(ADDR_MINER1, 500);
+      await service.recordShare(ADDR_MINER2, 300);
+      await service.recordShare(ADDR_MINER3, 200);
+
+      // 2. Get payout distribution
+      const distribution = await service.getPayoutDistribution(BLOCK_REWARD);
+      expect(distribution.length).toBe(4); // fee + 3 miners
+
+      // Verify percentages sum to 100
+      const totalPercent = distribution.reduce((s, d) => s + d.percent, 0);
+      expect(totalPercent).toBeCloseTo(100, 1);
+
+      // 3. Create real MiningJob with the distribution
+      const jobTemplate = createMockJobTemplate();
+      const configService = { get: (key: string) => key === 'POOL_IDENTIFIER' ? 'blitzpool-test' : undefined };
+      const job = new MiningJob(configService as any, NETWORK, '1', distribution, jobTemplate);
+
+      // 4. Parse the coinbase transaction
+      const coinbaseHex = job.getCoinbaseTxHex();
+      expect(coinbaseHex).toBeDefined();
+      expect(coinbaseHex.length).toBeGreaterThan(0);
+
+      const coinbaseTx = bitcoinjs.Transaction.fromHex(coinbaseHex);
+
+      // Should have: 4 payout outputs + 1 OP_RETURN (witness commitment) = 5
+      expect(coinbaseTx.outs.length).toBe(5);
+
+      // 5. Verify output amounts sum to block reward
+      // (OP_RETURN output has value 0, so sum of the other 4 should be BLOCK_REWARD)
+      const payoutOutputs = coinbaseTx.outs.filter(o => o.value > 0);
+      const totalSats = payoutOutputs.reduce((s, o) => s + o.value, 0);
+      expect(totalSats).toBe(BLOCK_REWARD);
+
+      // 6. Verify fee address gets ~2%
+      // Fee is first output (unshifted in getPayoutDistribution)
+      const feeOutput = coinbaseTx.outs[0];
+      const expectedFeeSats = Math.floor(0.02 * BLOCK_REWARD); // 6,250,000
+      // Fee gets the remainder too, so it's >= 2%
+      expect(feeOutput.value).toBeGreaterThanOrEqual(expectedFeeSats);
+
+      // 7. Verify miners get proportional amounts
+      // Miner outputs are index 1,2,3 (after fee)
+      const minerOutputValues = [coinbaseTx.outs[1].value, coinbaseTx.outs[2].value, coinbaseTx.outs[3].value];
+      minerOutputValues.sort((a, b) => b - a); // largest first
+
+      // Largest miner (50%) should get ~49% of reward
+      const rewardForMiners = Math.floor(0.98 * BLOCK_REWARD); // 306,250,000
+      expect(minerOutputValues[0]).toBeGreaterThan(rewardForMiners * 0.45);
+      expect(minerOutputValues[0]).toBeLessThan(rewardForMiners * 0.55);
+
+      console.log('\n=== PPLNS Coinbase Verification ===');
+      console.log(`Block reward: ${BLOCK_REWARD} sats (${BLOCK_REWARD / 1e8} BTC)`);
+      console.log(`Fee output:   ${feeOutput.value} sats (${(feeOutput.value / BLOCK_REWARD * 100).toFixed(2)}%)`);
+      minerOutputValues.forEach((v, i) => {
+        console.log(`Miner ${i + 1}:     ${v} sats (${(v / BLOCK_REWARD * 100).toFixed(2)}%)`);
+      });
+      console.log(`Total:        ${totalSats} sats`);
+      console.log(`Coinbase size: ${coinbaseHex.length / 2} bytes, ${coinbaseTx.weight()} weight units`);
+      console.log(`Outputs:      ${coinbaseTx.outs.length} (${payoutOutputs.length} payouts + 1 OP_RETURN)`);
+    });
+
+    it('should handle block found and update balances correctly', async () => {
+      const { service, balanceService, payoutHistoryRepo } = createPplnsService(ADDR_FEE, '2');
+      service.setNetworkDifficulty(100_000);
+
+      // Record shares
+      await service.recordShare(ADDR_MINER1, 600);
+      await service.recordShare(ADDR_MINER2, 400);
+
+      // Simulate block found
+      await service.onBlockFound(800_000, BLOCK_REWARD);
+
+      // Both miners should be above dust → history logged
+      const history = payoutHistoryRepo._getSaved();
+      expect(history.length).toBe(3); // 2 miners + 1 fee
+
+      // Fee entry
+      const feeEntry = history.find((h: any) => h.address === ADDR_FEE);
+      expect(feeEntry).toBeDefined();
+      expect(feeEntry.paidSats).toBe(BLOCK_REWARD - Math.floor(0.98 * BLOCK_REWARD));
+      expect(feeEntry.inCoinbase).toBe(true);
+
+      // Miner entries
+      const miner1Entry = history.find((h: any) => h.address === ADDR_MINER1);
+      const miner2Entry = history.find((h: any) => h.address === ADDR_MINER2);
+      expect(miner1Entry.paidSats).toBeGreaterThan(miner2Entry.paidSats); // 60% > 40%
+      expect(miner1Entry.inCoinbase).toBe(true);
+      expect(miner2Entry.inCoinbase).toBe(true);
+
+      // Total paid should equal block reward
+      const totalPaid = history.reduce((s: number, h: any) => s + h.paidSats, 0);
+      // Due to Math.floor rounding, total may be slightly less than BLOCK_REWARD
+      expect(totalPaid).toBeLessThanOrEqual(BLOCK_REWARD);
+      expect(totalPaid).toBeGreaterThan(BLOCK_REWARD - 10); // At most a few sats lost to rounding
+
+      console.log('\n=== Block Found Payout History ===');
+      history.forEach((h: any) => {
+        console.log(`  ${h.address.substring(0, 20)}...: ${h.paidSats} sats (${h.percent.toFixed(2)}%) ${h.inCoinbase ? 'COINBASE' : 'PENDING'}`);
+      });
+    });
+
+    it('should accumulate sub-dust miners across blocks and eventually pay out', async () => {
+      const { service, balanceService } = createPplnsService(ADDR_FEE, '2');
+      service.setNetworkDifficulty(10_000_000); // large window
+
+      // Miner 1 dominates, Miner 2 is tiny (sub-dust per block)
+      await service.recordShare(ADDR_MINER1, 10_000_000);
+      await service.recordShare(ADDR_MINER2, 1); // ~30 sats per block
+
+      // Block 1: Miner 2 gets sub-dust → pending
+      await service.onBlockFound(800_000, BLOCK_REWARD);
+      const pending1 = balanceService._get(ADDR_MINER2)?.pendingSats ?? 0;
+      expect(pending1).toBeGreaterThan(0);
+      expect(pending1).toBeLessThan(546); // sub-dust
+      console.log(`\nBlock 1: Miner2 pending = ${pending1} sats`);
+
+      // Blocks 2-20: accumulate
+      for (let i = 1; i <= 19; i++) {
+        await service.onBlockFound(800_000 + i, BLOCK_REWARD);
+      }
+      const pending20 = balanceService._get(ADDR_MINER2)?.pendingSats ?? 0;
+      console.log(`Block 20: Miner2 pending = ${pending20} sats`);
+
+      // After enough blocks, pending should exceed dust
+      if (pending20 >= 546) {
+        console.log('Miner2 has accumulated enough for coinbase payout!');
+        // Next distribution should include Miner 2
+        const dist = await service.getPayoutDistribution(BLOCK_REWARD);
+        const miner2InDist = dist.find(d => d.address === ADDR_MINER2);
+        expect(miner2InDist).toBeDefined();
+      } else {
+        // Need more blocks — calculate how many
+        const perBlock = pending20 / 20;
+        const blocksNeeded = Math.ceil(546 / perBlock);
+        console.log(`Miner2 needs ~${blocksNeeded} blocks to reach dust limit`);
+      }
+    });
+
+    it('should create valid coinbase for large miner count', async () => {
+      const { service } = createPplnsService(ADDR_FEE, '2');
+      service.setNetworkDifficulty(100_000_000);
+
+      // Simulate 50 miners with varying hashrates
+      const miners: string[] = [];
+      for (let i = 0; i < 50; i++) {
+        // Generate unique fake addresses (won't validate on mainnet but valid for test)
+        const addr = ADDR_MINER1; // Re-use same address for simplicity in output count
+        await service.recordShare(addr, 1000 + i * 100);
+      }
+      // Add some distinct addresses
+      await service.recordShare(ADDR_MINER1, 50_000);
+      await service.recordShare(ADDR_MINER2, 30_000);
+      await service.recordShare(ADDR_MINER3, 20_000);
+
+      const distribution = await service.getPayoutDistribution(BLOCK_REWARD);
+      expect(distribution.length).toBeGreaterThanOrEqual(2); // at least fee + 1 miner
+
+      // Create coinbase
+      const jobTemplate = createMockJobTemplate();
+      const configService = { get: () => 'test' };
+      const job = new MiningJob(configService as any, NETWORK, '1', distribution, jobTemplate);
+      const coinbaseHex = job.getCoinbaseTxHex();
+      const coinbaseTx = bitcoinjs.Transaction.fromHex(coinbaseHex);
+
+      // Verify total value
+      const totalValue = coinbaseTx.outs.reduce((s, o) => s + o.value, 0);
+      expect(totalValue).toBe(BLOCK_REWARD);
+
+      // Verify weight is within limits
+      expect(coinbaseTx.weight()).toBeLessThan(4_000_000);
+
+      console.log(`\n=== Large Pool Coinbase ===`);
+      console.log(`Miners in distribution: ${distribution.length - 1}`);
+      console.log(`Coinbase outputs: ${coinbaseTx.outs.length}`);
+      console.log(`Coinbase weight: ${coinbaseTx.weight()} WU`);
+      console.log(`Coinbase size: ${coinbaseHex.length / 2} bytes`);
+    });
+
+    it('should produce consistent distribution and onBlockFound accounting', async () => {
+      const { service, payoutHistoryRepo } = createPplnsService(ADDR_FEE, '2');
+      service.setNetworkDifficulty(100_000);
+
+      // Equal shares
+      await service.recordShare(ADDR_MINER1, 500);
+      await service.recordShare(ADDR_MINER2, 500);
+
+      // Get distribution (what goes into coinbase)
+      const dist = await service.getPayoutDistribution(BLOCK_REWARD);
+
+      // Build coinbase
+      const jobTemplate = createMockJobTemplate();
+      const configService = { get: () => 'test' };
+      const job = new MiningJob(configService as any, NETWORK, '1', dist, jobTemplate);
+      const coinbaseTx = bitcoinjs.Transaction.fromHex(job.getCoinbaseTxHex());
+
+      // Simulate block found
+      await service.onBlockFound(800_000, BLOCK_REWARD);
+
+      // Compare coinbase output values with history
+      const history = payoutHistoryRepo._getSaved();
+      const historyMiner1 = history.find((h: any) => h.address === ADDR_MINER1);
+      const historyMiner2 = history.find((h: any) => h.address === ADDR_MINER2);
+
+      // Both should get equal amounts (50/50)
+      expect(historyMiner1.paidSats).toBe(historyMiner2.paidSats);
+
+      // Verify coinbase outputs match history
+      // Outputs: [fee, miner1, miner2, OP_RETURN]
+      const payoutOutputs = coinbaseTx.outs.filter(o => o.value > 0);
+      const coinbaseMinerValues = payoutOutputs.slice(1).map(o => o.value).sort();
+      const historyMinerValues = [historyMiner1.paidSats, historyMiner2.paidSats].sort();
+
+      // They should match (same window state, same calculation)
+      expect(coinbaseMinerValues).toEqual(historyMinerValues);
+
+      console.log('\n=== Consistency Check ===');
+      console.log(`Coinbase miner outputs: ${coinbaseMinerValues}`);
+      console.log(`History paidSats:       ${historyMinerValues}`);
+      console.log(`Match: ${JSON.stringify(coinbaseMinerValues) === JSON.stringify(historyMinerValues)}`);
+    });
+  });
+});

--- a/src/services/pplns.service.spec.ts
+++ b/src/services/pplns.service.spec.ts
@@ -1,0 +1,584 @@
+jest.mock('node-telegram-bot-api', () => jest.fn());
+
+import { PplnsService } from './pplns.service';
+
+// ── Mock Redis ──────────────────────────────────────────────────
+
+function createMockRedis() {
+  const store = new Map<string, string>();
+  // Sorted set: array of { score, value } sorted by score
+  let zset: { score: number; value: string }[] = [];
+
+  return {
+    incr: jest.fn(async (key: string) => {
+      const val = parseInt(store.get(key) ?? '0', 10) + 1;
+      store.set(key, val.toString());
+      return val;
+    }),
+    get: jest.fn(async (key: string) => store.get(key) ?? null),
+    set: jest.fn(async (key: string, value: string) => { store.set(key, value); }),
+    incrByFloat: jest.fn(async (key: string, amount: number) => {
+      const val = parseFloat(store.get(key) ?? '0') + amount;
+      store.set(key, val.toString());
+      return val;
+    }),
+    zAdd: jest.fn(async (_key: string, entry: { score: number; value: string }) => {
+      zset.push(entry);
+      zset.sort((a, b) => a.score - b.score);
+    }),
+    zRange: jest.fn(async (_key: string, start: number, end: number) => {
+      if (end === -1) end = zset.length - 1;
+      return zset.slice(start, end + 1).map(e => e.value);
+    }),
+    zRemRangeByRank: jest.fn(async (_key: string, start: number, end: number) => {
+      zset.splice(start, end - start + 1);
+    }),
+    zCard: jest.fn(async () => zset.length),
+    // Helpers for tests
+    _getZset: () => zset,
+    _clear: () => { store.clear(); zset = []; },
+  };
+}
+
+// ── Mock Balance Service ────────────────────────────────────────
+
+function createMockBalanceService() {
+  const balances = new Map<string, { pendingSats: number; totalPaidSats: number }>();
+
+  return {
+    addPending: jest.fn(async (address: string, sats: number) => {
+      const existing = balances.get(address);
+      if (existing) {
+        existing.pendingSats += sats;
+      } else {
+        balances.set(address, { pendingSats: sats, totalPaidSats: 0 });
+      }
+    }),
+    getPending: jest.fn(async (address: string) => balances.get(address)?.pendingSats ?? 0),
+    getBalance: jest.fn(async (address: string) => balances.get(address) ?? null),
+    getAllWithPending: jest.fn(async () =>
+      Array.from(balances.entries())
+        .filter(([, b]) => b.pendingSats > 0)
+        .map(([address, b]) => ({ address, ...b })),
+    ),
+    markPaid: jest.fn(async (address: string, sats: number) => {
+      const existing = balances.get(address);
+      if (existing) {
+        existing.pendingSats = Math.max(0, existing.pendingSats - sats);
+        existing.totalPaidSats += sats;
+      }
+    }),
+    // Helper
+    _set: (address: string, pendingSats: number, totalPaidSats = 0) => {
+      balances.set(address, { pendingSats, totalPaidSats });
+    },
+    _get: (address: string) => balances.get(address),
+  };
+}
+
+// ── Mock Payout History Repo ────────────────────────────────────
+
+function createMockPayoutHistoryRepo() {
+  const saved: any[] = [];
+  return {
+    create: jest.fn((data: any) => data),
+    save: jest.fn(async (entity: any) => { saved.push(entity); return entity; }),
+    find: jest.fn(async () => saved),
+    _getSaved: () => saved,
+  };
+}
+
+// ── Service Factory ─────────────────────────────────────────────
+
+function createService(opts: { feeAddress?: string; feePercent?: string; port?: string } = {}) {
+  const redis = createMockRedis();
+  const balanceService = createMockBalanceService();
+  const payoutHistoryRepo = createMockPayoutHistoryRepo();
+
+  const configService = {
+    get: jest.fn((key: string) => {
+      const config: Record<string, string> = {
+        PPLNS_FEE_ADDRESS: opts.feeAddress ?? 'bc1qfee',
+        PPLNS_FEE_PERCENT: opts.feePercent ?? '2',
+        PPLNS_PORT: opts.port ?? '3340',
+      };
+      return config[key];
+    }),
+  };
+
+  const cacheManager = { store: { client: redis } };
+
+  const service = new PplnsService(
+    configService as any,
+    cacheManager as any,
+    balanceService as any,
+    payoutHistoryRepo as any,
+  );
+
+  // Manually trigger onModuleInit to wire up Redis
+  (service as any).redis = redis;
+  (service as any).enabled = true;
+
+  return { service, redis, balanceService, payoutHistoryRepo };
+}
+
+// ── Helper: record N shares ─────────────────────────────────────
+
+async function recordShares(
+  service: PplnsService,
+  shares: { address: string; difficulty: number }[],
+) {
+  for (const s of shares) {
+    await service.recordShare(s.address, s.difficulty);
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════
+// TESTS
+// ═════════════════════════════════════════════════════════════════
+
+describe('PplnsService', () => {
+  // ── Share Recording ──────────────────────────────────────────
+
+  describe('recordShare', () => {
+    it('should add shares to the Redis sorted set', async () => {
+      const { service, redis } = createService();
+      service.setNetworkDifficulty(1000);
+
+      await service.recordShare('bc1qminerA', 500);
+      await service.recordShare('bc1qminerB', 300);
+
+      const entries = await redis.zRange('pplns:shares', 0, -1);
+      expect(entries).toHaveLength(2);
+      expect(entries[0]).toContain('bc1qminerA:500:');
+      expect(entries[1]).toContain('bc1qminerB:300:');
+    });
+
+    it('should update the window total', async () => {
+      const { service, redis } = createService();
+      service.setNetworkDifficulty(100000);
+
+      await service.recordShare('bc1qminerA', 500);
+      await service.recordShare('bc1qminerB', 300);
+
+      const total = parseFloat(await redis.get('pplns:window:total') ?? '0');
+      expect(total).toBe(800);
+    });
+  });
+
+  // ── Window Trimming ──────────────────────────────────────────
+
+  describe('trimWindow', () => {
+    it('should trim oldest shares when window exceeds N', async () => {
+      const { service, redis } = createService();
+      // Window size = 4 * 100 = 400
+      service.setNetworkDifficulty(100);
+
+      // Add 500 total difficulty (exceeds 400 window)
+      await recordShares(service, [
+        { address: 'A', difficulty: 100 },
+        { address: 'B', difficulty: 100 },
+        { address: 'C', difficulty: 100 },
+        { address: 'D', difficulty: 100 },
+        { address: 'E', difficulty: 100 },
+      ]);
+
+      // Oldest share(s) should have been trimmed
+      const entries = await redis.zRange('pplns:shares', 0, -1);
+      const totalDiff = entries.reduce((sum: number, e: string) => sum + parseFloat(e.split(':')[1]), 0);
+      expect(totalDiff).toBeLessThanOrEqual(400);
+    });
+
+    it('should keep window total in sync', async () => {
+      const { service, redis } = createService();
+      service.setNetworkDifficulty(100); // window = 400
+
+      await recordShares(service, [
+        { address: 'A', difficulty: 200 },
+        { address: 'B', difficulty: 200 },
+        { address: 'C', difficulty: 200 }, // total 600, exceeds 400
+      ]);
+
+      const stored = parseFloat(await redis.get('pplns:window:total') ?? '0');
+      const entries = await redis.zRange('pplns:shares', 0, -1);
+      const actual = entries.reduce((sum: number, e: string) => sum + parseFloat(e.split(':')[1]), 0);
+
+      expect(Math.abs(stored - actual)).toBeLessThan(0.01);
+    });
+
+    it('should not trim when window is not full', async () => {
+      const { service, redis } = createService();
+      service.setNetworkDifficulty(1000); // window = 4000
+
+      await recordShares(service, [
+        { address: 'A', difficulty: 100 },
+        { address: 'B', difficulty: 100 },
+      ]);
+
+      const entries = await redis.zRange('pplns:shares', 0, -1);
+      expect(entries).toHaveLength(2);
+    });
+  });
+
+  // ── Payout Distribution ──────────────────────────────────────
+
+  describe('getPayoutDistribution', () => {
+    const BLOCK_REWARD = 312_500_000; // 3.125 BTC
+
+    it('should distribute proportionally with pool fee', async () => {
+      const { service } = createService({ feePercent: '2' });
+      service.setNetworkDifficulty(100000);
+
+      await recordShares(service, [
+        { address: 'bc1qA', difficulty: 500 },
+        { address: 'bc1qB', difficulty: 300 },
+        { address: 'bc1qC', difficulty: 200 },
+      ]);
+
+      const dist = await service.getPayoutDistribution(BLOCK_REWARD);
+
+      // Fee should be first
+      expect(dist[0].address).toBe('bc1qfee');
+
+      // Sum should be ~100%
+      const totalPercent = dist.reduce((s, d) => s + d.percent, 0);
+      expect(totalPercent).toBeCloseTo(100, 1);
+
+      // Fee should be ~2%
+      expect(dist[0].percent).toBeCloseTo(2, 0);
+
+      // Miner A should have highest share
+      const minerA = dist.find(d => d.address === 'bc1qA');
+      const minerB = dist.find(d => d.address === 'bc1qB');
+      expect(minerA!.percent).toBeGreaterThan(minerB!.percent);
+    });
+
+    it('should calculate correct sat amounts from percentages', async () => {
+      const { service } = createService({ feePercent: '2' });
+      service.setNetworkDifficulty(100000);
+
+      // 50/50 split
+      await recordShares(service, [
+        { address: 'bc1qA', difficulty: 500 },
+        { address: 'bc1qB', difficulty: 500 },
+      ]);
+
+      const dist = await service.getPayoutDistribution(BLOCK_REWARD);
+      const minerA = dist.find(d => d.address === 'bc1qA')!;
+      const minerB = dist.find(d => d.address === 'bc1qB')!;
+
+      // Each miner should get 49% (half of 98%)
+      expect(minerA.percent).toBeCloseTo(49, 0);
+      expect(minerB.percent).toBeCloseTo(49, 0);
+
+      // Sat calculation: floor(0.49 * 312_500_000) = 153_125_000
+      const satA = Math.floor((minerA.percent / 100) * BLOCK_REWARD);
+      expect(satA).toBeGreaterThan(150_000_000);
+    });
+
+    it('should filter sub-dust miners from coinbase', async () => {
+      const { service } = createService({ feePercent: '2' });
+      // Set window large enough to hold all shares without trimming
+      service.setNetworkDifficulty(10_000_000);
+
+      // Miner B has negligible shares → sub-dust
+      // ratio = 1/10_000_001 ≈ 1e-7, baseSats = floor(1e-7 * 306_250_000) = 30 < 546
+      await recordShares(service, [
+        { address: 'bc1qA', difficulty: 10_000_000 },
+        { address: 'bc1qB', difficulty: 1 },
+      ]);
+
+      const dist = await service.getPayoutDistribution(BLOCK_REWARD);
+      const minerB = dist.find(d => d.address === 'bc1qB');
+      expect(minerB).toBeUndefined(); // Not in coinbase — sub-dust
+    });
+
+    it('should include pending balance in payout calculation', async () => {
+      const { service, balanceService } = createService({ feePercent: '2' });
+      service.setNetworkDifficulty(100000);
+
+      // Miner B has small shares but large pending
+      balanceService._set('bc1qB', 100_000); // 100k sats pending
+
+      await recordShares(service, [
+        { address: 'bc1qA', difficulty: 900 },
+        { address: 'bc1qB', difficulty: 100 },
+      ]);
+
+      const dist = await service.getPayoutDistribution(BLOCK_REWARD);
+      const minerB = dist.find(d => d.address === 'bc1qB');
+      expect(minerB).toBeDefined(); // Should be in coinbase (pending + base > dust)
+    });
+
+    it('should include pending-only addresses above dust', async () => {
+      const { service, balanceService } = createService({ feePercent: '2' });
+      service.setNetworkDifficulty(100000);
+
+      // Miner C has no current shares but enough pending
+      balanceService._set('bc1qC', 1000); // 1000 sats pending >= 546
+
+      await recordShares(service, [
+        { address: 'bc1qA', difficulty: 500 },
+      ]);
+
+      const dist = await service.getPayoutDistribution(BLOCK_REWARD);
+      const minerC = dist.find(d => d.address === 'bc1qC');
+      expect(minerC).toBeDefined();
+    });
+
+    it('should return fallback when window is empty', async () => {
+      const { service } = createService();
+      service.setNetworkDifficulty(100000);
+
+      const dist = await service.getPayoutDistribution(BLOCK_REWARD);
+      expect(dist).toHaveLength(1);
+      expect(dist[0].address).toBe('bc1qfee');
+      expect(dist[0].percent).toBe(100);
+    });
+
+    it('should assign remainder percent to fee address', async () => {
+      const { service } = createService({ feePercent: '2' });
+      service.setNetworkDifficulty(100000);
+
+      // Two miners, one gets filtered as sub-dust
+      // The sub-dust miner's share goes to fee as remainder
+      await recordShares(service, [
+        { address: 'bc1qA', difficulty: 500 },
+        { address: 'bc1qB', difficulty: 500 },
+      ]);
+
+      const dist = await service.getPayoutDistribution(BLOCK_REWARD);
+      const totalPercent = dist.reduce((s, d) => s + d.percent, 0);
+      // Remainder mechanism ensures total is 100%
+      expect(totalPercent).toBeCloseTo(100, 1);
+
+      // Fee should be at least 2%
+      const fee = dist.find(d => d.address === 'bc1qfee');
+      expect(fee).toBeDefined();
+      expect(fee!.percent).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // ── Block Found ──────────────────────────────────────────────
+
+  describe('onBlockFound', () => {
+    const BLOCK_REWARD = 312_500_000;
+
+    it('should mark pending as paid for above-dust miners', async () => {
+      const { service, balanceService } = createService({ feePercent: '2' });
+      service.setNetworkDifficulty(100000);
+
+      balanceService._set('bc1qA', 5000); // 5000 sats pending
+
+      await recordShares(service, [
+        { address: 'bc1qA', difficulty: 500 },
+        { address: 'bc1qB', difficulty: 500 },
+      ]);
+
+      await service.onBlockFound(800000, BLOCK_REWARD);
+
+      // A's pending should be cleared
+      const balA = balanceService._get('bc1qA');
+      expect(balA!.pendingSats).toBe(0);
+      expect(balA!.totalPaidSats).toBe(5000);
+    });
+
+    it('should accumulate pending for sub-dust miners', async () => {
+      const { service, balanceService } = createService({ feePercent: '2' });
+      // Large window to avoid trimming
+      service.setNetworkDifficulty(10_000_000);
+
+      // ratio = 1/10_000_001 ≈ 1e-7, baseSats = floor(1e-7 * 306_250_000) = 30
+      await recordShares(service, [
+        { address: 'bc1qBig', difficulty: 10_000_000 },
+        { address: 'bc1qTiny', difficulty: 1 },
+      ]);
+
+      await service.onBlockFound(800000, BLOCK_REWARD);
+
+      // 30 sats < 546 → addPending should have been called
+      expect(balanceService.addPending).toHaveBeenCalledWith('bc1qTiny', expect.any(Number));
+      const balTiny = balanceService._get('bc1qTiny');
+      expect(balTiny).toBeDefined();
+      expect(balTiny!.pendingSats).toBeGreaterThan(0);
+      expect(balTiny!.totalPaidSats).toBe(0);
+    });
+
+    it('should process pending-only addresses', async () => {
+      const { service, balanceService } = createService({ feePercent: '2' });
+      service.setNetworkDifficulty(100000);
+
+      // Miner C has pending from previous blocks but no current shares
+      balanceService._set('bc1qC', 1000);
+
+      await recordShares(service, [
+        { address: 'bc1qA', difficulty: 500 },
+      ]);
+
+      await service.onBlockFound(800000, BLOCK_REWARD);
+
+      // C's pending should be marked as paid (>= 546 dust)
+      const balC = balanceService._get('bc1qC');
+      expect(balC!.pendingSats).toBe(0);
+      expect(balC!.totalPaidSats).toBe(1000);
+    });
+
+    it('should NOT process pending-only addresses below dust', async () => {
+      const { service, balanceService } = createService({ feePercent: '2' });
+      service.setNetworkDifficulty(100000);
+
+      // Miner C has pending below dust
+      balanceService._set('bc1qC', 200); // < 546
+
+      await recordShares(service, [
+        { address: 'bc1qA', difficulty: 500 },
+      ]);
+
+      await service.onBlockFound(800000, BLOCK_REWARD);
+
+      // C's pending should remain untouched
+      const balC = balanceService._get('bc1qC');
+      expect(balC!.pendingSats).toBe(200);
+      expect(balC!.totalPaidSats).toBe(0);
+    });
+
+    it('should log payout history for all miners including fee', async () => {
+      const { service, payoutHistoryRepo } = createService({ feePercent: '2' });
+      service.setNetworkDifficulty(100000);
+
+      await recordShares(service, [
+        { address: 'bc1qA', difficulty: 600 },
+        { address: 'bc1qB', difficulty: 400 },
+      ]);
+
+      await service.onBlockFound(800000, BLOCK_REWARD);
+
+      const history = payoutHistoryRepo._getSaved();
+      // 2 miners + 1 fee = 3 entries
+      expect(history.length).toBe(3);
+
+      const feeEntry = history.find((h: any) => h.address === 'bc1qfee');
+      expect(feeEntry).toBeDefined();
+      expect(feeEntry.inCoinbase).toBe(true);
+      expect(feeEntry.blockHeight).toBe(800000);
+    });
+
+    it('should handle accumulation across multiple blocks', async () => {
+      const { service, balanceService } = createService({ feePercent: '2' });
+      // Large window to avoid trimming
+      service.setNetworkDifficulty(10_000_000);
+
+      // ratio = 1/10_000_001 → baseSats ≈ 30
+      await recordShares(service, [
+        { address: 'bc1qBig', difficulty: 10_000_000 },
+        { address: 'bc1qSmall', difficulty: 1 },
+      ]);
+
+      await service.onBlockFound(800000, BLOCK_REWARD);
+      const afterBlock1 = balanceService._get('bc1qSmall')?.pendingSats ?? 0;
+      expect(afterBlock1).toBeGreaterThan(0);
+
+      // Block 2: accumulate more (same window shares)
+      await service.onBlockFound(800001, BLOCK_REWARD);
+      const afterBlock2 = balanceService._get('bc1qSmall')?.pendingSats ?? 0;
+      expect(afterBlock2).toBeGreaterThan(afterBlock1);
+    });
+  });
+
+  // ── Window Stats ──────────────────────────────────────────────
+
+  describe('getWindowStats', () => {
+    it('should return correct stats', async () => {
+      const { service } = createService();
+      service.setNetworkDifficulty(1000); // window = 4000
+
+      await recordShares(service, [
+        { address: 'bc1qA', difficulty: 500 },
+        { address: 'bc1qB', difficulty: 300 },
+        { address: 'bc1qA', difficulty: 200 }, // A again
+      ]);
+
+      const stats = await service.getWindowStats();
+      expect(stats.shareCount).toBe(3);
+      expect(stats.minerCount).toBe(2); // A and B
+      expect(stats.totalDifficulty).toBe(1000);
+      expect(stats.windowSize).toBe(4000);
+    });
+  });
+
+  // ── Address Status ────────────────────────────────────────────
+
+  describe('getAddressStatus', () => {
+    it('should return window share and pending balance', async () => {
+      const { service, balanceService } = createService();
+      service.setNetworkDifficulty(100000);
+      balanceService._set('bc1qA', 5000, 50000);
+
+      await recordShares(service, [
+        { address: 'bc1qA', difficulty: 600 },
+        { address: 'bc1qB', difficulty: 400 },
+      ]);
+
+      const status = await service.getAddressStatus('bc1qA');
+      expect(status.pendingSats).toBe(5000);
+      expect(status.totalPaidSats).toBe(50000);
+      expect(status.currentWindowDifficulty).toBe(600);
+      expect(status.currentWindowPercent).toBeCloseTo(60, 0);
+    });
+
+    it('should return zeros for unknown address', async () => {
+      const { service } = createService();
+      service.setNetworkDifficulty(100000);
+
+      const status = await service.getAddressStatus('bc1qUnknown');
+      expect(status.pendingSats).toBe(0);
+      expect(status.totalPaidSats).toBe(0);
+      expect(status.currentWindowDifficulty).toBe(0);
+      expect(status.currentWindowPercent).toBe(0);
+    });
+  });
+
+  // ── Current Distribution ──────────────────────────────────────
+
+  describe('getCurrentDistribution', () => {
+    it('should return sorted distribution', async () => {
+      const { service } = createService();
+      service.setNetworkDifficulty(100000);
+
+      await recordShares(service, [
+        { address: 'bc1qA', difficulty: 100 },
+        { address: 'bc1qB', difficulty: 300 },
+        { address: 'bc1qC', difficulty: 600 },
+      ]);
+
+      const dist = await service.getCurrentDistribution();
+      expect(dist).toHaveLength(3);
+      // Sorted by percent descending
+      expect(dist[0].address).toBe('bc1qC');
+      expect(dist[0].percent).toBeCloseTo(60, 0);
+      expect(dist[1].address).toBe('bc1qB');
+      expect(dist[2].address).toBe('bc1qA');
+    });
+  });
+
+  // ── Disabled Service ──────────────────────────────────────────
+
+  describe('disabled state', () => {
+    it('should not record shares when disabled', async () => {
+      const { service, redis } = createService({ port: '' });
+      (service as any).enabled = false;
+
+      await service.recordShare('bc1qA', 500);
+      expect(redis.zAdd).not.toHaveBeenCalled();
+    });
+
+    it('should return fallback distribution when disabled', async () => {
+      const { service } = createService({ port: '' });
+      (service as any).enabled = false;
+
+      const dist = await service.getPayoutDistribution(312_500_000);
+      expect(dist).toHaveLength(1);
+      expect(dist[0].percent).toBe(100);
+    });
+  });
+});

--- a/src/services/pplns.service.spec.ts
+++ b/src/services/pplns.service.spec.ts
@@ -108,11 +108,16 @@ function createService(opts: { feeAddress?: string; feePercent?: string; port?: 
 
   const cacheManager = { store: { client: redis } };
 
+  const stratumV1JobsService = {
+    newMiningJob$: { subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })) },
+  };
+
   const service = new PplnsService(
     configService as any,
     cacheManager as any,
     balanceService as any,
     payoutHistoryRepo as any,
+    stratumV1JobsService as any,
   );
 
   // Manually trigger onModuleInit to wire up Redis

--- a/src/services/pplns.service.ts
+++ b/src/services/pplns.service.ts
@@ -1,0 +1,436 @@
+import { Injectable, Inject, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PplnsBalanceService } from '../ORM/pplns-balance/pplns-balance.service';
+import { PplnsPayoutHistoryEntity } from '../ORM/pplns-balance/pplns-payout-history.entity';
+
+/**
+ * PPLNS (Pay Per Last N Shares) engine.
+ *
+ * Tracks shares in a Redis sorted set and computes coinbase payout
+ * distributions.  Window size = 4 * network_difficulty (diff1-equivalent).
+ *
+ * Only active when PPLNS_PORT is configured.
+ */
+
+const PPLNS_WINDOW_FACTOR = 4;
+const DUST_LIMIT_SATS = 546; // P2PKH dust; P2WPKH is 294 but use higher for safety
+const REDIS_KEY_SHARES = 'pplns:shares';
+const REDIS_KEY_COUNTER = 'pplns:counter';
+const REDIS_KEY_WINDOW_TOTAL = 'pplns:window:total';
+
+export interface PplnsPayoutEntry {
+    address: string;
+    percent: number;
+}
+
+@Injectable()
+export class PplnsService implements OnModuleInit {
+    private redis: any = null;
+    private enabled = false;
+    private feeAddress: string;
+    private feePercent: number;
+    private networkDifficulty = 0;
+
+    constructor(
+        private readonly configService: ConfigService,
+        @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+        private readonly balanceService: PplnsBalanceService,
+        @InjectRepository(PplnsPayoutHistoryEntity)
+        private readonly payoutHistoryRepo: Repository<PplnsPayoutHistoryEntity>,
+    ) {
+        this.feeAddress = this.configService.get('PPLNS_FEE_ADDRESS') ?? '';
+        this.feePercent = parseFloat(this.configService.get('PPLNS_FEE_PERCENT') ?? '2');
+        this.enabled = !!this.configService.get('PPLNS_PORT');
+    }
+
+    async onModuleInit(): Promise<void> {
+        if (!this.enabled) return;
+
+        try {
+            const store: any = this.cacheManager.store;
+            if (store?.client) {
+                this.redis = store.client;
+                console.log('[PPLNS] Service initialized with Redis');
+            } else {
+                console.error('[PPLNS] Redis not available — PPLNS will not function!');
+            }
+        } catch (error) {
+            console.error('[PPLNS] Failed to access Redis client:', error);
+        }
+    }
+
+    isEnabled(): boolean {
+        return this.enabled && !!this.redis;
+    }
+
+    /**
+     * Update network difficulty (called when new block template arrives).
+     */
+    setNetworkDifficulty(difficulty: number): void {
+        if (Number.isFinite(difficulty) && difficulty > 0) {
+            this.networkDifficulty = difficulty;
+        }
+    }
+
+    /**
+     * Get the current PPLNS window size in diff1-equivalent shares.
+     */
+    getWindowSize(): number {
+        return PPLNS_WINDOW_FACTOR * this.networkDifficulty;
+    }
+
+    // ── Share Recording ──────────────────────────────────────────
+
+    /**
+     * Record an accepted share from a PPLNS miner.
+     */
+    async recordShare(address: string, difficulty: number): Promise<void> {
+        if (!this.redis || !this.enabled) return;
+
+        const counter = await this.redis.incr(REDIS_KEY_COUNTER);
+        const entry = `${address}:${difficulty}:${Date.now()}`;
+        await this.redis.zAdd(REDIS_KEY_SHARES, { score: counter, value: entry });
+        await this.redis.incrByFloat(REDIS_KEY_WINDOW_TOTAL, difficulty);
+
+        await this.trimWindow();
+    }
+
+    private trimCounter = 0;
+
+    /**
+     * Trim oldest shares to keep window within N = 4 * networkDifficulty.
+     */
+    private async trimWindow(): Promise<void> {
+        const windowSize = this.getWindowSize();
+        if (windowSize <= 0) return;
+
+        const totalStr = await this.redis.get(REDIS_KEY_WINDOW_TOTAL);
+        let total = parseFloat(totalStr) || 0;
+
+        // Trim in batches of 100 for efficiency
+        while (total > windowSize) {
+            const oldest = await this.redis.zRange(REDIS_KEY_SHARES, 0, 99);
+            if (!oldest || oldest.length === 0) break;
+
+            let removedDiff = 0;
+            for (const entry of oldest) {
+                const parts = entry.split(':');
+                removedDiff += parseFloat(parts[1]) || 0;
+            }
+
+            await this.redis.zRemRangeByRank(REDIS_KEY_SHARES, 0, oldest.length - 1);
+            total -= removedDiff;
+        }
+
+        this.trimCounter++;
+
+        // Every 1000 trims, recalculate total from sorted set to fix float drift
+        if (this.trimCounter % 1000 === 0) {
+            total = await this.recalculateWindowTotal();
+        }
+
+        await this.redis.set(REDIS_KEY_WINDOW_TOTAL, total.toString());
+    }
+
+    /**
+     * Recalculate window total from all entries in the sorted set.
+     * Fixes accumulated floating-point drift.
+     */
+    private async recalculateWindowTotal(): Promise<number> {
+        const entries = await this.redis.zRange(REDIS_KEY_SHARES, 0, -1);
+        let total = 0;
+        for (const entry of (entries ?? [])) {
+            total += parseFloat(entry.split(':')[1]) || 0;
+        }
+        return total;
+    }
+
+    // ── Payout Distribution ──────────────────────────────────────
+
+    /**
+     * Calculate the current PPLNS payout distribution for coinbase construction.
+     * Returns an array of {address, percent} suitable for MiningJob.
+     *
+     * @param blockRewardSats - Total block reward in satoshis
+     */
+    async getPayoutDistribution(blockRewardSats: number): Promise<PplnsPayoutEntry[]> {
+        if (!this.redis || !this.enabled) {
+            return this.fallbackDistribution();
+        }
+
+        // 1. Read all shares from window
+        const entries = await this.redis.zRange(REDIS_KEY_SHARES, 0, -1);
+        if (!entries || entries.length === 0) {
+            return this.fallbackDistribution();
+        }
+
+        // 2. Sum difficulty per address
+        const addressDiff = new Map<string, number>();
+        let totalDiff = 0;
+
+        for (const entry of entries) {
+            const parts = entry.split(':');
+            const addr = parts[0];
+            const diff = parseFloat(parts[1]) || 0;
+            addressDiff.set(addr, (addressDiff.get(addr) ?? 0) + diff);
+            totalDiff += diff;
+        }
+
+        if (totalDiff <= 0) {
+            return this.fallbackDistribution();
+        }
+
+        // 3. Calculate pool fee
+        const feePercent = this.feePercent;
+        const minerPercent = 100 - feePercent;
+
+        // 4. Calculate sat amounts per miner and handle dust/pending
+        const rewardForMiners = Math.floor((minerPercent / 100) * blockRewardSats);
+        const payouts: PplnsPayoutEntry[] = [];
+        let totalAssignedPercent = 0;
+
+        // Load pending balances
+        const pendingEntities = await this.balanceService.getAllWithPending();
+        const pendingMap = new Map<string, number>();
+        for (const e of pendingEntities) {
+            pendingMap.set(e.address, e.pendingSats);
+        }
+
+        // Calculate each miner's share
+        const minerShares: { address: string; sats: number; percent: number }[] = [];
+        for (const [addr, diff] of addressDiff) {
+            const ratio = diff / totalDiff;
+            const baseSats = Math.floor(ratio * rewardForMiners);
+            const pendingSats = pendingMap.get(addr) ?? 0;
+            const totalSats = baseSats + pendingSats;
+            const percent = (totalSats / blockRewardSats) * 100;
+
+            minerShares.push({ address: addr, sats: totalSats, percent });
+        }
+
+        // Also include addresses with pending balance that have NO shares in current window
+        for (const [addr, pending] of pendingMap) {
+            if (!addressDiff.has(addr) && pending >= DUST_LIMIT_SATS) {
+                // This miner has accumulated enough from previous blocks
+                const percent = (pending / blockRewardSats) * 100;
+                minerShares.push({ address: addr, sats: pending, percent });
+            }
+        }
+
+        // Separate into coinbase-eligible (>= dust) and pending (< dust)
+        for (const ms of minerShares) {
+            if (ms.sats >= DUST_LIMIT_SATS) {
+                payouts.push({ address: ms.address, percent: ms.percent });
+                totalAssignedPercent += ms.percent;
+            }
+            // Sub-dust amounts are handled in onBlockFound()
+        }
+
+        // 5. Add pool fee
+        if (this.feeAddress) {
+            payouts.unshift({ address: this.feeAddress, percent: feePercent });
+            totalAssignedPercent += feePercent;
+        }
+
+        // 6. Ensure percentages sum to ~100 — assign remainder to fee address
+        if (payouts.length > 0 && totalAssignedPercent < 100) {
+            const remainder = 100 - totalAssignedPercent;
+            if (this.feeAddress) {
+                payouts[0].percent += remainder;
+            } else {
+                payouts[payouts.length - 1].percent += remainder;
+            }
+        }
+
+        return payouts.length > 0 ? payouts : this.fallbackDistribution();
+    }
+
+    /**
+     * Fallback: all reward goes to pool fee address.
+     */
+    private fallbackDistribution(): PplnsPayoutEntry[] {
+        if (this.feeAddress) {
+            return [{ address: this.feeAddress, percent: 100 }];
+        }
+        return [];
+    }
+
+    // ── Block Found ──────────────────────────────────────────────
+
+    /**
+     * Called when a block is found on a PPLNS port.
+     * Updates pending balances for sub-dust miners and marks paid for others.
+     */
+    async onBlockFound(blockHeight: number, blockRewardSats: number): Promise<void> {
+        if (!this.redis || !this.enabled) return;
+
+        console.log(`[PPLNS] Block ${blockHeight} found! Processing payouts...`);
+
+        // Read current window
+        const entries = await this.redis.zRange(REDIS_KEY_SHARES, 0, -1);
+        if (!entries || entries.length === 0) return;
+
+        // Sum difficulty per address
+        const addressDiff = new Map<string, number>();
+        let totalDiff = 0;
+
+        for (const entry of entries) {
+            const parts = entry.split(':');
+            const addr = parts[0];
+            const diff = parseFloat(parts[1]) || 0;
+            addressDiff.set(addr, (addressDiff.get(addr) ?? 0) + diff);
+            totalDiff += diff;
+        }
+
+        if (totalDiff <= 0) return;
+
+        const rewardForMiners = Math.floor(((100 - this.feePercent) / 100) * blockRewardSats);
+
+        for (const [addr, diff] of addressDiff) {
+            const ratio = diff / totalDiff;
+            const sats = Math.floor(ratio * rewardForMiners);
+            const pending = await this.balanceService.getPending(addr);
+            const totalSats = sats + pending;
+
+            const percent = (ratio * (100 - this.feePercent));
+
+            if (totalSats >= DUST_LIMIT_SATS) {
+                // Was included in coinbase — mark pending as paid
+                if (pending > 0) {
+                    await this.balanceService.markPaid(addr, pending);
+                }
+                await this.payoutHistoryRepo.save(this.payoutHistoryRepo.create({
+                    blockHeight, address: addr, paidSats: totalSats, percent, inCoinbase: true,
+                }));
+                console.log(`[PPLNS]   ${addr}: ${totalSats} sats (paid in coinbase, ${percent.toFixed(2)}%)`);
+            } else {
+                // Below dust — accumulate
+                await this.balanceService.addPending(addr, sats);
+                await this.payoutHistoryRepo.save(this.payoutHistoryRepo.create({
+                    blockHeight, address: addr, paidSats: sats, percent, inCoinbase: false,
+                }));
+                console.log(`[PPLNS]   ${addr}: ${sats} sats → pending (total: ${sats + pending})`);
+            }
+        }
+
+        // Log pool fee
+        const feeSats = blockRewardSats - rewardForMiners;
+        if (this.feeAddress) {
+            await this.payoutHistoryRepo.save(this.payoutHistoryRepo.create({
+                blockHeight, address: this.feeAddress, paidSats: feeSats, percent: this.feePercent, inCoinbase: true,
+            }));
+        }
+
+        console.log(`[PPLNS] Block ${blockHeight} payouts processed for ${addressDiff.size} miners`);
+    }
+
+    // ── Stats ────────────────────────────────────────────────────
+
+    async getWindowStats(): Promise<{
+        totalDifficulty: number;
+        windowSize: number;
+        shareCount: number;
+        minerCount: number;
+    }> {
+        if (!this.redis) {
+            return { totalDifficulty: 0, windowSize: 0, shareCount: 0, minerCount: 0 };
+        }
+
+        const totalStr = await this.redis.get(REDIS_KEY_WINDOW_TOTAL);
+        const shareCount = await this.redis.zCard(REDIS_KEY_SHARES);
+        const entries = await this.redis.zRange(REDIS_KEY_SHARES, 0, -1);
+        const miners = new Set<string>();
+        for (const entry of (entries ?? [])) {
+            miners.add(entry.split(':')[0]);
+        }
+
+        return {
+            totalDifficulty: parseFloat(totalStr) || 0,
+            windowSize: this.getWindowSize(),
+            shareCount: shareCount ?? 0,
+            minerCount: miners.size,
+        };
+    }
+
+    /**
+     * Get PPLNS status for a specific address.
+     */
+    async getAddressStatus(address: string): Promise<{
+        pendingSats: number;
+        totalPaidSats: number;
+        currentWindowDifficulty: number;
+        currentWindowPercent: number;
+    }> {
+        const balance = await this.balanceService.getBalance(address);
+
+        let currentWindowDifficulty = 0;
+        let currentWindowPercent = 0;
+
+        if (this.redis) {
+            const entries = await this.redis.zRange(REDIS_KEY_SHARES, 0, -1);
+            let totalDiff = 0;
+            let addressDiff = 0;
+            for (const entry of (entries ?? [])) {
+                const parts = entry.split(':');
+                const diff = parseFloat(parts[1]) || 0;
+                totalDiff += diff;
+                if (parts[0] === address) {
+                    addressDiff += diff;
+                }
+            }
+            currentWindowDifficulty = addressDiff;
+            if (totalDiff > 0) {
+                currentWindowPercent = (addressDiff / totalDiff) * 100;
+            }
+        }
+
+        return {
+            pendingSats: balance?.pendingSats ?? 0,
+            totalPaidSats: balance?.totalPaidSats ?? 0,
+            currentWindowDifficulty,
+            currentWindowPercent,
+        };
+    }
+
+    /**
+     * Get current distribution (all miners and their share).
+     */
+    async getCurrentDistribution(): Promise<{ address: string; difficulty: number; percent: number }[]> {
+        if (!this.redis) return [];
+
+        const entries = await this.redis.zRange(REDIS_KEY_SHARES, 0, -1);
+        if (!entries || entries.length === 0) return [];
+
+        const addressDiff = new Map<string, number>();
+        let totalDiff = 0;
+        for (const entry of entries) {
+            const parts = entry.split(':');
+            const diff = parseFloat(parts[1]) || 0;
+            addressDiff.set(parts[0], (addressDiff.get(parts[0]) ?? 0) + diff);
+            totalDiff += diff;
+        }
+
+        return Array.from(addressDiff.entries())
+            .map(([address, difficulty]) => ({
+                address,
+                difficulty,
+                percent: totalDiff > 0 ? (difficulty / totalDiff) * 100 : 0,
+            }))
+            .sort((a, b) => b.percent - a.percent);
+    }
+
+    /**
+     * Get payout history for an address.
+     */
+    async getPayoutHistory(address: string, limit = 50): Promise<PplnsPayoutHistoryEntity[]> {
+        return this.payoutHistoryRepo.find({
+            where: { address },
+            order: { createdAt: 'DESC' },
+            take: limit,
+        });
+    }
+}

--- a/src/services/pplns.service.ts
+++ b/src/services/pplns.service.ts
@@ -290,6 +290,9 @@ export class PplnsService implements OnModuleInit {
 
         const rewardForMiners = Math.floor(((100 - this.feePercent) / 100) * blockRewardSats);
 
+        // Track which pending addresses we've already processed
+        const processedAddresses = new Set<string>();
+
         for (const [addr, diff] of addressDiff) {
             const ratio = diff / totalDiff;
             const sats = Math.floor(ratio * rewardForMiners);
@@ -297,6 +300,7 @@ export class PplnsService implements OnModuleInit {
             const totalSats = sats + pending;
 
             const percent = (ratio * (100 - this.feePercent));
+            processedAddresses.add(addr);
 
             if (totalSats >= DUST_LIMIT_SATS) {
                 // Was included in coinbase — mark pending as paid
@@ -314,6 +318,21 @@ export class PplnsService implements OnModuleInit {
                     blockHeight, address: addr, paidSats: sats, percent, inCoinbase: false,
                 }));
                 console.log(`[PPLNS]   ${addr}: ${sats} sats → pending (total: ${sats + pending})`);
+            }
+        }
+
+        // Process pending-only addresses (no current shares but pending >= dust was in coinbase)
+        const pendingEntities = await this.balanceService.getAllWithPending();
+        for (const entity of pendingEntities) {
+            if (processedAddresses.has(entity.address)) continue;
+            if (entity.pendingSats >= DUST_LIMIT_SATS) {
+                // This address was included in coinbase via getPayoutDistribution() — mark as paid
+                const paidAmount = entity.pendingSats;
+                await this.balanceService.markPaid(entity.address, paidAmount);
+                await this.payoutHistoryRepo.save(this.payoutHistoryRepo.create({
+                    blockHeight, address: entity.address, paidSats: paidAmount, percent: (paidAmount / blockRewardSats) * 100, inCoinbase: true,
+                }));
+                console.log(`[PPLNS]   ${entity.address}: ${paidAmount} sats (pending-only, paid in coinbase)`);
             }
         }
 

--- a/src/services/pplns.service.ts
+++ b/src/services/pplns.service.ts
@@ -37,6 +37,7 @@ export class PplnsService implements OnModuleInit, OnModuleDestroy {
     private feePercent: number;
     private networkDifficulty = 0;
     private jobSubscription: Subscription | null = null;
+    private readonly isPrimaryInstance: boolean;
 
     constructor(
         private readonly configService: ConfigService,
@@ -49,6 +50,11 @@ export class PplnsService implements OnModuleInit, OnModuleDestroy {
         this.feeAddress = this.configService.get('PPLNS_FEE_ADDRESS') ?? '';
         this.feePercent = parseFloat(this.configService.get('PPLNS_FEE_PERCENT') ?? '2');
         this.enabled = !!this.configService.get('PPLNS_PORT');
+
+        // PM2 cluster safety: only primary instance processes block payouts
+        const pm2InstanceId = process.env.NODE_APP_INSTANCE ?? process.env.pm_id ?? process.env.PM2_INSTANCE_ID;
+        const normalized = typeof pm2InstanceId === 'string' ? pm2InstanceId.trim() : undefined;
+        this.isPrimaryInstance = !normalized || normalized === '0';
     }
 
     async onModuleInit(): Promise<void> {
@@ -283,6 +289,12 @@ export class PplnsService implements OnModuleInit, OnModuleDestroy {
      */
     async onBlockFound(blockHeight: number, blockRewardSats: number): Promise<void> {
         if (!this.redis || !this.enabled) return;
+
+        // PM2 cluster: only primary instance processes payouts to avoid double-crediting
+        if (!this.isPrimaryInstance) {
+            console.log(`[PPLNS] Block ${blockHeight} found — skipping payout processing (non-primary PM2 instance)`);
+            return;
+        }
 
         console.log(`[PPLNS] Block ${blockHeight} found! Processing payouts...`);
 

--- a/src/services/pplns.service.ts
+++ b/src/services/pplns.service.ts
@@ -1,11 +1,13 @@
-import { Injectable, Inject, OnModuleInit } from '@nestjs/common';
+import { Injectable, Inject, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { Subscription } from 'rxjs';
 import { PplnsBalanceService } from '../ORM/pplns-balance/pplns-balance.service';
 import { PplnsPayoutHistoryEntity } from '../ORM/pplns-balance/pplns-payout-history.entity';
+import { StratumV1JobsService } from './stratum-v1-jobs.service';
 
 /**
  * PPLNS (Pay Per Last N Shares) engine.
@@ -28,12 +30,13 @@ export interface PplnsPayoutEntry {
 }
 
 @Injectable()
-export class PplnsService implements OnModuleInit {
+export class PplnsService implements OnModuleInit, OnModuleDestroy {
     private redis: any = null;
     private enabled = false;
     private feeAddress: string;
     private feePercent: number;
     private networkDifficulty = 0;
+    private jobSubscription: Subscription | null = null;
 
     constructor(
         private readonly configService: ConfigService,
@@ -41,6 +44,7 @@ export class PplnsService implements OnModuleInit {
         private readonly balanceService: PplnsBalanceService,
         @InjectRepository(PplnsPayoutHistoryEntity)
         private readonly payoutHistoryRepo: Repository<PplnsPayoutHistoryEntity>,
+        private readonly stratumV1JobsService: StratumV1JobsService,
     ) {
         this.feeAddress = this.configService.get('PPLNS_FEE_ADDRESS') ?? '';
         this.feePercent = parseFloat(this.configService.get('PPLNS_FEE_PERCENT') ?? '2');
@@ -61,6 +65,18 @@ export class PplnsService implements OnModuleInit {
         } catch (error) {
             console.error('[PPLNS] Failed to access Redis client:', error);
         }
+
+        // Subscribe to new block templates to keep network difficulty in sync
+        this.jobSubscription = this.stratumV1JobsService.newMiningJob$.subscribe((jobTemplate) => {
+            if (jobTemplate?.blockData?.networkDifficulty) {
+                this.setNetworkDifficulty(jobTemplate.blockData.networkDifficulty);
+            }
+        });
+        console.log('[PPLNS] Subscribed to block template updates for network difficulty');
+    }
+
+    onModuleDestroy(): void {
+        this.jobSubscription?.unsubscribe();
     }
 
     isEnabled(): boolean {

--- a/src/services/protocol-detector.service.ts
+++ b/src/services/protocol-detector.service.ts
@@ -58,6 +58,7 @@ export class ProtocolDetectorService implements OnModuleInit {
       initialDifficulty: normalizedDefaultDifficulty,
       allowSuggestedDifficulty: true,
       targetSharesPerMinute: normalizedDefaultTargetShares,
+      payoutMode: 'solo',
     });
 
     if (!Number.isNaN(highDiffPort) && highDiffPort !== normalizedDefaultPort) {
@@ -71,7 +72,31 @@ export class ProtocolDetectorService implements OnModuleInit {
         initialDifficulty: normalizedHighDiffDifficulty,
         allowSuggestedDifficulty: false,
         targetSharesPerMinute: normalizedHighDiffTargetShares,
+        payoutMode: 'solo',
       });
+    }
+
+    // PPLNS port (optional)
+    const pplnsPortStr = this.configService.get<string>('PPLNS_PORT');
+    if (pplnsPortStr) {
+      const pplnsPort = parseInt(pplnsPortStr, 10);
+      if (!Number.isNaN(pplnsPort) && pplnsPort !== normalizedDefaultPort && pplnsPort !== highDiffPort) {
+        const pplnsDifficulty = parseFloat(
+          this.configService.get<string>('PPLNS_START_DIFFICULTY') ?? normalizedDefaultDifficulty.toString(),
+        );
+        const pplnsTargetShares = parseFloat(
+          this.configService.get<string>('PPLNS_TARGET_SHARES_PER_MINUTE') ?? normalizedDefaultTargetShares.toString(),
+        );
+
+        this.startUnifiedServer({
+          port: Number.isNaN(pplnsPort) ? 3340 : pplnsPort,
+          initialDifficulty: Number.isNaN(pplnsDifficulty) ? normalizedDefaultDifficulty : pplnsDifficulty,
+          allowSuggestedDifficulty: true,
+          targetSharesPerMinute: Number.isNaN(pplnsTargetShares) ? normalizedDefaultTargetShares : pplnsTargetShares,
+          payoutMode: 'pplns',
+        });
+        console.log(`[ProtocolDetector] PPLNS port configured: ${pplnsPort}`);
+      }
     }
   }
 

--- a/src/services/stratum-v1.service.spec.ts
+++ b/src/services/stratum-v1.service.spec.ts
@@ -40,6 +40,7 @@ describe('StratumV1Service.onModuleInit', () => {
       {} as unknown as ShareTotalsCacheService,
       { store: {} } as any,
       { onReset: jest.fn() } as any,
+      { isEnabled: () => false } as any,
     );
   }
 

--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -22,6 +22,7 @@ import { ShareTotalsCacheService } from './share-totals-cache.service';
 import { AddressSettingsCacheService } from './address-settings-cache.service';
 import { DifficultyScoresCacheService } from './difficulty-scores-cache.service';
 import { WorkerResetBroadcastService } from './worker-reset-broadcast.service';
+import { PplnsService } from './pplns.service';
 
 @Injectable()
 export class StratumV1Service implements OnModuleInit {
@@ -48,6 +49,7 @@ export class StratumV1Service implements OnModuleInit {
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     @Inject(forwardRef(() => WorkerResetBroadcastService))
     private readonly workerResetBroadcastService: WorkerResetBroadcastService,
+    private readonly pplnsService: PplnsService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -116,6 +118,8 @@ export class StratumV1Service implements OnModuleInit {
       portConfig.allowSuggestedDifficulty,
       portConfig.targetSharesPerMinute,
       this.redisClient,
+      portConfig.payoutMode ?? 'solo',
+      this.pplnsService,
     );
 
     socket.on('close', async (hadError: boolean) => {

--- a/src/services/stratum-v2.service.spec.ts
+++ b/src/services/stratum-v2.service.spec.ts
@@ -70,6 +70,7 @@ function createService(envOverrides: Record<string, string> = {}) {
     difficultyScoresCacheService as any, // difficultyScoresCacheService
     {} as any, // templateDistributionService
     {} as any, // jobDeclarationService
+    { isEnabled: () => false } as any, // pplnsService
   );
 
   return { service, configService, clientService, addressSettingsCacheService, workerResetBroadcastService, difficultyScoresCacheService };

--- a/src/services/stratum-v2.service.ts
+++ b/src/services/stratum-v2.service.ts
@@ -39,6 +39,7 @@ import { ClientRejectedStatisticsService } from '../ORM/client-rejected-statisti
 import { ExternalSharesService } from './external-shares.service';
 import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 import { ShareTotalsCacheService } from './share-totals-cache.service';
+import { PplnsService } from './pplns.service';
 import { WorkerResetBroadcastService } from './worker-reset-broadcast.service';
 import { DifficultyScoresCacheService } from './difficulty-scores-cache.service';
 
@@ -96,6 +97,7 @@ export class StratumV2Service implements OnModuleInit, IProtocolHandler {
     private readonly templateDistributionService: TemplateDistributionService,
     @Inject(forwardRef(() => JobDeclarationService))
     private readonly jobDeclarationService: JobDeclarationService,
+    private readonly pplnsService: PplnsService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -254,6 +256,7 @@ export class StratumV2Service implements OnModuleInit, IProtocolHandler {
       this.shareTotalsCacheService,
       this.extranonceManager,
       this.templateDistributionService,
+      this.pplnsService,
     );
 
     // Client self-registers when channel is opened and self-unregisters on close.

--- a/typeorm-cli.config.ts
+++ b/typeorm-cli.config.ts
@@ -20,6 +20,8 @@ import { PoolShareStatisticsEntity } from './src/ORM/pool-share-statistics/pool-
 import { PushSubscriptionEntity } from './src/ORM/push-subscriptions/push-subscription.entity';
 import { RpcBlockEntity } from './src/ORM/rpc-block/rpc-block.entity';
 import { TelegramSubscriptionsEntity } from './src/ORM/telegram-subscriptions/telegram-subscriptions.entity';
+import { PplnsBalanceEntity } from './src/ORM/pplns-balance/pplns-balance.entity';
+import { PplnsPayoutHistoryEntity } from './src/ORM/pplns-balance/pplns-payout-history.entity';
 
 loadEnv({ path: process.env.TYPEORM_ENV_PATH ?? '.env' });
 
@@ -42,6 +44,8 @@ const entities = [
     PushSubscriptionEntity,
     RpcBlockEntity,
     TelegramSubscriptionsEntity,
+    PplnsBalanceEntity,
+    PplnsPayoutHistoryEntity,
 ];
 
 const { autoLoadEntities, ...rest } = moduleOptions as DataSourceOptions & { autoLoadEntities?: boolean };


### PR DESCRIPTION
## Summary
PPLNS (Pay Per Last N Shares) engine with direct coinbase payouts, running alongside existing solo mining on a dedicated port.

- **PPLNS Engine**: Redis sorted set share window (N = 4 * network_difficulty), payout distribution calculator with dust accumulation (546 sat threshold)
- **Coinbase Payouts**: Proportional outputs directly in the coinbase transaction (OCEAN/DATUM model)
- **SV1 + SV2**: Full integration in both stratum protocols (share recording, shared coinbase, block-found handler)
- **API**: 4 endpoints — /pplns/status, /pplns/distribution, /pplns/:address, /pplns/:address/history
- **Payout History**: Per-block per-miner audit trail in database
- **PM2 Cluster Safe**: Only primary instance processes block payouts
- **Network Difficulty Sync**: Automatic via job subscription, no manual calls needed
- **29 Tests**: 24 unit tests + 5 integration tests with real bitcoinjs-lib coinbase verification

### Configuration
```
PPLNS_PORT=3340
PPLNS_FEE_ADDRESS=bc1q...
PPLNS_FEE_PERCENT=2
```

Solo mining on existing ports (3333, 3339) remains completely unchanged.

## Test plan
- [x] Unit tests: window trimming, distribution, dust, block-found, pending-only fix (24 passing)
- [x] Integration tests: shares → distribution → real coinbase → output verification (5 passing)
- [x] Compilation check: tsc --noEmit clean
- [ ] Regtest E2E with actual miner (follow-up)

## Follow-up PRs (on feature/pplns-pool-support)
- [ ] Payout distribution caching (performance)
- [ ] Block-fund consistency (snapshot distribution at job creation)
- [ ] Coinbase size/weight validation
- [ ] Block-found race condition guard
- [ ] JDP + PPLNS integration (coinbaseOutputs in AllocateMiningJobToken with full PPLNS distribution)
- [ ] UI integration on blitzpool-ui