### PR TITLE
Add coinbase weight validation for PPLNS outputs

### DIFF
--- a/full-setup/blitzpool-example.env
+++ b/full-setup/blitzpool-example.env
@@ -115,6 +115,10 @@ NETWORK=mainnet
 # This address receives the pool fee directly in the coinbase transaction
 #PPLNS_FEE_ADDRESS=bc1q...
 #PPLNS_FEE_PERCENT=2
+# Coinbase weight budget in WU — must match bitcoin.conf blockreservedweight
+# Default: 50000 (fits ~400 P2WPKH outputs). Set higher for more miners.
+# Requires bitcoin.conf: blockreservedweight=50000
+#PPLNS_COINBASE_WEIGHT_BUDGET=50000
 
 # Notes:
 # - PPLNS window size = 4 * network_difficulty (diff1-equivalent shares)

--- a/src/services/pplns.service.spec.ts
+++ b/src/services/pplns.service.spec.ts
@@ -90,7 +90,7 @@ function createMockPayoutHistoryRepo() {
 
 // ── Service Factory ─────────────────────────────────────────────
 
-function createService(opts: { feeAddress?: string; feePercent?: string; port?: string } = {}) {
+function createService(opts: { feeAddress?: string; feePercent?: string; port?: string; weightBudget?: string } = {}) {
   const redis = createMockRedis();
   const balanceService = createMockBalanceService();
   const payoutHistoryRepo = createMockPayoutHistoryRepo();
@@ -101,6 +101,7 @@ function createService(opts: { feeAddress?: string; feePercent?: string; port?: 
         PPLNS_FEE_ADDRESS: opts.feeAddress ?? 'bc1qfee',
         PPLNS_FEE_PERCENT: opts.feePercent ?? '2',
         PPLNS_PORT: opts.port ?? '3340',
+        ...(opts.weightBudget ? { PPLNS_COINBASE_WEIGHT_BUDGET: opts.weightBudget } : {}),
       };
       return config[key];
     }),
@@ -584,6 +585,91 @@ describe('PplnsService', () => {
       const dist = await service.getPayoutDistribution(312_500_000);
       expect(dist).toHaveLength(1);
       expect(dist[0].percent).toBe(100);
+    });
+  });
+
+  // ── Coinbase Weight Validation ────────────────────────────────
+
+  describe('coinbase weight validation', () => {
+    const BLOCK_REWARD = 312_500_000;
+
+    it('should report correct max outputs for default budget', () => {
+      const { service } = createService();
+      const max = service.getMaxCoinbaseOutputs();
+      // Budget 50000, base 320, fee+opreturn = 2*124 = 248
+      // (50000 - 320 - 248) / 124 = floor(49432/124) = 398
+      expect(max).toBeGreaterThan(300);
+      expect(max).toBeLessThan(500);
+    });
+
+    it('should trim outputs when miners exceed weight budget', async () => {
+      // Tiny budget: only fits ~3 miner outputs
+      // Budget 1000, base 320, fee+opreturn = 248, remaining = 432, per output = 124
+      // max miner outputs = floor(432/124) = 3
+      const { service } = createService({ weightBudget: '1000' });
+      service.setNetworkDifficulty(100_000_000); // large window
+
+      // Add 10 miners with equal shares
+      for (let i = 0; i < 10; i++) {
+        await service.recordShare(`miner${i}`, 1000);
+      }
+
+      const dist = await service.getPayoutDistribution(BLOCK_REWARD);
+
+      // Should have: fee + max 3 miners = 4 outputs (not 11)
+      const minerOutputs = dist.filter(d => d.address !== 'bc1qfee');
+      expect(minerOutputs.length).toBeLessThanOrEqual(3);
+      expect(dist.length).toBeLessThanOrEqual(4); // fee + 3 miners
+
+      // Percentages should still sum to ~100
+      const totalPercent = dist.reduce((s, d) => s + d.percent, 0);
+      expect(totalPercent).toBeCloseTo(100, 0);
+    });
+
+    it('should keep largest miners when trimming', async () => {
+      // Budget for ~3 miner outputs
+      const { service } = createService({ weightBudget: '1000' });
+      service.setNetworkDifficulty(100_000_000);
+
+      // Miners with very different shares
+      await service.recordShare('big1', 10000);
+      await service.recordShare('big2', 8000);
+      await service.recordShare('big3', 6000);
+      await service.recordShare('small1', 100);
+      await service.recordShare('small2', 50);
+      await service.recordShare('small3', 10);
+
+      const dist = await service.getPayoutDistribution(BLOCK_REWARD);
+      const minerAddrs = dist.filter(d => d.address !== 'bc1qfee').map(d => d.address);
+
+      // Big miners should be in, small miners trimmed
+      expect(minerAddrs).toContain('big1');
+      expect(minerAddrs).toContain('big2');
+      expect(minerAddrs).toContain('big3');
+      expect(minerAddrs).not.toContain('small1');
+      expect(minerAddrs).not.toContain('small2');
+      expect(minerAddrs).not.toContain('small3');
+    });
+
+    it('should not trim when miners fit within budget', async () => {
+      const { service } = createService(); // default 50000 budget
+      service.setNetworkDifficulty(100_000_000);
+
+      // 5 miners — well within 400 output limit
+      for (let i = 0; i < 5; i++) {
+        await service.recordShare(`miner${i}`, 1000);
+      }
+
+      const dist = await service.getPayoutDistribution(BLOCK_REWARD);
+      const minerOutputs = dist.filter(d => d.address !== 'bc1qfee');
+      expect(minerOutputs.length).toBe(5); // all 5 kept
+    });
+
+    it('should handle custom weight budget from env', () => {
+      const { service } = createService({ weightBudget: '100000' });
+      const max = service.getMaxCoinbaseOutputs();
+      // (100000 - 320 - 248) / 124 = floor(99432/124) = 802
+      expect(max).toBeGreaterThan(700);
     });
   });
 });

--- a/src/services/pplns.service.ts
+++ b/src/services/pplns.service.ts
@@ -24,6 +24,11 @@ const REDIS_KEY_SHARES = 'pplns:shares';
 const REDIS_KEY_COUNTER = 'pplns:counter';
 const REDIS_KEY_WINDOW_TOTAL = 'pplns:window:total';
 
+// Coinbase weight budget — must match bitcoin.conf blockreservedweight
+const DEFAULT_COINBASE_WEIGHT_BUDGET = 50_000; // WU — fits ~400 P2WPKH outputs
+const COINBASE_BASE_WEIGHT = 320; // Approx: input + witness + OP_RETURN commitment
+const COINBASE_OUTPUT_WEIGHT = 124; // Per P2WPKH output: (8 value + 1 len + 22 script) * 4
+
 export interface PplnsPayoutEntry {
     address: string;
     percent: number;
@@ -38,6 +43,7 @@ export class PplnsService implements OnModuleInit, OnModuleDestroy {
     private networkDifficulty = 0;
     private jobSubscription: Subscription | null = null;
     private readonly isPrimaryInstance: boolean;
+    private readonly coinbaseWeightBudget: number;
 
     // Distribution cache — avoids re-reading entire Redis sorted set on every job
     private cachedDistribution: PplnsPayoutEntry[] | null = null;
@@ -55,6 +61,7 @@ export class PplnsService implements OnModuleInit, OnModuleDestroy {
     ) {
         this.feeAddress = this.configService.get('PPLNS_FEE_ADDRESS') ?? '';
         this.feePercent = parseFloat(this.configService.get('PPLNS_FEE_PERCENT') ?? '2');
+        this.coinbaseWeightBudget = parseInt(this.configService.get('PPLNS_COINBASE_WEIGHT_BUDGET') ?? DEFAULT_COINBASE_WEIGHT_BUDGET.toString(), 10) || DEFAULT_COINBASE_WEIGHT_BUDGET;
         this.enabled = !!this.configService.get('PPLNS_PORT');
 
         // PM2 cluster safety: only primary instance processes block payouts
@@ -109,6 +116,16 @@ export class PplnsService implements OnModuleInit, OnModuleDestroy {
      */
     getWindowSize(): number {
         return PPLNS_WINDOW_FACTOR * this.networkDifficulty;
+    }
+
+    /**
+     * Max miner outputs that fit in the coinbase weight budget.
+     */
+    getMaxCoinbaseOutputs(): number {
+        const feeOutputCount = this.feeAddress ? 1 : 0;
+        return Math.floor(
+            (this.coinbaseWeightBudget - COINBASE_BASE_WEIGHT - (feeOutputCount + 1) * COINBASE_OUTPUT_WEIGHT) / COINBASE_OUTPUT_WEIGHT,
+        );
     }
 
     // ── Share Recording ──────────────────────────────────────────
@@ -262,15 +279,30 @@ export class PplnsService implements OnModuleInit, OnModuleDestroy {
         }
 
         // Separate into coinbase-eligible (>= dust) and pending (< dust)
-        for (const ms of minerShares) {
-            if (ms.sats >= DUST_LIMIT_SATS) {
-                payouts.push({ address: ms.address, percent: ms.percent });
-                totalAssignedPercent += ms.percent;
-            }
-            // Sub-dust amounts are handled in onBlockFound()
+        const eligible = minerShares
+            .filter(ms => ms.sats >= DUST_LIMIT_SATS)
+            .sort((a, b) => b.sats - a.sats); // largest first
+
+        // 5. Coinbase weight check — trim smallest outputs if coinbase would exceed budget
+        // +1 for fee output, +1 for OP_RETURN witness commitment
+        const feeOutputCount = this.feeAddress ? 1 : 0;
+        const maxMinerOutputs = Math.floor(
+            (this.coinbaseWeightBudget - COINBASE_BASE_WEIGHT - (feeOutputCount + 1) * COINBASE_OUTPUT_WEIGHT) / COINBASE_OUTPUT_WEIGHT,
+        );
+
+        let trimmed = eligible;
+        if (eligible.length > maxMinerOutputs && maxMinerOutputs > 0) {
+            trimmed = eligible.slice(0, maxMinerOutputs);
+            const removedCount = eligible.length - maxMinerOutputs;
+            console.warn(`[PPLNS] Coinbase weight limit: trimmed ${removedCount} smallest outputs to pending (${eligible.length} → ${trimmed.length} outputs, budget ${this.coinbaseWeightBudget} WU)`);
         }
 
-        // 5. Add pool fee
+        for (const ms of trimmed) {
+            payouts.push({ address: ms.address, percent: ms.percent });
+            totalAssignedPercent += ms.percent;
+        }
+
+        // 6. Add pool fee
         if (this.feeAddress) {
             payouts.unshift({ address: this.feeAddress, percent: feePercent });
             totalAssignedPercent += feePercent;

--- a/src/services/pplns.service.ts
+++ b/src/services/pplns.service.ts
@@ -51,6 +51,10 @@ export class PplnsService implements OnModuleInit, OnModuleDestroy {
     private cachedDistributionAt = 0;
     private static readonly DISTRIBUTION_CACHE_TTL_MS = 30_000; // 30 seconds max
 
+    // Coinbase snapshot — the distribution that was actually used to build the latest coinbase.
+    // onBlockFound uses this instead of recalculating, so bookkeeping matches on-chain reality.
+    private coinbaseSnapshot: { distribution: PplnsPayoutEntry[]; blockRewardSats: number } | null = null;
+
     constructor(
         private readonly configService: ConfigService,
         @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
@@ -325,6 +329,9 @@ export class PplnsService implements OnModuleInit, OnModuleDestroy {
         this.cachedDistributionReward = blockRewardSats;
         this.cachedDistributionAt = Date.now();
 
+        // Save snapshot — onBlockFound will use this for bookkeeping
+        this.coinbaseSnapshot = { distribution: result, blockRewardSats };
+
         return result;
     }
 
@@ -342,7 +349,8 @@ export class PplnsService implements OnModuleInit, OnModuleDestroy {
 
     /**
      * Called when a block is found on a PPLNS port.
-     * Updates pending balances for sub-dust miners and marks paid for others.
+     * Uses the coinbase snapshot (the distribution that was actually used to build the coinbase)
+     * so bookkeeping matches exactly what's on-chain.
      */
     async onBlockFound(blockHeight: number, blockRewardSats: number): Promise<void> {
         if (!this.redis || !this.enabled) return;
@@ -358,81 +366,134 @@ export class PplnsService implements OnModuleInit, OnModuleDestroy {
 
         console.log(`[PPLNS] Block ${blockHeight} found! Processing payouts...`);
 
-        // Read current window
+        // Use the coinbase snapshot — this is the exact distribution that went into the block.
+        // If no snapshot exists (e.g. first block, or race condition), fall back to recalculating.
+        const snapshot = this.coinbaseSnapshot;
+        if (!snapshot || snapshot.distribution.length === 0) {
+            console.warn(`[PPLNS] No coinbase snapshot available for block ${blockHeight} — falling back to window recalculation`);
+            await this.onBlockFoundFromWindow(blockHeight, blockRewardSats);
+            return;
+        }
+
+        // Clear snapshot — it's been consumed
+        this.coinbaseSnapshot = null;
+
+        const reward = snapshot.blockRewardSats;
+
+        for (const entry of snapshot.distribution) {
+            if (entry.address === this.feeAddress) {
+                // Log pool fee
+                const feeSats = Math.floor((entry.percent / 100) * reward);
+                await this.payoutHistoryRepo.save(this.payoutHistoryRepo.create({
+                    blockHeight, address: entry.address, paidSats: feeSats, percent: entry.percent, inCoinbase: true,
+                }));
+                console.log(`[PPLNS]   ${entry.address}: ${feeSats} sats (pool fee, ${entry.percent.toFixed(2)}%)`);
+                continue;
+            }
+
+            const paidSats = Math.floor((entry.percent / 100) * reward);
+            const pending = await this.balanceService.getPending(entry.address);
+
+            // This address was in the coinbase — mark any pending as paid
+            if (pending > 0) {
+                await this.balanceService.markPaid(entry.address, pending);
+            }
+
+            await this.payoutHistoryRepo.save(this.payoutHistoryRepo.create({
+                blockHeight, address: entry.address, paidSats, percent: entry.percent, inCoinbase: true,
+            }));
+            console.log(`[PPLNS]   ${entry.address}: ${paidSats} sats (paid in coinbase, ${entry.percent.toFixed(2)}%)`);
+        }
+
+        // Handle miners NOT in the snapshot (sub-dust or trimmed by weight limit)
+        // Their share from the current window goes to pending
+        const snapshotAddresses = new Set(snapshot.distribution.map(d => d.address));
+        const entries = await this.redis.zRange(REDIS_KEY_SHARES, 0, -1);
+        if (entries && entries.length > 0) {
+            const addressDiff = new Map<string, number>();
+            let totalDiff = 0;
+            for (const e of entries) {
+                const parts = e.split(':');
+                const diff = parseFloat(parts[1]) || 0;
+                addressDiff.set(parts[0], (addressDiff.get(parts[0]) ?? 0) + diff);
+                totalDiff += diff;
+            }
+
+            const rewardForMiners = Math.floor(((100 - this.feePercent) / 100) * reward);
+            for (const [addr, diff] of addressDiff) {
+                if (snapshotAddresses.has(addr)) continue; // Already processed above
+                const sats = Math.floor((diff / totalDiff) * rewardForMiners);
+                if (sats > 0) {
+                    await this.balanceService.addPending(addr, sats);
+                    await this.payoutHistoryRepo.save(this.payoutHistoryRepo.create({
+                        blockHeight, address: addr, paidSats: sats, percent: (diff / totalDiff) * (100 - this.feePercent), inCoinbase: false,
+                    }));
+                    console.log(`[PPLNS]   ${addr}: ${sats} sats → pending (not in coinbase)`);
+                }
+            }
+        }
+
+        console.log(`[PPLNS] Block ${blockHeight} payouts processed (from coinbase snapshot)`);
+    }
+
+    /**
+     * Fallback: recalculate from current window when no snapshot is available.
+     */
+    private async onBlockFoundFromWindow(blockHeight: number, blockRewardSats: number): Promise<void> {
         const entries = await this.redis.zRange(REDIS_KEY_SHARES, 0, -1);
         if (!entries || entries.length === 0) return;
 
-        // Sum difficulty per address
         const addressDiff = new Map<string, number>();
         let totalDiff = 0;
-
         for (const entry of entries) {
             const parts = entry.split(':');
-            const addr = parts[0];
-            const diff = parseFloat(parts[1]) || 0;
-            addressDiff.set(addr, (addressDiff.get(addr) ?? 0) + diff);
-            totalDiff += diff;
+            addressDiff.set(parts[0], (addressDiff.get(parts[0]) ?? 0) + (parseFloat(parts[1]) || 0));
+            totalDiff += parseFloat(parts[1]) || 0;
         }
-
         if (totalDiff <= 0) return;
 
         const rewardForMiners = Math.floor(((100 - this.feePercent) / 100) * blockRewardSats);
-
-        // Track which pending addresses we've already processed
-        const processedAddresses = new Set<string>();
 
         for (const [addr, diff] of addressDiff) {
             const ratio = diff / totalDiff;
             const sats = Math.floor(ratio * rewardForMiners);
             const pending = await this.balanceService.getPending(addr);
             const totalSats = sats + pending;
-
-            const percent = (ratio * (100 - this.feePercent));
-            processedAddresses.add(addr);
+            const percent = ratio * (100 - this.feePercent);
 
             if (totalSats >= DUST_LIMIT_SATS) {
-                // Was included in coinbase — mark pending as paid
-                if (pending > 0) {
-                    await this.balanceService.markPaid(addr, pending);
-                }
+                if (pending > 0) await this.balanceService.markPaid(addr, pending);
                 await this.payoutHistoryRepo.save(this.payoutHistoryRepo.create({
                     blockHeight, address: addr, paidSats: totalSats, percent, inCoinbase: true,
                 }));
-                console.log(`[PPLNS]   ${addr}: ${totalSats} sats (paid in coinbase, ${percent.toFixed(2)}%)`);
             } else {
-                // Below dust — accumulate
-                await this.balanceService.addPending(addr, sats);
+                if (sats > 0) await this.balanceService.addPending(addr, sats);
                 await this.payoutHistoryRepo.save(this.payoutHistoryRepo.create({
                     blockHeight, address: addr, paidSats: sats, percent, inCoinbase: false,
                 }));
-                console.log(`[PPLNS]   ${addr}: ${sats} sats → pending (total: ${sats + pending})`);
             }
         }
 
-        // Process pending-only addresses (no current shares but pending >= dust was in coinbase)
+        // Pending-only addresses
         const pendingEntities = await this.balanceService.getAllWithPending();
+        const processed = new Set(addressDiff.keys());
         for (const entity of pendingEntities) {
-            if (processedAddresses.has(entity.address)) continue;
+            if (processed.has(entity.address)) continue;
             if (entity.pendingSats >= DUST_LIMIT_SATS) {
-                // This address was included in coinbase via getPayoutDistribution() — mark as paid
-                const paidAmount = entity.pendingSats;
-                await this.balanceService.markPaid(entity.address, paidAmount);
+                await this.balanceService.markPaid(entity.address, entity.pendingSats);
                 await this.payoutHistoryRepo.save(this.payoutHistoryRepo.create({
-                    blockHeight, address: entity.address, paidSats: paidAmount, percent: (paidAmount / blockRewardSats) * 100, inCoinbase: true,
+                    blockHeight, address: entity.address, paidSats: entity.pendingSats,
+                    percent: (entity.pendingSats / blockRewardSats) * 100, inCoinbase: true,
                 }));
-                console.log(`[PPLNS]   ${entity.address}: ${paidAmount} sats (pending-only, paid in coinbase)`);
             }
         }
 
-        // Log pool fee
         const feeSats = blockRewardSats - rewardForMiners;
         if (this.feeAddress) {
             await this.payoutHistoryRepo.save(this.payoutHistoryRepo.create({
                 blockHeight, address: this.feeAddress, paidSats: feeSats, percent: this.feePercent, inCoinbase: true,
             }));
         }
-
-        console.log(`[PPLNS] Block ${blockHeight} payouts processed for ${addressDiff.size} miners`);
     }
 
     // ── Stats ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Prevents invalid blocks when PPLNS coinbase exceeds the weight budget from bitcoin.conf blockreservedweight.

- Calculates max miner outputs from configurable weight budget (default 50000 WU = ~400 outputs)
- When miners exceed limit, keeps largest outputs, trims smallest to pending (auto-accumulate)
- Configurable via PPLNS_COINBASE_WEIGHT_BUDGET env (must match blockreservedweight in bitcoin.conf)
- Requires bitcoin.conf: `blockreservedweight=50000`

## Test plan
- [x] 34 tests passing (29 existing + 5 new weight validation tests)
- [x] Trimming: 10 miners with budget for 3 → only 3 in coinbase
- [x] Largest-first: big miners kept, small miners trimmed to pending
- [x] No trim when within budget
- [x] Custom budget via env