### PR TITLE
Add group-solo mining mode

### DIFF
--- a/src/ORM/pplns-group/pplns-group-balance.entity.ts
+++ b/src/ORM/pplns-group/pplns-group-balance.entity.ts
@@ -1,0 +1,21 @@
+import { Column, Entity, Index, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('pplns_group_balance')
+export class PplnsGroupBalanceEntity {
+
+    @PrimaryColumn({ type: 'varchar', length: 62 })
+    address: string;
+
+    @Index()
+    @Column({ type: 'uuid' })
+    groupId: string;
+
+    @Column({ type: 'bigint', default: 0, transformer: { from: (v: string) => Number(v), to: (v: number) => v } })
+    pendingSats: number;
+
+    @Column({ type: 'bigint', default: 0, transformer: { from: (v: string) => Number(v), to: (v: number) => v } })
+    totalPaidSats: number;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/src/ORM/pplns-group/pplns-group-block-history.entity.ts
+++ b/src/ORM/pplns-group/pplns-group-block-history.entity.ts
@@ -1,0 +1,37 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('pplns_group_block_history')
+export class PplnsGroupBlockHistoryEntity {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Index()
+    @Column({ type: 'uuid' })
+    groupId: string;
+
+    @Index()
+    @Column({ type: 'int' })
+    blockHeight: number;
+
+    @Column({ type: 'varchar', length: 62 })
+    address: string;
+
+    @Column({ type: 'bigint', default: 0, transformer: { from: (v: string) => Number(v), to: (v: number) => v } })
+    paidSats: number;
+
+    @Column({ type: 'real', default: 0 })
+    percent: number;
+
+    @Column({ type: 'bigint', default: 0, transformer: { from: (v: string) => Number(v), to: (v: number) => v } })
+    sharesInRound: number;
+
+    @Column({ type: 'bigint', default: 0, transformer: { from: (v: string) => Number(v), to: (v: number) => v } })
+    totalSharesInRound: number;
+
+    @Column({ type: 'boolean', default: true })
+    inCoinbase: boolean;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/src/ORM/pplns-group/pplns-group-member.entity.ts
+++ b/src/ORM/pplns-group/pplns-group-member.entity.ts
@@ -1,0 +1,24 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+export type PplnsGroupMemberRole = 'creator' | 'member';
+
+@Entity('pplns_group_member')
+export class PplnsGroupMemberEntity {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Index()
+    @Column({ type: 'uuid' })
+    groupId: string;
+
+    @Index({ unique: true })
+    @Column({ type: 'varchar', length: 62 })
+    address: string;
+
+    @Column({ type: 'varchar', length: 16, default: 'member' })
+    role: PplnsGroupMemberRole;
+
+    @CreateDateColumn()
+    joinedAt: Date;
+}

--- a/src/ORM/pplns-group/pplns-group.entity.ts
+++ b/src/ORM/pplns-group/pplns-group.entity.ts
@@ -1,0 +1,30 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('pplns_group')
+export class PplnsGroupEntity {
+
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Index({ unique: true })
+    @Column({ type: 'varchar', length: 64 })
+    name: string;
+
+    @Column({ type: 'varchar', length: 62 })
+    creatorAddress: string;
+
+    @Column({ type: 'varchar', length: 255 })
+    adminTokenHash: string;
+
+    @Column({ type: 'boolean', default: false })
+    active: boolean;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+
+    @Column({ type: 'timestamp', nullable: true })
+    dissolvedAt: Date | null;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -54,6 +54,13 @@ import { PplnsBalanceService } from './ORM/pplns-balance/pplns-balance.service';
 import { PplnsBalanceEntity } from './ORM/pplns-balance/pplns-balance.entity';
 import { PplnsPayoutHistoryEntity } from './ORM/pplns-balance/pplns-payout-history.entity';
 import { PplnsController } from './controllers/pplns/pplns.controller';
+import { GroupSoloService } from './services/group-solo.service';
+import { GroupService } from './services/group.service';
+import { PplnsGroupEntity } from './ORM/pplns-group/pplns-group.entity';
+import { PplnsGroupMemberEntity } from './ORM/pplns-group/pplns-group-member.entity';
+import { PplnsGroupBlockHistoryEntity } from './ORM/pplns-group/pplns-group-block-history.entity';
+import { PplnsGroupBalanceEntity } from './ORM/pplns-group/pplns-group-balance.entity';
+import { PplnsGroupController } from './controllers/pplns-group/pplns-group.controller';
 import { DownstreamReportController } from './controllers/downstream-report/downstream-report.controller';
 import { ExternalShareController } from './controllers/external-share/external-share.controller';
 import { PushController } from './controllers/push/push.controller';
@@ -131,7 +138,14 @@ const ORMModules = [
         }),
         ScheduleModule.forRoot(),
         HttpModule,
-        TypeOrmModule.forFeature([PplnsBalanceEntity, PplnsPayoutHistoryEntity]),
+        TypeOrmModule.forFeature([
+            PplnsBalanceEntity,
+            PplnsPayoutHistoryEntity,
+            PplnsGroupEntity,
+            PplnsGroupMemberEntity,
+            PplnsGroupBlockHistoryEntity,
+            PplnsGroupBalanceEntity,
+        ]),
         ...ORMModules
     ],
     controllers: [
@@ -142,7 +156,8 @@ const ORMModules = [
         ExternalShareController,
         PushController,
         InfoController,
-        PplnsController
+        PplnsController,
+        PplnsGroupController,
     ],
     providers: [
         // TimeslotMigrationService, // Disabled - migration incomplete, leaving data in mixed state
@@ -175,6 +190,8 @@ const ORMModules = [
         JobDeclarationService,
         PplnsService,
         PplnsBalanceService,
+        GroupSoloService,
+        GroupService,
     ],
 })
 export class AppModule {

--- a/src/controllers/pplns-group/pplns-group.controller.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.ts
@@ -1,0 +1,172 @@
+import { Body, Controller, Delete, Get, Headers, HttpException, HttpStatus, Param, Post, Query } from '@nestjs/common';
+import { GroupService, GroupServiceError } from '../../services/group.service';
+import { GroupSoloService } from '../../services/group-solo.service';
+
+interface CreateGroupDto {
+    name?: string;
+    creatorAddress?: string;
+}
+
+interface AddMemberDto {
+    address?: string;
+}
+
+interface TransferDto {
+    toAddress?: string;
+}
+
+@Controller('pplns/groups')
+export class PplnsGroupController {
+
+    constructor(
+        private readonly groupService: GroupService,
+        private readonly groupSoloService: GroupSoloService,
+    ) {}
+
+    // ── Public endpoints ─────────────────────────────────────────
+
+    @Get()
+    async list() {
+        const groups = await this.groupService.listGroups();
+        return groups.map(g => this.publicGroupView(g));
+    }
+
+    @Get(':id')
+    async details(@Param('id') id: string) {
+        const group = await this.groupService.getGroup(id);
+        if (!group || group.dissolvedAt) throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
+        const members = await this.groupService.listMembers(id);
+        return {
+            ...this.publicGroupView(group),
+            members: members.map(m => ({ address: m.address, role: m.role, joinedAt: m.joinedAt })),
+        };
+    }
+
+    @Get(':id/distribution')
+    async distribution(@Param('id') id: string) {
+        const group = await this.groupService.getGroup(id);
+        if (!group || group.dissolvedAt) throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
+        return this.groupSoloService.getRoundStats(id);
+    }
+
+    @Get(':id/history')
+    async history(@Param('id') id: string, @Query('limit') limitStr?: string) {
+        const group = await this.groupService.getGroup(id);
+        if (!group || group.dissolvedAt) throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
+        const limit = Math.min(parseInt(limitStr ?? '100', 10) || 100, 500);
+        return this.groupSoloService.getBlockHistory(id, limit);
+    }
+
+    // ── Admin endpoints ──────────────────────────────────────────
+
+    @Post()
+    async create(@Body() body: CreateGroupDto) {
+        try {
+            const result = await this.groupService.createGroup(body.name ?? '', body.creatorAddress ?? '');
+            return {
+                ...this.publicGroupView(result.group),
+                adminToken: result.adminToken,
+                members: [{ address: result.group.creatorAddress, role: 'creator' }],
+            };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Post(':id/members')
+    async addMember(
+        @Param('id') id: string,
+        @Body() body: AddMemberDto,
+        @Headers('x-admin-token') token?: string,
+    ) {
+        try {
+            const member = await this.groupService.addMember(id, body.address ?? '', token);
+            return { address: member.address, role: member.role, joinedAt: member.joinedAt };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Delete(':id/members/:address')
+    async removeMember(
+        @Param('id') id: string,
+        @Param('address') address: string,
+        @Headers('x-admin-token') token?: string,
+    ) {
+        try {
+            await this.groupService.removeMember(id, address, token);
+            return { removed: true };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Delete(':id/members/:address/self')
+    async selfLeave(@Param('id') id: string, @Param('address') address: string) {
+        try {
+            await this.groupService.selfLeave(id, address);
+            return { removed: true };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Post(':id/transfer')
+    async transfer(
+        @Param('id') id: string,
+        @Body() body: TransferDto,
+        @Headers('x-admin-token') token?: string,
+    ) {
+        try {
+            const result = await this.groupService.transferCreator(id, body.toAddress ?? '', token);
+            return {
+                ...this.publicGroupView(result.group),
+                adminToken: result.adminToken,
+            };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Delete(':id')
+    async dissolve(@Param('id') id: string, @Headers('x-admin-token') token?: string) {
+        try {
+            await this.groupService.dissolveGroup(id, token);
+            return { dissolved: true };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────
+
+    private publicGroupView(group: { id: string; name: string; creatorAddress: string; active: boolean; createdAt: Date }) {
+        return {
+            id: group.id,
+            name: group.name,
+            creatorAddress: group.creatorAddress,
+            active: group.active,
+            createdAt: group.createdAt,
+        };
+    }
+
+    private toHttpError(e: unknown): HttpException {
+        if (e instanceof GroupServiceError) {
+            const status = {
+                'missing-token': HttpStatus.UNAUTHORIZED,
+                'invalid-token': HttpStatus.UNAUTHORIZED,
+                'not-found': HttpStatus.NOT_FOUND,
+                'not-member': HttpStatus.NOT_FOUND,
+                'invalid-name': HttpStatus.BAD_REQUEST,
+                'invalid-address': HttpStatus.BAD_REQUEST,
+                'name-taken': HttpStatus.CONFLICT,
+                'address-in-group': HttpStatus.CONFLICT,
+                'already-member': HttpStatus.CONFLICT,
+                'already-creator': HttpStatus.CONFLICT,
+                'creator-cannot-self-leave': HttpStatus.FORBIDDEN,
+            }[e.code] ?? HttpStatus.BAD_REQUEST;
+            return new HttpException({ code: e.code, message: e.message }, status);
+        }
+        return new HttpException({ code: 'internal-error', message: (e as Error)?.message ?? 'Internal error' }, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/controllers/pplns-group/pplns-group.controller.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Delete, Get, Headers, HttpException, HttpStatus, Param, Post, Query } from '@nestjs/common';
 import { GroupService, GroupServiceError } from '../../services/group.service';
 import { GroupSoloService } from '../../services/group-solo.service';
+import { ClientService } from '../../ORM/client/client.service';
 
 interface CreateGroupDto {
     name?: string;
@@ -21,7 +22,14 @@ export class PplnsGroupController {
     constructor(
         private readonly groupService: GroupService,
         private readonly groupSoloService: GroupSoloService,
+        private readonly clientService: ClientService,
     ) {}
+
+    /** Sum of live hashrates across all workers of an address. Matches /api/client/:address. */
+    private async addressHashrate(address: string): Promise<number> {
+        const workers = await this.clientService.getByAddress(address);
+        return workers.reduce((sum, w) => sum + (w.hashRate ?? 0), 0);
+    }
 
     // ── Public endpoints ─────────────────────────────────────────
 
@@ -36,9 +44,33 @@ export class PplnsGroupController {
         const group = await this.groupService.getGroup(id);
         if (!group || group.dissolvedAt) throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
         const members = await this.groupService.listMembers(id);
+        const membersWithHashrate = await Promise.all(members.map(async m => ({
+            address: m.address,
+            role: m.role,
+            joinedAt: m.joinedAt,
+            hashrate: await this.addressHashrate(m.address),
+        })));
+        const totalHashrate = membersWithHashrate.reduce((sum, m) => sum + m.hashrate, 0);
         return {
             ...this.publicGroupView(group),
-            members: members.map(m => ({ address: m.address, role: m.role, joinedAt: m.joinedAt })),
+            totalHashrate,
+            members: membersWithHashrate,
+        };
+    }
+
+    @Get(':id/hashrate')
+    async hashrate(@Param('id') id: string) {
+        const group = await this.groupService.getGroup(id);
+        if (!group || group.dissolvedAt) throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
+        const members = await this.groupService.listMembers(id);
+        const memberRates = await Promise.all(members.map(async m => ({
+            address: m.address,
+            hashrate: await this.addressHashrate(m.address),
+        })));
+        return {
+            groupId: id,
+            totalHashrate: memberRates.reduce((sum, m) => sum + m.hashrate, 0),
+            members: memberRates,
         };
     }
 

--- a/src/migrations/1776000000000-AddPplnsGroup.ts
+++ b/src/migrations/1776000000000-AddPplnsGroup.ts
@@ -1,0 +1,98 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class AddPplnsGroup1776000000000 implements MigrationInterface {
+    name = 'AddPplnsGroup1776000000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'pplns_group',
+                columns: [
+                    { name: 'id', type: 'uuid', isPrimary: true },
+                    { name: 'name', type: 'varchar', length: '64', isUnique: true },
+                    { name: 'creatorAddress', type: 'varchar', length: '62' },
+                    { name: 'adminTokenHash', type: 'varchar', length: '255' },
+                    { name: 'active', type: 'boolean', default: false },
+                    { name: 'createdAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                    { name: 'updatedAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                    { name: 'dissolvedAt', type: 'timestamp', isNullable: true },
+                ],
+            }),
+            true,
+        );
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'pplns_group_member',
+                columns: [
+                    { name: 'id', type: 'integer', isPrimary: true, isGenerated: true, generationStrategy: 'increment' },
+                    { name: 'groupId', type: 'uuid' },
+                    { name: 'address', type: 'varchar', length: '62', isUnique: true },
+                    { name: 'role', type: 'varchar', length: '16', default: "'member'" },
+                    { name: 'joinedAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                ],
+            }),
+            true,
+        );
+
+        await queryRunner.createIndex(
+            'pplns_group_member',
+            new TableIndex({ columnNames: ['groupId'] }),
+        );
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'pplns_group_block_history',
+                columns: [
+                    { name: 'id', type: 'integer', isPrimary: true, isGenerated: true, generationStrategy: 'increment' },
+                    { name: 'groupId', type: 'uuid' },
+                    { name: 'blockHeight', type: 'int' },
+                    { name: 'address', type: 'varchar', length: '62' },
+                    { name: 'paidSats', type: 'bigint', default: '0' },
+                    { name: 'percent', type: 'real', default: '0' },
+                    { name: 'sharesInRound', type: 'bigint', default: '0' },
+                    { name: 'totalSharesInRound', type: 'bigint', default: '0' },
+                    { name: 'inCoinbase', type: 'boolean', default: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                ],
+            }),
+            true,
+        );
+
+        await queryRunner.createIndex(
+            'pplns_group_block_history',
+            new TableIndex({ columnNames: ['groupId'] }),
+        );
+
+        await queryRunner.createIndex(
+            'pplns_group_block_history',
+            new TableIndex({ columnNames: ['blockHeight'] }),
+        );
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'pplns_group_balance',
+                columns: [
+                    { name: 'address', type: 'varchar', length: '62', isPrimary: true },
+                    { name: 'groupId', type: 'uuid' },
+                    { name: 'pendingSats', type: 'bigint', default: '0' },
+                    { name: 'totalPaidSats', type: 'bigint', default: '0' },
+                    { name: 'updatedAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                ],
+            }),
+            true,
+        );
+
+        await queryRunner.createIndex(
+            'pplns_group_balance',
+            new TableIndex({ columnNames: ['groupId'] }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('pplns_group_balance', true);
+        await queryRunner.dropTable('pplns_group_block_history', true);
+        await queryRunner.dropTable('pplns_group_member', true);
+        await queryRunner.dropTable('pplns_group', true);
+    }
+}

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -39,6 +39,7 @@ import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-stat
 import { ShareTotalsCacheService } from '../services/share-totals-cache.service';
 import { AddressSettingsCacheService } from '../services/address-settings-cache.service';
 import { PplnsService } from '../services/pplns.service';
+import { GroupSoloService } from '../services/group-solo.service';
 import { PayoutMode } from './interfaces/unified-stratum.interfaces';
 
 
@@ -59,6 +60,8 @@ export class StratumV1Client {
     private pendingSessionDifficulty: number | null = null;
     private deviceOnlineNotified = false;
     private deviceOfflineNotified = false;
+    /** Set during authorize if the address belongs to an active group. Activates group-solo mode for this session. */
+    private groupSoloGroupId: string | null = null;
 
     private entity: ClientEntity;
     private creatingEntity: Promise<void>;
@@ -116,6 +119,7 @@ export class StratumV1Client {
         private readonly redisClient?: any,
         private readonly payoutMode: PayoutMode = 'solo',
         private readonly pplnsService?: PplnsService,
+        private readonly groupSoloService?: GroupSoloService,
     ) {
         this.initialDifficulty = Number.isFinite(initialDifficulty)
             ? initialDifficulty
@@ -439,6 +443,16 @@ export class StratumV1Client {
                     return;
                 }
 
+                // Group-solo detection: if this address is in an active group,
+                // switch this session into group-solo payout regardless of the port mode.
+                if (this.groupSoloService?.isEnabled()) {
+                    const groupEntry = this.groupSoloService.getGroupForAddress(authorizationMessage.address);
+                    if (groupEntry?.active) {
+                        this.groupSoloGroupId = groupEntry.groupId;
+                        console.log(`[StratumV1Client] Address ${authorizationMessage.address} is in active group ${groupEntry.groupId} — enabling group-solo payout`);
+                    }
+                }
+
                 {
                     this.clientAuthorization = authorizationMessage;
 
@@ -730,7 +744,15 @@ export class StratumV1Client {
             this.hashRate = this.statistics.hashRate;
         }
 
-        if (this.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
+        if (this.groupSoloGroupId && this.groupSoloService?.isEnabled()) {
+            // Group-solo takes precedence: per-group shared coinbase, PROP-style
+            payoutInformation = await this.groupSoloService.getPayoutDistribution(
+                this.groupSoloGroupId,
+                jobTemplate.blockData.coinbasevalue,
+            );
+            this.noFee = false;
+            if (!payoutInformation || payoutInformation.length === 0) return;
+        } else if (this.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
             // PPLNS: Shared coinbase with proportional payouts
             // Network difficulty is synced centrally via PplnsService's job subscription
             payoutInformation = await this.pplnsService.getPayoutDistribution(jobTemplate.blockData.coinbasevalue);
@@ -989,8 +1011,15 @@ export class StratumV1Client {
                     await this.addressSettingsService.resetBestDifficultyAndShares();
                     await this.addressSettingsCacheService.clear();
 
-                    // Process PPLNS payouts (update pending balances)
-                    if (this.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
+                    // Process group-solo payouts (finder's group gets the coinbase, round resets)
+                    if (this.groupSoloGroupId && this.groupSoloService?.isEnabled() && this.clientAuthorization) {
+                        await this.groupSoloService.onBlockFound(
+                            jobTemplate.blockData.height,
+                            jobTemplate.blockData.coinbasevalue,
+                            this.clientAuthorization.address,
+                        );
+                    } else if (this.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
+                        // Process PPLNS payouts (update pending balances)
                         await this.pplnsService.onBlockFound(
                             jobTemplate.blockData.height,
                             jobTemplate.blockData.coinbasevalue,
@@ -1005,8 +1034,13 @@ export class StratumV1Client {
                 // Persist to Redis atomically (stateless service)
                 await this.clientStatisticsService.addAcceptedShare(this.entity, this.sessionDifficulty);
 
-                // Record share in PPLNS window if on PPLNS port
-                if (this.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
+                // Record share — group-solo takes precedence over port's payoutMode
+                if (this.groupSoloGroupId && this.groupSoloService?.isEnabled()) {
+                    await this.groupSoloService.recordShare(
+                        this.clientAuthorization.address,
+                        this.sessionDifficulty,
+                    );
+                } else if (this.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
                     await this.pplnsService.recordShare(
                         this.clientAuthorization.address,
                         this.sessionDifficulty,

--- a/src/models/StratumV2Client.ts
+++ b/src/models/StratumV2Client.ts
@@ -24,6 +24,7 @@ import { ExternalSharesService } from '../services/external-shares.service';
 import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 import { ShareTotalsCacheService } from '../services/share-totals-cache.service';
 import { PplnsService } from '../services/pplns.service';
+import { GroupSoloService } from '../services/group-solo.service';
 import { ClientEntity } from '../ORM/client/client.entity';
 import { MiningJob } from './MiningJob';
 import { StratumV1ClientStatistics } from './StratumV1ClientStatistics';
@@ -149,6 +150,8 @@ export class StratumV2Client {
 
   // Connection-level state
   private address: string | null = null;
+  /** Set during channel-open if the address belongs to an active group. Activates group-solo mode for this session. */
+  private groupSoloGroupId: string | null = null;
   private workerName: string = 'default';
   private userAgent: string = '';
   private vendorInfo: string = '';
@@ -212,6 +215,7 @@ export class StratumV2Client {
     private readonly extranonceManager?: Sv2ExtranonceManager,
     private readonly templateDistributionService?: TemplateDistributionService,
     private readonly pplnsService?: PplnsService,
+    private readonly groupSoloService?: GroupSoloService,
   ) {
     this.sessionId = this.generateSessionId();
     this.sessionStart = new Date();
@@ -515,6 +519,8 @@ export class StratumV2Client {
       return;
     }
 
+    this.detectGroupSoloMembership(rawAddress);
+
     // Multi-channel: subsequent channels must use same address
     if (this.address && this.address !== rawAddress) {
       const errorPayload = serializeOpenMiningChannelError({
@@ -651,6 +657,8 @@ export class StratumV2Client {
       this.destroySocket();
       return;
     }
+
+    this.detectGroupSoloMembership(rawAddress);
 
     // Multi-channel: subsequent channels must use same address
     if (this.address && this.address !== rawAddress) {
@@ -1451,8 +1459,15 @@ export class StratumV2Client {
         await this.addressSettingsService.resetBestDifficultyAndShares();
         await this.addressSettingsCacheService.clear();
 
-        // Process PPLNS payouts (update pending balances)
-        if (this.portConfig.payoutMode === 'pplns' && this.pplnsService?.isEnabled() && jobTemplate) {
+        // Group-solo takes precedence — finder's group gets the coinbase, round resets
+        if (this.groupSoloGroupId && this.groupSoloService?.isEnabled() && jobTemplate && this.address) {
+          await this.groupSoloService.onBlockFound(
+            jobTemplate.blockData.height,
+            jobTemplate.blockData.coinbasevalue,
+            this.address,
+          );
+        } else if (this.portConfig.payoutMode === 'pplns' && this.pplnsService?.isEnabled() && jobTemplate) {
+          // Process PPLNS payouts (update pending balances)
           await this.pplnsService.onBlockFound(
             jobTemplate.blockData.height,
             jobTemplate.blockData.coinbasevalue,
@@ -1466,8 +1481,10 @@ export class StratumV2Client {
       this.hashRate = this.statistics.hashRate;
       await this.clientStatisticsService.addAcceptedShare(this.entity!, jobDifficulty);
 
-      // Record share in PPLNS window if on PPLNS port
-      if (this.portConfig.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
+      // Record share — group-solo takes precedence over port's payoutMode
+      if (this.groupSoloGroupId && this.groupSoloService?.isEnabled()) {
+        await this.groupSoloService.recordShare(this.address!, jobDifficulty);
+      } else if (this.portConfig.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
         await this.pplnsService.recordShare(this.address!, jobDifficulty);
       }
 
@@ -1711,6 +1728,12 @@ export class StratumV2Client {
       return null; // Signal caller to use async path
     }
 
+    // Group-solo mode: per-group shared coinbase — also async
+    if (this.groupSoloGroupId && this.groupSoloService?.isEnabled() && blockRewardSats) {
+      this.noFee = false;
+      return null;
+    }
+
     // Solo mode: existing behavior
     const devFeeAddress = this.configService.get('DEV_FEE_ADDRESS');
     const devFeePercent = parseFloat(this.configService.get('DEV_FEE_PERCENT') ?? '1.5');
@@ -1732,6 +1755,14 @@ export class StratumV2Client {
   }
 
   private async buildPayoutInformationAsync(blockRewardSats: number): Promise<{ address: string; percent: number }[] | null> {
+    // Group-solo takes precedence over PPLNS.
+    if (this.groupSoloGroupId && this.groupSoloService?.isEnabled()) {
+      const distribution = await this.groupSoloService.getPayoutDistribution(this.groupSoloGroupId, blockRewardSats);
+      if (distribution && distribution.length > 0) {
+        this.noFee = false;
+        return distribution;
+      }
+    }
     if (this.portConfig.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
       const distribution = await this.pplnsService.getPayoutDistribution(blockRewardSats);
       if (distribution && distribution.length > 0) {
@@ -1740,6 +1771,19 @@ export class StratumV2Client {
       }
     }
     return this.buildPayoutInformation();
+  }
+
+  /**
+   * If the address is in an active group, switch this session into group-solo payout.
+   * Otherwise fall back to the port's configured payoutMode (solo/pplns).
+   */
+  private detectGroupSoloMembership(address: string): void {
+    if (!this.groupSoloService?.isEnabled()) return;
+    const entry = this.groupSoloService.getGroupForAddress(address);
+    if (entry?.active) {
+      this.groupSoloGroupId = entry.groupId;
+      console.log(`[SV2 ${this.sessionId}] Address ${address} is in active group ${entry.groupId} — enabling group-solo payout`);
+    }
   }
 
   private async sendNewMiningJob(jobTemplate: IJobTemplate, sendPrevHash: boolean, channelId?: number): Promise<void> {

--- a/src/models/interfaces/unified-stratum.interfaces.ts
+++ b/src/models/interfaces/unified-stratum.interfaces.ts
@@ -9,8 +9,9 @@ export type ProtocolVersion = 'v1' | 'v2';
  * Payout mode for a stratum port.
  * - 'solo': Each miner gets their own coinbase (existing behavior)
  * - 'pplns': Shared coinbase with proportional payouts based on PPLNS window
+ * - 'group-solo': Per-group shared coinbase, PROP-style (window resets on block)
  */
-export type PayoutMode = 'solo' | 'pplns';
+export type PayoutMode = 'solo' | 'pplns' | 'group-solo';
 
 /**
  * Configuration passed when starting a stratum port.

--- a/src/services/group-solo-regtest.spec.ts
+++ b/src/services/group-solo-regtest.spec.ts
@@ -1,0 +1,294 @@
+/**
+ * Group-Solo Regtest Integration Test
+ *
+ * Tests end-to-end flow: GroupSoloService computes a real distribution from
+ * recorded shares, builds a multi-output coinbase from that distribution, and
+ * Bitcoin Core accepts the block. Also verifies that onBlockFound resets the
+ * round (Redis keys cleared).
+ *
+ * Requires a running regtest node at localhost:18443 (rpcuser=test, rpcpassword=test).
+ *
+ * Run: npx jest group-solo-regtest --no-coverage
+ */
+
+import * as bitcoinjs from 'bitcoinjs-lib';
+import * as http from 'http';
+import { GroupSoloService } from './group-solo.service';
+
+const RPC_URL = 'http://127.0.0.1:18443';
+const RPC_USER = 'test';
+const RPC_PASS = 'test';
+const NETWORK = bitcoinjs.networks.regtest;
+
+const ADDR_FEE = 'bcrt1qqj0r5w2ua3pe0sh6gthvfeegvwsa3t4edumqzf';
+const ADDR_ALICE = 'bcrt1q2jf90sp25mt4pte5swkr4cujpj5d8zzwdt09fq';
+const ADDR_BOB = 'bcrt1qt2amqww2n3dcz3ckx6nlentvm9e6rpxqrfmvl7';
+const ADDR_CHARLIE = 'bcrt1qlppw7cnqspnky6qzv8p2n468lpvwuct7ehp7l2';
+
+// ── RPC Helper ──────────────────────────────────────────────────
+
+function rpcCall(method: string, params: any[] = []): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method, params });
+    const auth = Buffer.from(`${RPC_USER}:${RPC_PASS}`).toString('base64');
+
+    const req = http.request(RPC_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Basic ${auth}` },
+    }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => data += chunk);
+      res.on('end', () => {
+        try {
+          const parsed = JSON.parse(data);
+          if (parsed.error) reject(new Error(`RPC error: ${JSON.stringify(parsed.error)}`));
+          else resolve(parsed.result);
+        } catch (e) {
+          reject(new Error(`Invalid JSON: ${data}`));
+        }
+      });
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+// ── Mock stack for the service ──────────────────────────────────
+
+function createMockRedis() {
+  const store = new Map<string, string>();
+  const zsets = new Map<string, { score: number; value: string }[]>();
+  const getZ = (key: string) => {
+    if (!zsets.has(key)) zsets.set(key, []);
+    return zsets.get(key)!;
+  };
+  return {
+    incr: async (key: string) => {
+      const val = parseInt(store.get(key) ?? '0', 10) + 1;
+      store.set(key, val.toString());
+      return val;
+    },
+    get: async (key: string) => store.get(key) ?? null,
+    set: async (key: string, value: string) => { store.set(key, value); },
+    del: async (key: string) => { store.delete(key); zsets.delete(key); },
+    incrByFloat: async (key: string, amount: number) => {
+      const val = parseFloat(store.get(key) ?? '0') + amount;
+      store.set(key, val.toString());
+      return val;
+    },
+    zAdd: async (key: string, entry: { score: number; value: string }) => {
+      const z = getZ(key);
+      z.push(entry);
+      z.sort((a, b) => a.score - b.score);
+    },
+    zRange: async (key: string, start: number, end: number) => {
+      const z = getZ(key);
+      const e = end === -1 ? z.length - 1 : end;
+      return z.slice(start, e + 1).map(x => x.value);
+    },
+    zCard: async (key: string) => getZ(key).length,
+    _store: store,
+    _zsets: zsets,
+  };
+}
+
+function createMockRepo<T>() {
+  const rows: T[] = [];
+  return {
+    save: async (row: T) => { rows.push({ ...row }); return row; },
+    create: (partial: Partial<T>) => ({ ...partial }) as T,
+    find: async () => [...rows],
+    findOneBy: async (where: any) =>
+      (rows as any[]).find(r => Object.entries(where).every(([k, v]) => r[k] === v)) ?? null,
+    _rows: rows,
+  };
+}
+
+function makeService() {
+  const env: Record<string, string> = {
+    GROUP_SOLO_PORT: '3340',
+    PPLNS_FEE_ADDRESS: ADDR_FEE,
+    PPLNS_FEE_PERCENT: '2',
+  };
+  const addressToGroup = new Map<string, { groupId: string; active: boolean }>();
+  addressToGroup.set(ADDR_ALICE, { groupId: 'grp-1', active: true });
+  addressToGroup.set(ADDR_BOB, { groupId: 'grp-1', active: true });
+  addressToGroup.set(ADDR_CHARLIE, { groupId: 'grp-1', active: true });
+
+  const service = new GroupSoloService(
+    { get: (k: string) => env[k] } as any,
+    { store: {} } as any,
+    createMockRepo() as any,
+    createMockRepo() as any,
+    { getGroupForAddress: (a: string) => addressToGroup.get(a) } as any,
+  );
+  const redis = createMockRedis();
+  (service as any).redis = redis;
+  (service as any).enabled = true;
+  return { service, redis };
+}
+
+// ── Block Builder ───────────────────────────────────────────────
+
+function buildCoinbase(
+  payouts: { address: string; sats: number }[],
+  height: number,
+  witnessCommit: Buffer,
+): bitcoinjs.Transaction {
+  const tx = new bitcoinjs.Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, 0), 0xffffffff, 0xffffffff);
+  const heightEncoded = bitcoinjs.script.number.encode(height);
+  tx.ins[0].script = Buffer.concat([
+    Buffer.from([heightEncoded.length]),
+    heightEncoded,
+    Buffer.from('blitzpool-group-solo-test'),
+    Buffer.alloc(4, 0),
+  ]);
+  tx.ins[0].witness = [Buffer.alloc(32, 0)];
+
+  for (const payout of payouts) {
+    const script = bitcoinjs.address.toOutputScript(payout.address, NETWORK);
+    tx.addOutput(script, payout.sats);
+  }
+  const commitmentHeader = Buffer.from('aa21a9ed', 'hex');
+  tx.addOutput(
+    bitcoinjs.script.compile([
+      bitcoinjs.opcodes.OP_RETURN,
+      Buffer.concat([commitmentHeader, witnessCommit]),
+    ]),
+    0,
+  );
+  return tx;
+}
+
+function buildBlock(template: any, coinbaseTx: bitcoinjs.Transaction, transactions: bitcoinjs.Transaction[]): bitcoinjs.Block {
+  const block = new bitcoinjs.Block();
+  block.version = template.version;
+  block.prevHash = Buffer.from(template.previousblockhash, 'hex').reverse();
+  block.timestamp = template.curtime;
+  block.bits = parseInt(template.bits, 16);
+  block.nonce = 0;
+  block.transactions = [coinbaseTx, ...transactions];
+  block.merkleRoot = bitcoinjs.Block.calculateMerkleRoot(block.transactions, false);
+  return block;
+}
+
+function mineBlock(block: bitcoinjs.Block, targetHex: string): boolean {
+  const target = Buffer.from(targetHex.padStart(64, '0'), 'hex');
+  for (let nonce = 0; nonce < 0xffffffff; nonce++) {
+    block.nonce = nonce;
+    const hash = bitcoinjs.crypto.hash256(block.toBuffer(true));
+    if (Buffer.from(hash).reverse().compare(target) <= 0) return true;
+  }
+  return false;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// TESTS
+// ═══════════════════════════════════════════════════════════════
+
+describe('Group-Solo Regtest — End-to-End with Bitcoin Core', () => {
+
+  beforeAll(async () => {
+    try {
+      const info = await rpcCall('getblockchaininfo');
+      expect(info.chain).toBe('regtest');
+      // BIP34 requires the coinbase scriptSig to start with the block height as a minimally-encoded
+      // scriptNum. For heights 1–16 that means OP_N, which bitcoinjs.script.number.encode() encodes
+      // as an empty buffer (caller is expected to use the OP opcode). To keep the coinbase builder
+      // simple we require chain height ≥ 17 so the height always fits in the length-prefixed bytes
+      // encoding. Auto-mine up to that threshold if needed.
+      if (info.blocks < 17) {
+        try { await rpcCall('createwallet', ['default']); } catch { /* already exists */ }
+        const addr = await rpcCall('getnewaddress');
+        await rpcCall('generatetoaddress', [17 - info.blocks, addr]);
+      }
+    } catch {
+      throw new Error('Bitcoin Core regtest not running at localhost:18443. Start with: bitcoind -regtest -daemon -rpcuser=test -rpcpassword=test -rpcport=18443');
+    }
+  });
+
+  it('records shares, builds coinbase from real distribution, submits block, and resets round', async () => {
+    const { service, redis } = makeService();
+
+    // Simulate mining: Alice & Bob submit shares, Charlie hasn't yet
+    await service.recordShare(ADDR_ALICE, 600);
+    await service.recordShare(ADDR_BOB, 400);
+
+    const template = await rpcCall('getblocktemplate', [{ rules: ['segwit'] }]);
+    const blockReward = template.coinbasevalue;
+    const height = template.height;
+
+    // Build distribution from the *service*, not hardcoded
+    const distribution = await service.getPayoutDistribution('grp-1', blockReward);
+
+    // Distribution must include fee + Alice + Bob, NOT Charlie (no shares)
+    const addresses = distribution.map(d => d.address);
+    expect(addresses).toContain(ADDR_FEE);
+    expect(addresses).toContain(ADDR_ALICE);
+    expect(addresses).toContain(ADDR_BOB);
+    expect(addresses).not.toContain(ADDR_CHARLIE);
+
+    // Convert percent distribution to sat amounts for the coinbase
+    const payouts = distribution.map(d => ({
+      address: d.address,
+      sats: Math.floor((d.percent / 100) * blockReward),
+    }));
+    // Fix rounding remainder → add to fee output
+    const totalAssigned = payouts.reduce((s, p) => s + p.sats, 0);
+    if (totalAssigned < blockReward) {
+      payouts[0].sats += blockReward - totalAssigned;
+    }
+
+    console.log(`\n=== Group-Solo Regtest ===`);
+    console.log(`Height: ${height}`);
+    console.log(`Block reward: ${blockReward} sats`);
+    console.log(`Distribution from service (${payouts.length} outputs):`);
+    payouts.forEach((p, i) => {
+      const label = p.address === ADDR_FEE ? 'FEE'
+        : p.address === ADDR_ALICE ? 'ALICE (60% shares)'
+        : p.address === ADDR_BOB ? 'BOB (40% shares)'
+        : p.address.substring(0, 20);
+      console.log(`  Output ${i}: ${p.sats} sats → ${label}`);
+    });
+
+    // Build + submit block
+    const txs = template.transactions.map((t: any) => bitcoinjs.Transaction.fromHex(t.data));
+    const dummyCoinbase = new bitcoinjs.Transaction();
+    dummyCoinbase.version = 2;
+    dummyCoinbase.addInput(Buffer.alloc(32, 0), 0xffffffff, 0xffffffff);
+    dummyCoinbase.addOutput(Buffer.alloc(22, 0), 0);
+    dummyCoinbase.ins[0].witness = [Buffer.alloc(32, 0)];
+    const witnessCommit = bitcoinjs.Block.calculateMerkleRoot([dummyCoinbase, ...txs], true);
+
+    const coinbaseTx = buildCoinbase(payouts, height, witnessCommit);
+    const block = buildBlock(template, coinbaseTx, txs);
+    const mined = mineBlock(block, template.target);
+    expect(mined).toBe(true);
+
+    const result = await rpcCall('submitblock', [block.toHex(false)]);
+    console.log(`Submit result: ${result === null ? 'SUCCESS!' : result}`);
+    expect(result).toBeNull();
+
+    // Verify chain tip advanced
+    const info = await rpcCall('getblockchaininfo');
+    expect(info.blocks).toBe(height);
+
+    // Now call the service's onBlockFound — should reset the round
+    await service.onBlockFound(height, blockReward, ADDR_ALICE);
+
+    // Round reset: no more group-1 Redis keys
+    expect(redis._zsets.size).toBe(0);
+    for (const [key] of redis._store) {
+      expect(key).not.toMatch(/^groupsolo:grp-1:/);
+    }
+
+    // A fresh distribution call should now return the fee-only fallback
+    const freshDist = await service.getPayoutDistribution('grp-1', blockReward);
+    expect(freshDist).toEqual([{ address: ADDR_FEE, percent: 100 }]);
+
+    console.log('✅ End-to-end flow verified: shares → distribution → block submit → round reset');
+  }, 60000);
+});

--- a/src/services/group-solo.service.spec.ts
+++ b/src/services/group-solo.service.spec.ts
@@ -235,6 +235,56 @@ describe('GroupSoloService', () => {
         expect(tinyBalance2.totalPaidSats).toBeGreaterThanOrEqual(pendingAfterRound1);
     });
 
+    it('late-arriving shares (post-snapshot) are logged but NOT credited to pending — prevents double-counting', async () => {
+        // Scenario: pool builds a job, snapshot captures only Alice (Bob had no shares yet).
+        // Between snapshot-build and block-found, Bob submits shares.
+        // Alice then finds the block. The coinbase pays Alice via the snapshot.
+        // Bob's shares arrived too late for THIS block's coinbase → PROP rules: lost.
+        //
+        // The old code was crediting Bob to pending based on Bob.diff / (Alice.diff + Bob.diff) × rewardForMiners,
+        // which meant rewardForMiners was effectively paid out TWICE (once to Alice via coinbase,
+        // once to Bob via pending). This test locks in the PROP behavior: Bob gets 0 sats pending,
+        // but gets an audit history row so his submitted shares are visible.
+        const { service, balanceRepo, historyRepo, groupService } = makeService();
+        const BLOCK_REWARD = 100_000_000;
+        groupService._setMembership('bc1qalice', 'g1', true);
+        groupService._setMembership('bc1qbob', 'g1', true);
+
+        // Stage 1: only Alice has shares. Build snapshot.
+        await service.recordShare('bc1qalice', 1000);
+        await service.getPayoutDistribution('g1', BLOCK_REWARD);
+
+        // Stage 2: Bob arrives AFTER snapshot was built.
+        await service.recordShare('bc1qbob', 2000);
+
+        // Stage 3: Alice finds the block. Snapshot-based bookkeeping runs.
+        await service.onBlockFound(900_000, BLOCK_REWARD, 'bc1qalice');
+
+        // Bob's balance must NOT have been credited anything — the coinbase already
+        // claimed 100% of the miner cut via Alice's snapshot entry.
+        const bobBalance = await balanceRepo.findOneBy({ address: 'bc1qbob' });
+        expect(bobBalance?.pendingSats ?? 0).toBe(0);
+
+        // But Bob should have an audit history row showing his shares with paidSats=0
+        const bobRows = (historyRepo._rows as any[]).filter(r => r.address === 'bc1qbob');
+        expect(bobRows).toHaveLength(1);
+        expect(bobRows[0].paidSats).toBe(0);
+        expect(bobRows[0].inCoinbase).toBe(false);
+        expect(bobRows[0].sharesInRound).toBe(2000);
+
+        // Total paid via coinbase (fee + Alice) should not exceed BLOCK_REWARD
+        const coinbasePaid = (historyRepo._rows as any[])
+            .filter(r => r.inCoinbase === true)
+            .reduce((sum, r) => sum + r.paidSats, 0);
+        expect(coinbasePaid).toBeLessThanOrEqual(BLOCK_REWARD);
+        // And miner-cut portion (non-fee) should not exceed rewardForMiners
+        const minerCoinbasePaid = (historyRepo._rows as any[])
+            .filter(r => r.inCoinbase === true && r.address !== 'bc1qfee')
+            .reduce((sum, r) => sum + r.paidSats, 0);
+        const rewardForMiners = Math.floor(0.98 * BLOCK_REWARD);
+        expect(minerCoinbasePaid).toBeLessThanOrEqual(rewardForMiners);
+    });
+
     it('getRoundStats returns current round snapshot', async () => {
         const { service, groupService } = makeService();
         groupService._setMembership('bc1qalice', 'g1', true);

--- a/src/services/group-solo.service.spec.ts
+++ b/src/services/group-solo.service.spec.ts
@@ -195,6 +195,46 @@ describe('GroupSoloService', () => {
         expect(bigRows.some(r => r.inCoinbase === true)).toBe(true);
     });
 
+    it('pending balances accumulate across rounds until they cross dust, then are paid in coinbase', async () => {
+        const { service, balanceRepo, historyRepo, groupService } = makeService();
+        // Block reward chosen so Charlie's 1-of-1000 share is ~100 sats (well below 546 dust)
+        const BLOCK_REWARD = 10_000; // 10k sats
+        groupService._setMembership('bc1qbig', 'g1', true);
+        groupService._setMembership('bc1qtiny', 'g1', true);
+
+        // ── Round 1 ────────────────────────────────────────────────
+        await service.recordShare('bc1qbig', 999);
+        await service.recordShare('bc1qtiny', 1);
+        await service.getPayoutDistribution('g1', BLOCK_REWARD);
+        await service.onBlockFound(900_001, BLOCK_REWARD, 'bc1qbig');
+
+        // Charlie's round-1 sats went to pending (sub-dust); Alice was paid via coinbase
+        const round1Rows = historyRepo._rows as any[];
+        const tinyRound1 = round1Rows.find(r => r.address === 'bc1qtiny' && r.blockHeight === 900_001);
+        expect(tinyRound1.inCoinbase).toBe(false);
+        const tinyBalance1 = await balanceRepo.findOneBy({ address: 'bc1qtiny' });
+        expect(tinyBalance1.pendingSats).toBeGreaterThan(0);
+        const pendingAfterRound1: number = tinyBalance1.pendingSats;
+
+        // ── Round 2 ────────────────────────────────────────────────
+        // Now give Charlie a much bigger share so his new earnings + pending clearly exceed dust
+        await service.recordShare('bc1qbig', 100);
+        await service.recordShare('bc1qtiny', 900);
+        await service.getPayoutDistribution('g1', BLOCK_REWARD);
+        await service.onBlockFound(900_002, BLOCK_REWARD, 'bc1qbig');
+
+        // Charlie should now appear in round-2's coinbase and his pending should be cleared
+        const tinyRound2 = (historyRepo._rows as any[])
+            .filter(r => r.address === 'bc1qtiny' && r.blockHeight === 900_002);
+        expect(tinyRound2.length).toBeGreaterThan(0);
+        expect(tinyRound2.some(r => r.inCoinbase === true)).toBe(true);
+
+        const tinyBalance2 = await balanceRepo.findOneBy({ address: 'bc1qtiny' });
+        expect(tinyBalance2.pendingSats).toBe(0);
+        // Previous pending sats have moved to totalPaidSats
+        expect(tinyBalance2.totalPaidSats).toBeGreaterThanOrEqual(pendingAfterRound1);
+    });
+
     it('getRoundStats returns current round snapshot', async () => {
         const { service, groupService } = makeService();
         groupService._setMembership('bc1qalice', 'g1', true);

--- a/src/services/group-solo.service.spec.ts
+++ b/src/services/group-solo.service.spec.ts
@@ -1,0 +1,211 @@
+jest.mock('node-telegram-bot-api', () => jest.fn());
+
+import { GroupSoloService } from './group-solo.service';
+
+// ── Mock Redis (sorted set + key-value) ─────────────────────────
+
+function createMockRedis() {
+    const store = new Map<string, string>();
+    const zsets = new Map<string, { score: number; value: string }[]>();
+    const getZ = (key: string) => {
+        if (!zsets.has(key)) zsets.set(key, []);
+        return zsets.get(key)!;
+    };
+
+    return {
+        incr: jest.fn(async (key: string) => {
+            const val = parseInt(store.get(key) ?? '0', 10) + 1;
+            store.set(key, val.toString());
+            return val;
+        }),
+        get: jest.fn(async (key: string) => store.get(key) ?? null),
+        set: jest.fn(async (key: string, value: string) => { store.set(key, value); }),
+        del: jest.fn(async (key: string) => { store.delete(key); zsets.delete(key); }),
+        incrByFloat: jest.fn(async (key: string, amount: number) => {
+            const val = parseFloat(store.get(key) ?? '0') + amount;
+            store.set(key, val.toString());
+            return val;
+        }),
+        zAdd: jest.fn(async (key: string, entry: { score: number; value: string }) => {
+            const z = getZ(key);
+            z.push(entry);
+            z.sort((a, b) => a.score - b.score);
+        }),
+        zRange: jest.fn(async (key: string, start: number, end: number) => {
+            const z = getZ(key);
+            const e = end === -1 ? z.length - 1 : end;
+            return z.slice(start, e + 1).map(x => x.value);
+        }),
+        zCard: jest.fn(async (key: string) => getZ(key).length),
+        _store: store,
+        _zsets: zsets,
+    };
+}
+
+// ── Mock GroupService ───────────────────────────────────────────
+
+function createMockGroupService() {
+    const addressToGroup = new Map<string, { groupId: string; active: boolean }>();
+    return {
+        getGroupForAddress: jest.fn((address: string) => addressToGroup.get(address)),
+        _setMembership: (address: string, groupId: string, active = true) => {
+            addressToGroup.set(address, { groupId, active });
+        },
+    };
+}
+
+// ── Mock History + Balance repos ────────────────────────────────
+
+function createMockRepo<T>() {
+    const rows: T[] = [];
+    return {
+        save: jest.fn(async (row: T) => { rows.push({ ...row }); return row; }),
+        create: jest.fn((partial: Partial<T>) => ({ ...partial }) as T),
+        find: jest.fn(async () => [...rows]),
+        findOneBy: jest.fn(async (where: any) => {
+            return (rows as any[]).find(r =>
+                Object.entries(where).every(([k, v]) => r[k] === v),
+            ) ?? null;
+        }),
+        _rows: rows,
+    };
+}
+
+// ── Helper ──────────────────────────────────────────────────────
+
+function makeService(envOverrides: Record<string, string> = {}) {
+    const env: Record<string, string> = {
+        GROUP_SOLO_PORT: '3340',
+        PPLNS_FEE_ADDRESS: 'bc1qfee',
+        PPLNS_FEE_PERCENT: '2',
+        ...envOverrides,
+    };
+    const configService = { get: jest.fn((k: string) => env[k]) };
+    const cacheManager = { store: {} };
+    const historyRepo = createMockRepo();
+    const balanceRepo = createMockRepo();
+    const groupService = createMockGroupService();
+    const service = new GroupSoloService(
+        configService as any,
+        cacheManager as any,
+        historyRepo as any,
+        balanceRepo as any,
+        groupService as any,
+    );
+    const redis = createMockRedis();
+    // Inject redis by going through onModuleInit with a redis-shaped store
+    (service as any).redis = redis;
+    (service as any).enabled = true;
+    return { service, redis, historyRepo, balanceRepo, groupService };
+}
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('GroupSoloService', () => {
+
+    it('isEnabled returns false when GROUP_SOLO_PORT is not set', () => {
+        const { service } = makeService({ GROUP_SOLO_PORT: '' });
+        (service as any).enabled = false;
+        expect(service.isEnabled()).toBe(false);
+    });
+
+    it('recordShare rejects addresses not in an active group', async () => {
+        const { service, groupService } = makeService();
+        // address not registered
+        const ok = await service.recordShare('bc1qstranger', 100);
+        expect(ok).toBe(false);
+        // inactive group
+        groupService._setMembership('bc1qalice', 'g1', false);
+        const ok2 = await service.recordShare('bc1qalice', 100);
+        expect(ok2).toBe(false);
+    });
+
+    it('recordShare routes to the group\'s Redis bucket', async () => {
+        const { service, redis, groupService } = makeService();
+        groupService._setMembership('bc1qalice', 'g1', true);
+        await service.recordShare('bc1qalice', 100);
+        expect(redis._zsets.size).toBe(1);
+        const zset = Array.from(redis._zsets.values())[0];
+        expect(zset).toHaveLength(1);
+        expect(zset[0].value).toMatch(/^bc1qalice:100:/);
+    });
+
+    it('distribution splits proportionally to round shares (PROP)', async () => {
+        const { service, groupService } = makeService();
+        groupService._setMembership('bc1qalice', 'g1', true);
+        groupService._setMembership('bc1qbob', 'g1', true);
+        await service.recordShare('bc1qalice', 750);
+        await service.recordShare('bc1qbob', 250);
+
+        const dist = await service.getPayoutDistribution('g1', 100_000_000); // 1 BTC
+        // Fee (2%) + two miners
+        expect(dist).toHaveLength(3);
+        expect(dist[0].address).toBe('bc1qfee');
+        const alice = dist.find(d => d.address === 'bc1qalice')!;
+        const bob = dist.find(d => d.address === 'bc1qbob')!;
+        // Alice had 75% of shares, should get ~75% of the miner cut (98%)
+        expect(alice.percent).toBeCloseTo(73.5, 1);
+        expect(bob.percent).toBeCloseTo(24.5, 1);
+        // Sum of percents ≈ 100
+        const total = dist.reduce((s, d) => s + d.percent, 0);
+        expect(total).toBeCloseTo(100, 5);
+    });
+
+    it('onBlockFound writes history rows and resets the round', async () => {
+        const { service, redis, historyRepo, groupService } = makeService();
+        groupService._setMembership('bc1qalice', 'g1', true);
+        groupService._setMembership('bc1qbob', 'g1', true);
+        await service.recordShare('bc1qalice', 500);
+        await service.recordShare('bc1qbob', 500);
+        await service.getPayoutDistribution('g1', 100_000_000); // populate snapshot
+
+        await service.onBlockFound(900_000, 100_000_000, 'bc1qalice');
+
+        // All history rows reference the same block + group
+        const rows = historyRepo._rows as any[];
+        expect(rows.length).toBeGreaterThanOrEqual(2); // fee + at least one miner
+        expect(rows.every(r => r.blockHeight === 900_000 && r.groupId === 'g1')).toBe(true);
+
+        // Round reset: all Redis keys for this group are gone
+        expect(redis._zsets.size).toBe(0);
+        for (const [key] of redis._store) {
+            expect(key).not.toMatch(/^groupsolo:g1:/);
+        }
+    });
+
+    it('sub-dust miners go to pending, not coinbase', async () => {
+        const { service, balanceRepo, historyRepo, groupService } = makeService();
+        groupService._setMembership('bc1qbig', 'g1', true);
+        groupService._setMembership('bc1qtiny', 'g1', true);
+        // Bigger share for bc1qbig — make bc1qtiny's cut < dust (546 sats) of 1 BTC
+        await service.recordShare('bc1qbig', 999_999);
+        await service.recordShare('bc1qtiny', 1);
+
+        await service.getPayoutDistribution('g1', 100_000_000);
+        await service.onBlockFound(900_000, 100_000_000, 'bc1qbig');
+
+        // Tiny's small sat amount (< 546) should either not appear in coinbase
+        // or appear as inCoinbase=false (pending row).
+        const tinyRows = (historyRepo._rows as any[]).filter(r => r.address === 'bc1qtiny');
+        if (tinyRows.length > 0) {
+            expect(tinyRows[0].inCoinbase).toBe(false);
+        }
+        // Big miner paid via coinbase
+        const bigRows = (historyRepo._rows as any[]).filter(r => r.address === 'bc1qbig');
+        expect(bigRows.some(r => r.inCoinbase === true)).toBe(true);
+    });
+
+    it('getRoundStats returns current round snapshot', async () => {
+        const { service, groupService } = makeService();
+        groupService._setMembership('bc1qalice', 'g1', true);
+        await service.recordShare('bc1qalice', 100);
+        await service.recordShare('bc1qalice', 200);
+
+        const stats = await service.getRoundStats('g1');
+        expect(stats.shareCount).toBe(2);
+        expect(stats.totalDifficulty).toBe(300);
+        expect(stats.perAddress).toHaveLength(1);
+        expect(stats.perAddress[0].address).toBe('bc1qalice');
+        expect(stats.perAddress[0].percent).toBe(100);
+    });
+});

--- a/src/services/group-solo.service.ts
+++ b/src/services/group-solo.service.ts
@@ -1,0 +1,438 @@
+import { Injectable, Inject, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PplnsGroupBlockHistoryEntity } from '../ORM/pplns-group/pplns-group-block-history.entity';
+import { PplnsGroupBalanceEntity } from '../ORM/pplns-group/pplns-group-balance.entity';
+import { GroupService } from './group.service';
+
+/**
+ * Group-solo PROP-style payout engine.
+ *
+ * - One share window per group, kept in Redis: `groupsolo:{groupId}:shares`.
+ * - PROP semantics: the window is cleared on every block-found event.
+ * - Distribution: each member's cut = (their shares in round / total shares in round) × (1 - feePercent).
+ * - Pool fee (PPLNS_FEE_PERCENT / PPLNS_FEE_ADDRESS) applied before member distribution,
+ *   identical to the main PPLNS engine.
+ * - Outputs trimmed by coinbase weight budget go to `pplns_group_balance.pendingSats`.
+ *
+ * Only active when GROUP_SOLO_PORT is configured.
+ */
+
+const DUST_LIMIT_SATS = 546;
+const DEFAULT_COINBASE_WEIGHT_BUDGET = 50_000;
+const COINBASE_BASE_WEIGHT = 320;
+const COINBASE_OUTPUT_WEIGHT = 124;
+
+function redisKeys(groupId: string) {
+    return {
+        shares: `groupsolo:${groupId}:shares`,
+        counter: `groupsolo:${groupId}:counter`,
+        total: `groupsolo:${groupId}:total`,
+    };
+}
+
+export interface GroupSoloPayoutEntry {
+    address: string;
+    percent: number;
+}
+
+@Injectable()
+export class GroupSoloService implements OnModuleInit {
+
+    private redis: any = null;
+    private enabled = false;
+    private feeAddress: string;
+    private feePercent: number;
+    private readonly coinbaseWeightBudget: number;
+
+    /** Coinbase snapshot per group — so onBlockFound can match on-chain payouts exactly. */
+    private snapshots = new Map<string, { distribution: GroupSoloPayoutEntry[]; blockRewardSats: number }>();
+
+    /** Per-group block-found reentrancy guard. */
+    private blockFoundLocks = new Set<string>();
+
+    constructor(
+        private readonly configService: ConfigService,
+        @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+        @InjectRepository(PplnsGroupBlockHistoryEntity)
+        private readonly historyRepo: Repository<PplnsGroupBlockHistoryEntity>,
+        @InjectRepository(PplnsGroupBalanceEntity)
+        private readonly balanceRepo: Repository<PplnsGroupBalanceEntity>,
+        private readonly groupService: GroupService,
+    ) {
+        this.feeAddress = this.configService.get('PPLNS_FEE_ADDRESS') ?? '';
+        this.feePercent = parseFloat(this.configService.get('PPLNS_FEE_PERCENT') ?? '2');
+        this.coinbaseWeightBudget = parseInt(
+            this.configService.get('PPLNS_COINBASE_WEIGHT_BUDGET') ?? DEFAULT_COINBASE_WEIGHT_BUDGET.toString(),
+            10,
+        ) || DEFAULT_COINBASE_WEIGHT_BUDGET;
+        this.enabled = !!this.configService.get('GROUP_SOLO_PORT');
+    }
+
+    async onModuleInit(): Promise<void> {
+        if (!this.enabled) return;
+
+        try {
+            const store: any = this.cacheManager.store;
+            if (store?.client) {
+                this.redis = store.client;
+                console.log('[GroupSolo] Service initialized with Redis');
+            } else {
+                console.error('[GroupSolo] Redis not available — group-solo will not function!');
+            }
+        } catch (error) {
+            console.error('[GroupSolo] Failed to access Redis client:', error);
+        }
+    }
+
+    isEnabled(): boolean {
+        return this.enabled && !!this.redis;
+    }
+
+    /** Delegate to GroupService — allows stratum layer to query address membership via one service. */
+    getGroupForAddress(address: string) {
+        return this.groupService.getGroupForAddress(address);
+    }
+
+    // ── Share Recording ──────────────────────────────────────────
+
+    /** Record an accepted share from a group-solo miner. Returns false if address is not routable. */
+    async recordShare(address: string, difficulty: number): Promise<boolean> {
+        if (!this.isEnabled()) return false;
+        const entry = this.groupService.getGroupForAddress(address);
+        if (!entry || !entry.active) return false;
+
+        const keys = redisKeys(entry.groupId);
+        const counter = await this.redis.incr(keys.counter);
+        const payload = `${address}:${difficulty}:${Date.now()}`;
+        await this.redis.zAdd(keys.shares, { score: counter, value: payload });
+        await this.redis.incrByFloat(keys.total, difficulty);
+        return true;
+    }
+
+    // ── Payout Distribution ──────────────────────────────────────
+
+    /**
+     * Build the current round's payout distribution for the given group.
+     * Stores a snapshot so onBlockFound can use the exact same split.
+     */
+    async getPayoutDistribution(groupId: string, blockRewardSats: number): Promise<GroupSoloPayoutEntry[]> {
+        if (!this.isEnabled()) return this.fallback();
+
+        const keys = redisKeys(groupId);
+        const entries = await this.redis.zRange(keys.shares, 0, -1);
+        if (!entries || entries.length === 0) {
+            return this.fallback();
+        }
+
+        const addressDiff = new Map<string, number>();
+        let totalDiff = 0;
+        for (const e of entries) {
+            const [addr, diffStr] = e.split(':');
+            const diff = parseFloat(diffStr) || 0;
+            addressDiff.set(addr, (addressDiff.get(addr) ?? 0) + diff);
+            totalDiff += diff;
+        }
+        if (totalDiff <= 0) return this.fallback();
+
+        const feePercent = this.feePercent;
+        const rewardForMiners = Math.floor(((100 - feePercent) / 100) * blockRewardSats);
+
+        // Include pending balances from prior rounds.
+        const pendingEntities = await this.balanceRepo.find({ where: { groupId } });
+        const pendingMap = new Map<string, number>();
+        for (const p of pendingEntities) pendingMap.set(p.address, p.pendingSats);
+
+        const minerShares: { address: string; sats: number; percent: number }[] = [];
+        for (const [addr, diff] of addressDiff) {
+            const ratio = diff / totalDiff;
+            const baseSats = Math.floor(ratio * rewardForMiners);
+            const totalSats = baseSats + (pendingMap.get(addr) ?? 0);
+            minerShares.push({
+                address: addr,
+                sats: totalSats,
+                percent: (totalSats / blockRewardSats) * 100,
+            });
+        }
+        // Pending-only entries (members with pending ≥ dust but no shares this round).
+        for (const [addr, pending] of pendingMap) {
+            if (!addressDiff.has(addr) && pending >= DUST_LIMIT_SATS) {
+                minerShares.push({
+                    address: addr,
+                    sats: pending,
+                    percent: (pending / blockRewardSats) * 100,
+                });
+            }
+        }
+
+        const eligible = minerShares
+            .filter(m => m.sats >= DUST_LIMIT_SATS)
+            .sort((a, b) => b.sats - a.sats);
+
+        const feeOutputCount = this.feeAddress ? 1 : 0;
+        const maxMinerOutputs = Math.floor(
+            (this.coinbaseWeightBudget - COINBASE_BASE_WEIGHT - (feeOutputCount + 1) * COINBASE_OUTPUT_WEIGHT)
+            / COINBASE_OUTPUT_WEIGHT,
+        );
+
+        const trimmed = eligible.length > maxMinerOutputs && maxMinerOutputs > 0
+            ? eligible.slice(0, maxMinerOutputs)
+            : eligible;
+        if (trimmed.length < eligible.length) {
+            console.warn(`[GroupSolo] Group ${groupId}: trimmed ${eligible.length - trimmed.length} smallest outputs to pending`);
+        }
+
+        const payouts: GroupSoloPayoutEntry[] = trimmed.map(m => ({ address: m.address, percent: m.percent }));
+        let total = trimmed.reduce((sum, m) => sum + m.percent, 0);
+
+        if (this.feeAddress) {
+            payouts.unshift({ address: this.feeAddress, percent: feePercent });
+            total += feePercent;
+        }
+
+        // Sweep remainder into fee (or last miner if no fee address).
+        if (payouts.length > 0 && total < 100) {
+            const remainder = 100 - total;
+            if (this.feeAddress) {
+                payouts[0].percent += remainder;
+            } else {
+                payouts[payouts.length - 1].percent += remainder;
+            }
+        }
+
+        const result = payouts.length > 0 ? payouts : this.fallback();
+        this.snapshots.set(groupId, { distribution: result, blockRewardSats });
+        return result;
+    }
+
+    private fallback(): GroupSoloPayoutEntry[] {
+        if (this.feeAddress) return [{ address: this.feeAddress, percent: 100 }];
+        return [];
+    }
+
+    // ── Block Found ──────────────────────────────────────────────
+
+    /**
+     * Called when a block is found by a group-solo miner. Uses the coinbase snapshot
+     * for bookkeeping, credits addresses trimmed from the coinbase to pending, and
+     * resets the round (deletes all three Redis keys for this group).
+     */
+    async onBlockFound(blockHeight: number, blockRewardSats: number, finderAddress: string): Promise<void> {
+        if (!this.isEnabled()) return;
+        const entry = this.groupService.getGroupForAddress(finderAddress);
+        if (!entry) return;
+        const groupId = entry.groupId;
+
+        if (this.blockFoundLocks.has(groupId)) {
+            console.warn(`[GroupSolo] Block ${blockHeight} for group ${groupId} — already processing`);
+            return;
+        }
+        this.blockFoundLocks.add(groupId);
+
+        try {
+            console.log(`[GroupSolo] Block ${blockHeight} found by group ${groupId} (finder=${finderAddress})`);
+
+            const snapshot = this.snapshots.get(groupId);
+            if (!snapshot || snapshot.distribution.length === 0) {
+                console.warn(`[GroupSolo] No snapshot for group ${groupId} — using window recalculation fallback`);
+                await this.onBlockFoundFromWindow(groupId, blockHeight, blockRewardSats);
+                return;
+            }
+            this.snapshots.delete(groupId);
+            const reward = snapshot.blockRewardSats;
+
+            // Miners in the snapshot get paid via coinbase; clear any prior pending.
+            for (const d of snapshot.distribution) {
+                const paidSats = Math.floor((d.percent / 100) * reward);
+                const isFee = d.address === this.feeAddress;
+                if (!isFee) {
+                    const existing = await this.balanceRepo.findOneBy({ address: d.address });
+                    if (existing && existing.pendingSats > 0) {
+                        existing.totalPaidSats += existing.pendingSats;
+                        existing.pendingSats = 0;
+                        await this.balanceRepo.save(existing);
+                    }
+                }
+                await this.historyRepo.save(this.historyRepo.create({
+                    groupId, blockHeight, address: d.address,
+                    paidSats, percent: d.percent,
+                    sharesInRound: 0, totalSharesInRound: 0,
+                    inCoinbase: true,
+                }));
+            }
+
+            // Members with shares this round who didn't make the coinbase → pending.
+            const snapshotAddrs = new Set(snapshot.distribution.map(d => d.address));
+            const keys = redisKeys(groupId);
+            const entries = await this.redis.zRange(keys.shares, 0, -1);
+            if (entries && entries.length > 0) {
+                const addressDiff = new Map<string, number>();
+                let totalDiff = 0;
+                for (const e of entries) {
+                    const [addr, diffStr] = e.split(':');
+                    const diff = parseFloat(diffStr) || 0;
+                    addressDiff.set(addr, (addressDiff.get(addr) ?? 0) + diff);
+                    totalDiff += diff;
+                }
+                const rewardForMiners = Math.floor(((100 - this.feePercent) / 100) * reward);
+                for (const [addr, diff] of addressDiff) {
+                    if (snapshotAddrs.has(addr)) continue;
+                    const sats = Math.floor((diff / totalDiff) * rewardForMiners);
+                    if (sats > 0) {
+                        await this.addPending(groupId, addr, sats);
+                        await this.historyRepo.save(this.historyRepo.create({
+                            groupId, blockHeight, address: addr,
+                            paidSats: sats,
+                            percent: (diff / totalDiff) * (100 - this.feePercent),
+                            sharesInRound: Math.round(diff),
+                            totalSharesInRound: Math.round(totalDiff),
+                            inCoinbase: false,
+                        }));
+                    }
+                }
+            }
+
+            // PROP semantics: clear the round.
+            await this.resetRound(groupId);
+        } finally {
+            this.blockFoundLocks.delete(groupId);
+        }
+    }
+
+    /** Fallback when no snapshot is available (first block or race). */
+    private async onBlockFoundFromWindow(groupId: string, blockHeight: number, blockRewardSats: number): Promise<void> {
+        const keys = redisKeys(groupId);
+        const entries = await this.redis.zRange(keys.shares, 0, -1);
+        if (!entries || entries.length === 0) {
+            await this.resetRound(groupId);
+            return;
+        }
+
+        const addressDiff = new Map<string, number>();
+        let totalDiff = 0;
+        for (const e of entries) {
+            const [addr, diffStr] = e.split(':');
+            const diff = parseFloat(diffStr) || 0;
+            addressDiff.set(addr, (addressDiff.get(addr) ?? 0) + diff);
+            totalDiff += diff;
+        }
+        if (totalDiff <= 0) {
+            await this.resetRound(groupId);
+            return;
+        }
+
+        const rewardForMiners = Math.floor(((100 - this.feePercent) / 100) * blockRewardSats);
+
+        for (const [addr, diff] of addressDiff) {
+            const ratio = diff / totalDiff;
+            const sats = Math.floor(ratio * rewardForMiners);
+            const existing = await this.balanceRepo.findOneBy({ address: addr });
+            const pending = existing?.pendingSats ?? 0;
+            const totalSats = sats + pending;
+            const percent = ratio * (100 - this.feePercent);
+
+            if (totalSats >= DUST_LIMIT_SATS) {
+                if (existing && pending > 0) {
+                    existing.totalPaidSats += pending;
+                    existing.pendingSats = 0;
+                    await this.balanceRepo.save(existing);
+                }
+                await this.historyRepo.save(this.historyRepo.create({
+                    groupId, blockHeight, address: addr,
+                    paidSats: totalSats, percent,
+                    sharesInRound: Math.round(diff),
+                    totalSharesInRound: Math.round(totalDiff),
+                    inCoinbase: true,
+                }));
+            } else {
+                if (sats > 0) {
+                    await this.addPending(groupId, addr, sats);
+                    await this.historyRepo.save(this.historyRepo.create({
+                        groupId, blockHeight, address: addr,
+                        paidSats: sats, percent,
+                        sharesInRound: Math.round(diff),
+                        totalSharesInRound: Math.round(totalDiff),
+                        inCoinbase: false,
+                    }));
+                }
+            }
+        }
+
+        if (this.feeAddress) {
+            const feeSats = blockRewardSats - rewardForMiners;
+            await this.historyRepo.save(this.historyRepo.create({
+                groupId, blockHeight, address: this.feeAddress,
+                paidSats: feeSats, percent: this.feePercent,
+                sharesInRound: 0, totalSharesInRound: 0,
+                inCoinbase: true,
+            }));
+        }
+
+        await this.resetRound(groupId);
+    }
+
+    private async addPending(groupId: string, address: string, sats: number): Promise<void> {
+        const existing = await this.balanceRepo.findOneBy({ address });
+        if (existing) {
+            existing.pendingSats += sats;
+            await this.balanceRepo.save(existing);
+        } else {
+            await this.balanceRepo.save(this.balanceRepo.create({
+                address, groupId, pendingSats: sats, totalPaidSats: 0,
+            }));
+        }
+    }
+
+    private async resetRound(groupId: string): Promise<void> {
+        const keys = redisKeys(groupId);
+        await this.redis.del(keys.shares);
+        await this.redis.del(keys.counter);
+        await this.redis.del(keys.total);
+    }
+
+    // ── Stats (for API) ──────────────────────────────────────────
+
+    async getRoundStats(groupId: string): Promise<{
+        totalDifficulty: number;
+        shareCount: number;
+        perAddress: { address: string; difficulty: number; percent: number }[];
+    }> {
+        if (!this.isEnabled()) {
+            return { totalDifficulty: 0, shareCount: 0, perAddress: [] };
+        }
+        const keys = redisKeys(groupId);
+        const entries = await this.redis.zRange(keys.shares, 0, -1);
+        const addressDiff = new Map<string, number>();
+        let totalDiff = 0;
+        for (const e of (entries ?? [])) {
+            const [addr, diffStr] = e.split(':');
+            const diff = parseFloat(diffStr) || 0;
+            addressDiff.set(addr, (addressDiff.get(addr) ?? 0) + diff);
+            totalDiff += diff;
+        }
+        const perAddress = Array.from(addressDiff.entries())
+            .map(([address, difficulty]) => ({
+                address,
+                difficulty,
+                percent: totalDiff > 0 ? (difficulty / totalDiff) * 100 : 0,
+            }))
+            .sort((a, b) => b.percent - a.percent);
+
+        return {
+            totalDifficulty: totalDiff,
+            shareCount: (entries ?? []).length,
+            perAddress,
+        };
+    }
+
+    async getBlockHistory(groupId: string, limit = 100): Promise<PplnsGroupBlockHistoryEntity[]> {
+        return this.historyRepo.find({
+            where: { groupId },
+            order: { createdAt: 'DESC' },
+            take: Math.min(Math.max(limit, 1), 500),
+        });
+    }
+}

--- a/src/services/group-solo.service.ts
+++ b/src/services/group-solo.service.ts
@@ -48,8 +48,19 @@ export class GroupSoloService implements OnModuleInit {
     private feePercent: number;
     private readonly coinbaseWeightBudget: number;
 
-    /** Coinbase snapshot per group — so onBlockFound can match on-chain payouts exactly. */
-    private snapshots = new Map<string, { distribution: GroupSoloPayoutEntry[]; blockRewardSats: number }>();
+    /**
+     * Coinbase snapshot per group.  `distribution` = what goes into the coinbase;
+     * `consideredAddresses` = every address that was in the Redis window at the moment
+     * the snapshot was built (including sub-dust miners that were filtered out).  This
+     * lets onBlockFound tell apart two classes of "not in coinbase" miners:
+     *   - sub-dust: was in the window at snapshot time → credit to pending so they accumulate
+     *   - late arriver: submitted after snapshot was built → don't credit (would double-count)
+     */
+    private snapshots = new Map<string, {
+        distribution: GroupSoloPayoutEntry[];
+        blockRewardSats: number;
+        consideredAddresses: Set<string>;
+    }>();
 
     /** Per-group block-found reentrancy guard. */
     private blockFoundLocks = new Set<string>();
@@ -69,7 +80,9 @@ export class GroupSoloService implements OnModuleInit {
             this.configService.get('PPLNS_COINBASE_WEIGHT_BUDGET') ?? DEFAULT_COINBASE_WEIGHT_BUDGET.toString(),
             10,
         ) || DEFAULT_COINBASE_WEIGHT_BUDGET;
-        this.enabled = !!this.configService.get('GROUP_SOLO_PORT');
+        // Group-solo is always enabled if the service is loaded — routing is
+        // address-driven via the GroupService's address→group cache.
+        this.enabled = true;
     }
 
     async onModuleInit(): Promise<void> {
@@ -204,7 +217,12 @@ export class GroupSoloService implements OnModuleInit {
         }
 
         const result = payouts.length > 0 ? payouts : this.fallback();
-        this.snapshots.set(groupId, { distribution: result, blockRewardSats });
+        // Record every address that contributed work at snapshot-build time, including
+        // sub-dust miners that got filtered out of the coinbase. See `snapshots` field
+        // doc for why this distinction matters.
+        const consideredAddresses = new Set<string>(addressDiff.keys());
+        for (const addr of pendingMap.keys()) consideredAddresses.add(addr);
+        this.snapshots.set(groupId, { distribution: result, blockRewardSats, consideredAddresses });
         return result;
     }
 
@@ -264,7 +282,14 @@ export class GroupSoloService implements OnModuleInit {
                 }));
             }
 
-            // Members with shares this round who didn't make the coinbase → pending.
+            // For each window address not in snapshot.distribution, determine whether
+            // it was considered at snapshot-build time:
+            //   - YES → sub-dust miner (filtered by dust or weight-budget): credit to
+            //     pending so it accumulates for future coinbase inclusion.
+            //   - NO  → late arriver (share landed in Redis after snapshot was built):
+            //     under PROP rules this work is lost for the current block. Credit
+            //     would double-count because the snapshot already claims 100% of the
+            //     miner cut in the on-chain coinbase.
             const snapshotAddrs = new Set(snapshot.distribution.map(d => d.address));
             const keys = redisKeys(groupId);
             const entries = await this.redis.zRange(keys.shares, 0, -1);
@@ -280,17 +305,36 @@ export class GroupSoloService implements OnModuleInit {
                 const rewardForMiners = Math.floor(((100 - this.feePercent) / 100) * reward);
                 for (const [addr, diff] of addressDiff) {
                     if (snapshotAddrs.has(addr)) continue;
-                    const sats = Math.floor((diff / totalDiff) * rewardForMiners);
-                    if (sats > 0) {
-                        await this.addPending(groupId, addr, sats);
+                    const wasConsidered = snapshot.consideredAddresses.has(addr);
+                    if (wasConsidered) {
+                        // Sub-dust or weight-trimmed — credit to pending proportional to
+                        // their share of the (original) snapshot-time window. Since we
+                        // don't store the snapshot-time totalDiff, we use current-window
+                        // ratio as an approximation; on mainnet the window is stable
+                        // enough that this is accurate to within rounding.
+                        const sats = Math.floor((diff / totalDiff) * rewardForMiners);
+                        if (sats > 0) {
+                            await this.addPending(groupId, addr, sats);
+                            await this.historyRepo.save(this.historyRepo.create({
+                                groupId, blockHeight, address: addr,
+                                paidSats: sats,
+                                percent: (diff / totalDiff) * (100 - this.feePercent),
+                                sharesInRound: Math.round(diff),
+                                totalSharesInRound: Math.round(totalDiff),
+                                inCoinbase: false,
+                            }));
+                        }
+                    } else {
+                        // Late arriver — audit row only, no payout.
                         await this.historyRepo.save(this.historyRepo.create({
                             groupId, blockHeight, address: addr,
-                            paidSats: sats,
-                            percent: (diff / totalDiff) * (100 - this.feePercent),
+                            paidSats: 0,
+                            percent: 0,
                             sharesInRound: Math.round(diff),
                             totalSharesInRound: Math.round(totalDiff),
                             inCoinbase: false,
                         }));
+                        console.log(`[GroupSolo]   ${addr}: ${diff.toFixed(2)} shares in round but not in coinbase snapshot (late arrival, PROP rules)`);
                     }
                 }
             }

--- a/src/services/group.service.spec.ts
+++ b/src/services/group.service.spec.ts
@@ -1,0 +1,213 @@
+jest.mock('node-telegram-bot-api', () => jest.fn());
+
+import { GroupService, GroupServiceError } from './group.service';
+
+// ── Mock Repos ──────────────────────────────────────────────────
+
+function createMockRepo<T extends { id?: any }>() {
+    const rows = new Map<any, T>();
+    let nextNumeric = 1;
+
+    return {
+        _rows: rows,
+        save: jest.fn(async (row: T) => {
+            if (!row.id) {
+                (row as any).id = typeof (row as any).id === 'number'
+                    ? nextNumeric++
+                    : 'uuid-' + nextNumeric++;
+            }
+            rows.set((row as any).id, { ...row });
+            return { ...row };
+        }),
+        create: jest.fn((partial: Partial<T>) => ({ ...partial }) as T),
+        find: jest.fn(async (query?: any) => {
+            const all = Array.from(rows.values());
+            if (!query) return all;
+            if (query.where) {
+                const where = Array.isArray(query.where) ? query.where : [query.where];
+                return all.filter(row =>
+                    where.some((w: any) =>
+                        Object.entries(w).every(([k, v]) => {
+                            if (v && typeof v === 'object' && '_type' in (v as any) && (v as any)._type === 'isNull') {
+                                return (row as any)[k] == null;
+                            }
+                            return (row as any)[k] === v;
+                        }),
+                    ),
+                );
+            }
+            return all;
+        }),
+        findOne: jest.fn(async (query: any) => {
+            const all = Array.from(rows.values());
+            if (!query?.where) return null;
+            return all.find(row =>
+                Object.entries(query.where).every(([k, v]) => (row as any)[k] === v),
+            ) ?? null;
+        }),
+        findOneBy: jest.fn(async (where: any) => {
+            const all = Array.from(rows.values());
+            return all.find(row =>
+                Object.entries(where).every(([k, v]) => (row as any)[k] === v),
+            ) ?? null;
+        }),
+        count: jest.fn(async (query?: any) => {
+            const all = Array.from(rows.values());
+            if (!query?.where) return all.length;
+            return all.filter(row =>
+                Object.entries(query.where).every(([k, v]) => (row as any)[k] === v),
+            ).length;
+        }),
+        delete: jest.fn(async (where: any) => {
+            const all = Array.from(rows.entries());
+            for (const [id, row] of all) {
+                if (Object.entries(where).every(([k, v]) => (row as any)[k] === v)) {
+                    rows.delete(id);
+                }
+            }
+        }),
+    };
+}
+
+// typeorm's IsNull() returns a FindOperator; our mock just recognizes a marker
+jest.mock('typeorm', () => ({
+    ...jest.requireActual('typeorm'),
+    IsNull: () => ({ _type: 'isNull' }),
+}));
+
+describe('GroupService', () => {
+    let groupRepo: ReturnType<typeof createMockRepo>;
+    let memberRepo: ReturnType<typeof createMockRepo>;
+    let service: GroupService;
+
+    beforeEach(async () => {
+        groupRepo = createMockRepo();
+        memberRepo = createMockRepo();
+        service = new GroupService(groupRepo as any, memberRepo as any);
+        await service.onModuleInit();
+    });
+
+    // ── Creation ────────────────────────────────────────────────
+
+    it('creates a group and returns a plaintext admin token + hashed DB value', async () => {
+        const result = await service.createGroup('my-group', 'bc1qalice');
+        expect(result.adminToken).toMatch(/^GRP-/);
+        expect(result.group.adminTokenHash).toBeDefined();
+        expect(result.group.adminTokenHash).not.toBe(result.adminToken);
+        expect(result.group.creatorAddress).toBe('bc1qalice');
+        expect(result.group.active).toBe(false); // only 1 member
+    });
+
+    it('rejects short group names', async () => {
+        await expect(service.createGroup('ab', 'bc1qalice')).rejects.toThrow(GroupServiceError);
+    });
+
+    it('adds the creator as first member with role creator', async () => {
+        await service.createGroup('group-one', 'bc1qalice');
+        const members = Array.from(memberRepo._rows.values()) as any[];
+        expect(members).toHaveLength(1);
+        expect(members[0].role).toBe('creator');
+        expect(members[0].address).toBe('bc1qalice');
+    });
+
+    it('rejects creator address already in another group', async () => {
+        await service.createGroup('group-one', 'bc1qalice');
+        await expect(service.createGroup('group-two', 'bc1qalice'))
+            .rejects.toMatchObject({ code: 'address-in-group' });
+    });
+
+    // ── Token auth ──────────────────────────────────────────────
+
+    it('accepts valid admin token', async () => {
+        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
+        await expect(service.requireAdminToken(group.id, adminToken)).resolves.toBeDefined();
+    });
+
+    it('rejects invalid admin token', async () => {
+        const { group } = await service.createGroup('group-one', 'bc1qalice');
+        await expect(service.requireAdminToken(group.id, 'GRP-wrong')).rejects.toMatchObject({ code: 'invalid-token' });
+    });
+
+    it('rejects missing admin token', async () => {
+        const { group } = await service.createGroup('group-one', 'bc1qalice');
+        await expect(service.requireAdminToken(group.id, undefined)).rejects.toMatchObject({ code: 'missing-token' });
+    });
+
+    // ── Membership ──────────────────────────────────────────────
+
+    it('activates group when second member joins', async () => {
+        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
+        await service.addMember(group.id, 'bc1qbob', adminToken);
+        const updated: any = await groupRepo.findOneBy({ id: group.id });
+        expect(updated.active).toBe(true);
+    });
+
+    it('deactivates group when member count drops below 2', async () => {
+        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
+        await service.addMember(group.id, 'bc1qbob', adminToken);
+        await service.selfLeave(group.id, 'bc1qbob');
+        const updated: any = await groupRepo.findOneBy({ id: group.id });
+        expect(updated.active).toBe(false);
+    });
+
+    it('rejects adding an address already in another group', async () => {
+        const { group: g1, adminToken: t1 } = await service.createGroup('group-one', 'bc1qalice');
+        await service.addMember(g1.id, 'bc1qbob', t1);
+        const { group: g2, adminToken: t2 } = await service.createGroup('group-two', 'bc1qcharlie');
+        await expect(service.addMember(g2.id, 'bc1qbob', t2))
+            .rejects.toMatchObject({ code: 'address-in-group' });
+    });
+
+    it('populates address cache after membership changes', async () => {
+        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
+        await service.addMember(group.id, 'bc1qbob', adminToken);
+        expect(service.getGroupForAddress('bc1qbob')).toEqual({ groupId: group.id, active: true });
+    });
+
+    it('cache reflects inactive state when only one member remains', async () => {
+        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
+        await service.addMember(group.id, 'bc1qbob', adminToken);
+        await service.selfLeave(group.id, 'bc1qbob');
+        // Creator still present but group inactive
+        expect(service.getGroupForAddress('bc1qalice')).toEqual({ groupId: group.id, active: false });
+    });
+
+    // ── Creator leave / transfer ────────────────────────────────
+
+    it('blocks creator self-leave', async () => {
+        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
+        await service.addMember(group.id, 'bc1qbob', adminToken);
+        await expect(service.selfLeave(group.id, 'bc1qalice'))
+            .rejects.toMatchObject({ code: 'creator-cannot-self-leave' });
+    });
+
+    it('auto-transfers creator role to oldest member when creator is kicked by token', async () => {
+        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
+        await service.addMember(group.id, 'bc1qbob', adminToken);
+        await service.addMember(group.id, 'bc1qcharlie', adminToken);
+        await service.removeMember(group.id, 'bc1qalice', adminToken);
+
+        const members = Array.from(memberRepo._rows.values()) as any[];
+        const creator = members.find(m => m.role === 'creator');
+        expect(creator.address).toBe('bc1qbob'); // oldest remaining
+    });
+
+    it('dissolves group when last creator leaves alone', async () => {
+        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
+        await service.removeMember(group.id, 'bc1qalice', adminToken);
+        const updated: any = await groupRepo.findOneBy({ id: group.id });
+        expect(updated.dissolvedAt).toBeDefined();
+    });
+
+    it('transferCreator rotates admin token', async () => {
+        const { group, adminToken: oldToken } = await service.createGroup('group-one', 'bc1qalice');
+        await service.addMember(group.id, 'bc1qbob', oldToken);
+        const { adminToken: newToken } = await service.transferCreator(group.id, 'bc1qbob', oldToken);
+        expect(newToken).not.toBe(oldToken);
+        // Old token no longer works
+        await expect(service.requireAdminToken(group.id, oldToken))
+            .rejects.toMatchObject({ code: 'invalid-token' });
+        // New token works
+        await expect(service.requireAdminToken(group.id, newToken)).resolves.toBeDefined();
+    });
+});

--- a/src/services/group.service.ts
+++ b/src/services/group.service.ts
@@ -138,6 +138,7 @@ export class GroupService implements OnModuleInit {
 
         const adminToken = this.generateToken();
         const group = await this.groupRepo.save(this.groupRepo.create({
+            id: crypto.randomUUID(),
             name: trimmedName,
             creatorAddress,
             adminTokenHash: this.hashToken(adminToken),

--- a/src/services/group.service.ts
+++ b/src/services/group.service.ts
@@ -1,0 +1,298 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import * as crypto from 'crypto';
+import { PplnsGroupEntity } from '../ORM/pplns-group/pplns-group.entity';
+import { PplnsGroupMemberEntity } from '../ORM/pplns-group/pplns-group-member.entity';
+
+/**
+ * Manages group lifecycle (create/transfer/dissolve), membership (add/kick/self-leave),
+ * admin-token auth, and an in-memory address→groupId cache used by the stratum layer.
+ *
+ * Groups are "active" once they have ≥ MIN_MEMBERS_ACTIVE members; the stratum layer
+ * refuses connections for addresses that belong to an inactive group.
+ */
+
+const MIN_MEMBERS_ACTIVE = 2;
+
+export class GroupServiceError extends Error {
+    constructor(public readonly code: string, message: string) {
+        super(message);
+    }
+}
+
+export interface GroupCreateResult {
+    group: PplnsGroupEntity;
+    /** Plain-text admin token — shown to the creator exactly once. */
+    adminToken: string;
+}
+
+export interface GroupCacheEntry {
+    groupId: string;
+    active: boolean;
+}
+
+@Injectable()
+export class GroupService implements OnModuleInit {
+
+    /** address → { groupId, active }. Refreshed on every membership change. */
+    private addressCache = new Map<string, GroupCacheEntry>();
+
+    constructor(
+        @InjectRepository(PplnsGroupEntity)
+        private readonly groupRepo: Repository<PplnsGroupEntity>,
+        @InjectRepository(PplnsGroupMemberEntity)
+        private readonly memberRepo: Repository<PplnsGroupMemberEntity>,
+    ) {}
+
+    async onModuleInit(): Promise<void> {
+        await this.rebuildCache();
+    }
+
+    /** Full rebuild — called on startup and after any membership change. */
+    private async rebuildCache(): Promise<void> {
+        const members = await this.memberRepo.find();
+        const groupIds = Array.from(new Set(members.map(m => m.groupId)));
+        const groups = groupIds.length > 0
+            ? await this.groupRepo.find({ where: groupIds.map(id => ({ id, dissolvedAt: IsNull() })) })
+            : [];
+        const activeById = new Map(groups.map(g => [g.id, g.active]));
+
+        const next = new Map<string, GroupCacheEntry>();
+        for (const m of members) {
+            const active = activeById.get(m.groupId);
+            if (active === undefined) continue; // group dissolved — skip
+            next.set(m.address, { groupId: m.groupId, active });
+        }
+        this.addressCache = next;
+    }
+
+    // ── Token helpers ─────────────────────────────────────────────
+
+    private generateToken(): string {
+        return 'GRP-' + crypto.randomBytes(24).toString('base64url');
+    }
+
+    private hashToken(token: string): string {
+        return crypto.createHash('sha256').update(token).digest('hex');
+    }
+
+    private verifyToken(providedToken: string, storedHash: string): boolean {
+        const providedHash = this.hashToken(providedToken);
+        if (providedHash.length !== storedHash.length) return false;
+        return crypto.timingSafeEqual(Buffer.from(providedHash), Buffer.from(storedHash));
+    }
+
+    async requireAdminToken(groupId: string, token: string | undefined): Promise<PplnsGroupEntity> {
+        if (!token) {
+            throw new GroupServiceError('missing-token', 'Admin token required');
+        }
+        const group = await this.groupRepo.findOneBy({ id: groupId });
+        if (!group || group.dissolvedAt) {
+            throw new GroupServiceError('not-found', 'Group not found');
+        }
+        if (!this.verifyToken(token, group.adminTokenHash)) {
+            throw new GroupServiceError('invalid-token', 'Invalid admin token');
+        }
+        return group;
+    }
+
+    // ── Lookup ────────────────────────────────────────────────────
+
+    getGroupForAddress(address: string): GroupCacheEntry | undefined {
+        return this.addressCache.get(address);
+    }
+
+    async getGroup(groupId: string): Promise<PplnsGroupEntity | null> {
+        return this.groupRepo.findOneBy({ id: groupId });
+    }
+
+    async listGroups(): Promise<PplnsGroupEntity[]> {
+        return this.groupRepo.find({ where: { dissolvedAt: IsNull() } });
+    }
+
+    async listMembers(groupId: string): Promise<PplnsGroupMemberEntity[]> {
+        return this.memberRepo.find({ where: { groupId }, order: { joinedAt: 'ASC' } });
+    }
+
+    // ── Lifecycle ─────────────────────────────────────────────────
+
+    async createGroup(name: string, creatorAddress: string): Promise<GroupCreateResult> {
+        const trimmedName = name?.trim();
+        if (!trimmedName || trimmedName.length < 3 || trimmedName.length > 64) {
+            throw new GroupServiceError('invalid-name', 'Group name must be 3–64 characters');
+        }
+        if (!creatorAddress) {
+            throw new GroupServiceError('invalid-address', 'Creator address required');
+        }
+
+        const existingByName = await this.groupRepo.findOneBy({ name: trimmedName });
+        if (existingByName && !existingByName.dissolvedAt) {
+            throw new GroupServiceError('name-taken', 'Group name already in use');
+        }
+
+        const existingMember = await this.memberRepo.findOneBy({ address: creatorAddress });
+        if (existingMember) {
+            throw new GroupServiceError('address-in-group', 'Address is already a member of another group');
+        }
+
+        const adminToken = this.generateToken();
+        const group = await this.groupRepo.save(this.groupRepo.create({
+            name: trimmedName,
+            creatorAddress,
+            adminTokenHash: this.hashToken(adminToken),
+            active: false,
+        }));
+
+        await this.memberRepo.save(this.memberRepo.create({
+            groupId: group.id,
+            address: creatorAddress,
+            role: 'creator',
+        }));
+
+        await this.rebuildCache();
+
+        return { group, adminToken };
+    }
+
+    async addMember(groupId: string, address: string, token: string | undefined): Promise<PplnsGroupMemberEntity> {
+        await this.requireAdminToken(groupId, token);
+        if (!address) {
+            throw new GroupServiceError('invalid-address', 'Address required');
+        }
+
+        const existing = await this.memberRepo.findOneBy({ address });
+        if (existing) {
+            if (existing.groupId === groupId) {
+                throw new GroupServiceError('already-member', 'Address is already in this group');
+            }
+            throw new GroupServiceError('address-in-group', 'Address is already a member of another group');
+        }
+
+        const member = await this.memberRepo.save(this.memberRepo.create({
+            groupId,
+            address,
+            role: 'member',
+        }));
+
+        await this.recomputeActive(groupId);
+        await this.rebuildCache();
+        return member;
+    }
+
+    async removeMember(groupId: string, address: string, token: string | undefined): Promise<void> {
+        await this.requireAdminToken(groupId, token);
+        await this.internalRemove(groupId, address, /*fromCreator*/ true);
+    }
+
+    async selfLeave(groupId: string, address: string): Promise<void> {
+        const member = await this.memberRepo.findOneBy({ groupId, address });
+        if (!member) {
+            throw new GroupServiceError('not-member', 'Address is not a member of this group');
+        }
+        if (member.role === 'creator') {
+            throw new GroupServiceError('creator-cannot-self-leave', 'Creator must transfer role or dissolve the group before leaving');
+        }
+        await this.internalRemove(groupId, address, /*fromCreator*/ false);
+    }
+
+    private async internalRemove(groupId: string, address: string, fromCreator: boolean): Promise<void> {
+        const member = await this.memberRepo.findOneBy({ groupId, address });
+        if (!member) {
+            throw new GroupServiceError('not-member', 'Address is not a member of this group');
+        }
+
+        if (member.role === 'creator') {
+            // Creator removal: auto-transfer to oldest remaining member, or dissolve if none.
+            const remaining = await this.memberRepo.find({
+                where: { groupId },
+                order: { joinedAt: 'ASC' },
+            });
+            const others = remaining.filter(m => m.address !== address);
+            if (others.length === 0) {
+                await this.dissolveInternal(groupId);
+                return;
+            }
+            const newCreator = others[0];
+            newCreator.role = 'creator';
+            await this.memberRepo.save(newCreator);
+            // Rotate admin token so old one can't be used anymore.
+            const newToken = this.generateToken();
+            const group = await this.groupRepo.findOneBy({ id: groupId });
+            if (group) {
+                group.adminTokenHash = this.hashToken(newToken);
+                group.creatorAddress = newCreator.address;
+                await this.groupRepo.save(group);
+            }
+            // NOTE: The new admin token can't be returned from this path since it's
+            // triggered by a creator-leave. The new creator must call /recover if
+            // they don't have the token. (Recovery not implemented in MVP.)
+        }
+
+        await this.memberRepo.delete({ groupId, address });
+        await this.recomputeActive(groupId);
+        await this.rebuildCache();
+    }
+
+    /**
+     * Explicit creator handoff with a freshly-issued admin token.
+     * The current creator calls this; the new admin token is returned (once).
+     */
+    async transferCreator(
+        groupId: string,
+        toAddress: string,
+        token: string | undefined,
+    ): Promise<{ group: PplnsGroupEntity; adminToken: string }> {
+        const group = await this.requireAdminToken(groupId, token);
+        const newCreator = await this.memberRepo.findOneBy({ groupId, address: toAddress });
+        if (!newCreator) {
+            throw new GroupServiceError('not-member', 'Target address is not a member of this group');
+        }
+        if (newCreator.role === 'creator') {
+            throw new GroupServiceError('already-creator', 'Target is already the creator');
+        }
+
+        const oldCreator = await this.memberRepo.findOne({ where: { groupId, role: 'creator' } });
+        if (oldCreator) {
+            oldCreator.role = 'member';
+            await this.memberRepo.save(oldCreator);
+        }
+        newCreator.role = 'creator';
+        await this.memberRepo.save(newCreator);
+
+        const newToken = this.generateToken();
+        group.adminTokenHash = this.hashToken(newToken);
+        group.creatorAddress = toAddress;
+        const saved = await this.groupRepo.save(group);
+
+        await this.rebuildCache();
+        return { group: saved, adminToken: newToken };
+    }
+
+    async dissolveGroup(groupId: string, token: string | undefined): Promise<void> {
+        await this.requireAdminToken(groupId, token);
+        await this.dissolveInternal(groupId);
+    }
+
+    private async dissolveInternal(groupId: string): Promise<void> {
+        await this.memberRepo.delete({ groupId });
+        const group = await this.groupRepo.findOneBy({ id: groupId });
+        if (group) {
+            group.active = false;
+            group.dissolvedAt = new Date();
+            await this.groupRepo.save(group);
+        }
+        await this.rebuildCache();
+    }
+
+    private async recomputeActive(groupId: string): Promise<void> {
+        const count = await this.memberRepo.count({ where: { groupId } });
+        const group = await this.groupRepo.findOneBy({ id: groupId });
+        if (!group || group.dissolvedAt) return;
+        const shouldBeActive = count >= MIN_MEMBERS_ACTIVE;
+        if (group.active !== shouldBeActive) {
+            group.active = shouldBeActive;
+            await this.groupRepo.save(group);
+        }
+    }
+}

--- a/src/services/protocol-detector.service.ts
+++ b/src/services/protocol-detector.service.ts
@@ -148,6 +148,10 @@ export class ProtocolDetectorService implements OnModuleInit {
         console.log(`[ProtocolDetector] PPLNS port configured: ${pplnsPort}`);
       }
     }
+
+    // Group-solo mining is not port-bound — membership is looked up per-address.
+    // Any miner whose address is in an active group is automatically routed into
+    // group-solo payout on whatever port they connect to (typically the solo port).
   }
 
   private startUnifiedServer(portConfig: StratumPortConfig): void {

--- a/src/services/stratum-v1.service.spec.ts
+++ b/src/services/stratum-v1.service.spec.ts
@@ -38,6 +38,7 @@ describe('StratumV1Service.onModuleInit', () => {
       {} as unknown as ShareTotalsCacheService,
       { store: {} } as any,
       { isEnabled: () => false } as any,
+      { isEnabled: () => false, getGroupForAddress: () => undefined } as any,
     );
   }
 

--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -22,6 +22,7 @@ import { ShareTotalsCacheService } from './share-totals-cache.service';
 import { AddressSettingsCacheService } from './address-settings-cache.service';
 import { DifficultyScoresCacheService } from './difficulty-scores-cache.service';
 import { PplnsService } from './pplns.service';
+import { GroupSoloService } from './group-solo.service';
 
 @Injectable()
 export class StratumV1Service implements OnModuleInit {
@@ -47,6 +48,7 @@ export class StratumV1Service implements OnModuleInit {
     private readonly shareTotalsCacheService: ShareTotalsCacheService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     private readonly pplnsService: PplnsService,
+    private readonly groupSoloService: GroupSoloService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -108,6 +110,7 @@ export class StratumV1Service implements OnModuleInit {
       this.redisClient,
       portConfig.payoutMode ?? 'solo',
       this.pplnsService,
+      this.groupSoloService,
     );
 
     socket.on('close', async (hadError: boolean) => {

--- a/src/services/stratum-v2.service.spec.ts
+++ b/src/services/stratum-v2.service.spec.ts
@@ -65,6 +65,7 @@ function createService(envOverrides: Record<string, string> = {}) {
     {} as any, // templateDistributionService
     {} as any, // jobDeclarationService
     { isEnabled: () => false } as any, // pplnsService
+    { isEnabled: () => false, getGroupForAddress: () => undefined } as any, // groupSoloService
   );
 
   return { service, configService, clientService, addressSettingsCacheService, difficultyScoresCacheService };
@@ -298,6 +299,7 @@ describe('StratumV2Service', () => {
         expect.anything(), // extranonceManager
         expect.anything(), // templateDistributionService
         expect.anything(), // pplnsService
+        expect.anything(), // groupSoloService
       );
     });
   });

--- a/src/services/stratum-v2.service.ts
+++ b/src/services/stratum-v2.service.ts
@@ -34,6 +34,7 @@ import { ExternalSharesService } from './external-shares.service';
 import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-statistics/client-difficulty-statistics.service';
 import { ShareTotalsCacheService } from './share-totals-cache.service';
 import { PplnsService } from './pplns.service';
+import { GroupSoloService } from './group-solo.service';
 import { DifficultyScoresCacheService } from './difficulty-scores-cache.service';
 
 interface GroupChannel {
@@ -83,6 +84,7 @@ export class StratumV2Service implements OnModuleInit, IProtocolHandler {
     @Inject(forwardRef(() => JobDeclarationService))
     private readonly jobDeclarationService: JobDeclarationService,
     private readonly pplnsService: PplnsService,
+    private readonly groupSoloService: GroupSoloService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -184,6 +186,7 @@ export class StratumV2Service implements OnModuleInit, IProtocolHandler {
       this.extranonceManager,
       this.templateDistributionService,
       this.pplnsService,
+      this.groupSoloService,
     );
 
     // Client self-registers when channel is opened and self-unregisters on close.

--- a/typeorm-cli.config.ts
+++ b/typeorm-cli.config.ts
@@ -22,6 +22,10 @@ import { RpcBlockEntity } from './src/ORM/rpc-block/rpc-block.entity';
 import { TelegramSubscriptionsEntity } from './src/ORM/telegram-subscriptions/telegram-subscriptions.entity';
 import { PplnsBalanceEntity } from './src/ORM/pplns-balance/pplns-balance.entity';
 import { PplnsPayoutHistoryEntity } from './src/ORM/pplns-balance/pplns-payout-history.entity';
+import { PplnsGroupEntity } from './src/ORM/pplns-group/pplns-group.entity';
+import { PplnsGroupMemberEntity } from './src/ORM/pplns-group/pplns-group-member.entity';
+import { PplnsGroupBlockHistoryEntity } from './src/ORM/pplns-group/pplns-group-block-history.entity';
+import { PplnsGroupBalanceEntity } from './src/ORM/pplns-group/pplns-group-balance.entity';
 
 loadEnv({ path: process.env.TYPEORM_ENV_PATH ?? '.env' });
 
@@ -46,6 +50,10 @@ const entities = [
     TelegramSubscriptionsEntity,
     PplnsBalanceEntity,
     PplnsPayoutHistoryEntity,
+    PplnsGroupEntity,
+    PplnsGroupMemberEntity,
+    PplnsGroupBlockHistoryEntity,
+    PplnsGroupBalanceEntity,
 ];
 
 const { autoLoadEntities, ...rest } = moduleOptions as DataSourceOptions & { autoLoadEntities?: boolean };


### PR DESCRIPTION
> ⚠️ Stacked on top of #118 (\`feature/pplns-pool-support\`). Merge that one first — GitHub will then auto-update this PR's base to \`blitzpool-master\`.

## Summary

A new mining mode where friends can mine together on the pool and split rewards among the group's members. PROP-style payout (window resets on each found block). Built on the existing PPLNS engine and coinbase-construction mechanics.

**Address-driven, not port-driven.** Any miner whose address is in an active group is automatically routed into group-solo payout on whatever port they connect to. No new stratum port, no miner config changes.

## How it works

1. **Admin creates a group** via \`POST /api/pplns/groups\`, gets a one-time admin token.
2. **Admin adds member BTC addresses** via \`POST /api/pplns/groups/:id/members\` with the admin token. Members never need to authenticate — trust model is: admin adds addresses, miners just point their hardware at the pool as usual.
3. **Members mine with their own addresses** — they're automatically routed into the group's Redis bucket. When the group finds a block, the coinbase contains one output per member (plus the pool fee output), sized proportionally to each member's shares in the current round.
4. **PROP semantics:** Round resets on block found. Late-arriving shares (after the winning job's snapshot was built) are logged as audit rows but not credited — the coinbase is immutable and crediting would double-count. Sub-dust / weight-trimmed miners still accumulate to pending and get paid when they cross dust in a future round.

## Components

**Data model** (new): \`pplns_group\`, \`pplns_group_member\`, \`pplns_group_block_history\`, \`pplns_group_balance\`.

**Services:**
- \`GroupService\` — CRUD, admin-token auth (SHA-256 hashed, shown to creator exactly once on create), address→group cache for fast lookup in the stratum hot path, min-2-member activation, creator auto-transfer on leave.
- \`GroupSoloService\` — PROP engine with snapshot-based bookkeeping (coinbase matches on-chain reality byte-for-byte), handles sub-dust vs late-arriver distinction to prevent double-counting.

**Stratum integration** — V1 + V2 clients detect group membership at authorize / channel-open and switch the session into group-solo payout. Group-solo takes precedence over the port's configured \`payoutMode\` (so group members always get group treatment).

**REST API**
- \`POST /api/pplns/groups\` — create group (returns adminToken once)
- \`GET /api/pplns/groups\` — list active groups
- \`GET /api/pplns/groups/:id\` — details + per-member hashrate + totalHashrate
- \`GET /api/pplns/groups/:id/hashrate\` — compact hashrate-only endpoint (for dashboard polling)
- \`GET /api/pplns/groups/:id/distribution\` — current round shares per address
- \`GET /api/pplns/groups/:id/history?limit=N\` — block-found audit trail
- \`POST /api/pplns/groups/:id/members\` — add member (admin token)
- \`DELETE /api/pplns/groups/:id/members/:address\` — kick (admin token)
- \`DELETE /api/pplns/groups/:id/members/:address/self\` — non-creator self-leave (no auth)
- \`POST /api/pplns/groups/:id/transfer\` — rotate creator role + admin token
- \`DELETE /api/pplns/groups/:id\` — dissolve

## Tests (25 new)

- \`group.service.spec.ts\` (16) — CRUD, token verify/rotate, min-size activation, auto-transfer, cache invalidation, address-exclusivity
- \`group-solo.service.spec.ts\` (9) — share routing, PROP distribution, round reset, sub-dust pending, multi-round pending accumulation, **late-arriver-not-double-credited** (locks in the PROP double-counting fix discovered during live testing with two Bitaxes)
- \`group-solo-regtest.spec.ts\` (1) — end-to-end regtest integration: records shares, builds a real coinbase from the service's distribution, submits the block to Bitcoin Core, verifies round reset and that non-members are excluded from the coinbase

## Live validation

Tested with two real Bitaxe devices against a regtest node over 104 blocks. All blocks accepted by Bitcoin Core 29.0. Found and fixed one real bug in the process (late-arriving share double-counting — now covered by a unit test).

## Test plan
- [x] Full Jest suite green (504 tests, 58 suites)
- [x] Build clean, no TypeScript errors
- [x] Live-tested with 2 Bitaxes on SV1: 104 blocks, all accepted by bitcoind
- [x] Unit test locks in PROP late-arriver behavior to prevent regression