### PR TITLE
Add GET /pplns/mode/:address for UI mode detection

### DIFF
--- a/src/controllers/pplns/pplns.controller.spec.ts
+++ b/src/controllers/pplns/pplns.controller.spec.ts
@@ -1,0 +1,71 @@
+jest.mock('node-telegram-bot-api', () => jest.fn());
+
+import { PplnsController } from './pplns.controller';
+
+describe('PplnsController.getMiningMode', () => {
+
+    function setup(opts: {
+        distribution?: { address: string; difficulty: number; percent: number }[];
+        groupForAddress?: Record<string, { groupId: string; active: boolean } | undefined>;
+    }) {
+        const pplnsService = {
+            getCurrentDistribution: jest.fn().mockResolvedValue(opts.distribution ?? []),
+        };
+        const groupService = {
+            getGroupForAddress: jest.fn((address: string) => opts.groupForAddress?.[address]),
+        };
+        const controller = new PplnsController(pplnsService as any, groupService as any);
+        return { controller, pplnsService, groupService };
+    }
+
+    it('returns group-solo when the address is in an active group', async () => {
+        const { controller } = setup({
+            groupForAddress: {
+                'bc1qalice': { groupId: 'grp-1', active: true },
+            },
+        });
+        const res = await controller.getMiningMode('bc1qalice');
+        expect(res).toEqual({ mode: 'group-solo', groupId: 'grp-1' });
+    });
+
+    it('ignores inactive group membership and falls through to pplns/solo', async () => {
+        // Group exists but hasn't reached min 2 members yet → inactive.
+        // The address isn't routed to group-solo until activation.
+        const { controller } = setup({
+            groupForAddress: {
+                'bc1qalice': { groupId: 'grp-1', active: false },
+            },
+            distribution: [
+                { address: 'bc1qalice', difficulty: 100, percent: 100 },
+            ],
+        });
+        const res = await controller.getMiningMode('bc1qalice');
+        expect(res).toEqual({ mode: 'pplns' });
+    });
+
+    it('returns pplns when the address has shares in the window but no group', async () => {
+        const { controller } = setup({
+            distribution: [
+                { address: 'bc1qbob', difficulty: 200, percent: 100 },
+            ],
+        });
+        const res = await controller.getMiningMode('bc1qbob');
+        expect(res).toEqual({ mode: 'pplns' });
+    });
+
+    it('returns solo when the address has no group and no PPLNS window shares', async () => {
+        const { controller } = setup({
+            distribution: [
+                { address: 'bc1qother', difficulty: 100, percent: 100 },
+            ],
+        });
+        const res = await controller.getMiningMode('bc1qcharlie');
+        expect(res).toEqual({ mode: 'solo' });
+    });
+
+    it('returns solo when no groups exist and no PPLNS activity at all', async () => {
+        const { controller } = setup({});
+        const res = await controller.getMiningMode('bc1qnew');
+        expect(res).toEqual({ mode: 'solo' });
+    });
+});

--- a/src/controllers/pplns/pplns.controller.ts
+++ b/src/controllers/pplns/pplns.controller.ts
@@ -1,10 +1,37 @@
 import { Controller, Get, Param, Query } from '@nestjs/common';
 import { PplnsService } from '../../services/pplns.service';
+import { GroupService } from '../../services/group.service';
 
 @Controller('pplns')
 export class PplnsController {
 
-    constructor(private readonly pplnsService: PplnsService) {}
+    constructor(
+        private readonly pplnsService: PplnsService,
+        private readonly groupService: GroupService,
+    ) {}
+
+    /**
+     * GET /pplns/mode/:address
+     * Returns the mining mode the given BTC address is currently operating in.
+     *   - 'group-solo' if the address is in an active group
+     *   - 'pplns' otherwise, if the address has shares in the PPLNS window
+     *   - 'solo' otherwise
+     * The UI uses this for mode-aware dashboard rendering (hiding solo-only
+     * widgets, showing PPLNS/group panels).
+     */
+    @Get('mode/:address')
+    async getMiningMode(@Param('address') address: string) {
+        const group = this.groupService.getGroupForAddress(address);
+        if (group && group.active) {
+            return { mode: 'group-solo', groupId: group.groupId };
+        }
+        const distribution = await this.pplnsService.getCurrentDistribution();
+        const inPplns = distribution.some(d => d.address === address);
+        if (inPplns) {
+            return { mode: 'pplns' };
+        }
+        return { mode: 'solo' };
+    }
 
     /**
      * GET /pplns/status


### PR DESCRIPTION
> ⚠️ Stacks on top of #119 (\`feature/group-solo-mining\`). Merge #118 then #119 first; GitHub will auto-update this PR's base to \`blitzpool-master\`.

## Summary

Adds a single endpoint the UI uses to learn what mining mode a given address is currently operating in:

\`\`\`
GET /api/pplns/mode/:address
→ { "mode": "solo" | "pplns" | "group-solo", "groupId"?: "uuid" }
\`\`\`

Resolution logic (in this order):
1. If the address is a member of an active group → \`group-solo\` (includes \`groupId\`)
2. If the address has shares in the PPLNS window → \`pplns\`
3. Otherwise → \`solo\`

The UI (separate repo, separate PR) uses this to:
- Hide solo-only menu items (Block Reward, Block Hit Calc) in non-solo modes
- Hide the Block Luck widget (individual-hashrate-to-block-probability doesn't apply when a pool finds blocks)
- Later: auto-redirect group-solo users to their group's dashboard

Backend-side this is a thin wrapper — \`GroupService.getGroupForAddress\` + \`PplnsService.getCurrentDistribution\`, both already exist and are cached.

## Tests

5 unit tests (\`pplns.controller.spec.ts\`) cover all mode transitions and the inactive-group edge case (a group with only 1 member doesn't yet route as \`group-solo\` — falls through to PPLNS/solo).

## Test plan
- [x] Full Jest suite green (505 tests, 59 suites)
- [x] Build clean