### PR TITLE
Add GET /pplns/groups/:id/chart (group hashrate time-series)

### DIFF
--- a/docs/security-review-payout-groups.md
+++ b/docs/security-review-payout-groups.md
@@ -1,0 +1,380 @@
+# Security & Code Review — Blitzpool Payout Group Feature
+
+*Date: 2026-04-22*
+*Scope: feature/group-chart-endpoint (pool backend) + feature/payout-group-ui (Angular UI)*
+*Reviewer: independent audit (claims verified against source)*
+
+## Executive Summary
+
+Der email-basierte Invitation-Flow ist konzeptionell gut gedacht (Verified-Email als Trust-Anchor, Token nicht in create/banner-Response, HTML-Escaping korrekt, 256-bit Token-Entropie, SHA-256 + `timingSafeEqual` für Admin-Token). **Aber es gibt zwei Show-Stopper, die das "silent-add"-Versprechen ins Wanken bringen**, plus einen Money-Math-Bug in der Balance-Row-Verwaltung.
+
+Gesamt-Risikobewertung: **nicht produktionsreif** in aktuellem Zustand. Drei `CRITICAL`-Findings verhindern Mainnet-Release. Einige davon sind Einzeiler zum Fixen, aber sie sind die Art "wenn wir übersehen hätten, würde es uns später richtig wehtun".
+
+---
+
+## 1. Critical Findings
+
+### C1 — `selfLeave` ist vollständig unauthentifiziert → Kick-Bob-by-Address DoS
+
+**File:** `src/controllers/pplns-group/pplns-group.controller.ts:400-408`
+
+```ts
+@Delete(':id/members/:address/self')
+async selfLeave(@Param('id') id: string, @Param('address') address: string) {
+    try {
+        await this.groupService.selfLeave(id, address);
+        return { removed: true };
+    } catch (e) {
+        throw this.toHttpError(e);
+    }
+}
+```
+
+Kein `@Headers('x-admin-token')`, keine Session, keine Signatur-Verifikation, **keine Prüfung dass der Caller die Adresse tatsächlich besitzt**. Jeder der Bob's BTC-Adresse kennt (= öffentlich bekannt sobald Bob irgendeine Zahlung erhalten hat), kann:
+
+```
+curl -X DELETE https://pool/api/pplns/groups/<gid>/members/bc1qbob.../self
+```
+
+Bob fliegt aus der Gruppe. `selfLeave` in `group.service.ts:258-267` blockt zwar das Löschen des Creators (`creator-cannot-self-leave`), aber **jedes normale Member** ist fair game. Bob muss das Problem bemerken, Admin kontaktieren, erneut eingeladen werden. Mallory kann das alle paar Minuten wiederholen.
+
+**Impact:** Dauerhafter Denial-of-Payout auf einzelne Adressen; Kriegsführung zwischen konkurrierenden Gruppen.
+
+**Reproducer:**
+1. Bob ist Member in Gruppe G
+2. Mallory liest Bob's Mining-Adresse aus der Public-Member-Liste (`GET /pplns/groups/:id`)
+3. `DELETE /pplns/groups/<gid>/members/bc1qbob/self` — keine Auth-Header
+4. Bob ist raus, Shares routen wieder Solo/PPLNS
+
+**Fix direction:** Caller muss Ownership der Adresse beweisen. Optionen: (a) BIP-137-Signatur im Body (`signmessage` mit Adressen-Privkey), Backend verifiziert gegen Adresse; (b) Bob als Miner hat eh eine authentifizierte Stratum-Session — falls es einen Signed-Action-Mechanismus gibt, den nutzen; (c) vorerst einfach den Endpoint **entfernen** und Leaves nur über Admin-Kick zulassen, bis das Auth-Modell steht. Option (c) ist der pragmatischste Sofort-Fix.
+
+---
+
+### C2 — Admin sieht Invitation-Token im Klartext → silent-add ist umgangen
+
+**File:** `src/controllers/pplns-group/pplns-group.controller.ts:346-365`
+
+```ts
+@Get(':id/invitations')
+async listInvitations(@Param('id') id: string, @Headers('x-admin-token') token?: string) {
+    await this.groupService.requireAdminToken(id, token);
+    const rows = await this.invitationService.listPendingForGroup(id);
+    return rows.map(r => ({
+        token: r.token,             // ← plaintext token
+        address: r.address,
+        email: maskEmail(r.email),
+        ...
+    }));
+}
+```
+
+Parallel dazu: `POST :id/invitations` (Zeile 280-292) gibt den Token **nicht** zurück — das ist korrekt, der Admin braucht ihn nicht. **Aber 50 Zeilen weiter unten gibt das Admin-Listing-Endpoint ihn doch aus.** Das vernichtet den gesamten "email ist Trust-Anchor"-Schutz:
+
+**Angriff:**
+1. Mallory ist Admin von Gruppe M (sie hat sie selbst angelegt, hat `x-admin-token`)
+2. Victim Alice hat eine verifizierte Email (normaler Flow)
+3. Mallory: `POST /pplns/groups/M/invitations` mit `{ address: "bc1qalice..." }` → backend schickt Einladungsmail an Alice
+4. Mallory: `GET /pplns/groups/M/invitations` mit ihrem Admin-Token → Response enthält `token: "abc..."` im Klartext
+5. Mallory: `POST /pplns/invitations/abc.../accept` (public endpoint, keine Auth) → **Alice ist jetzt Mitglied, ohne die Mail je gesehen zu haben**
+6. Alice's Block-Fund-Payouts routen nach Gruppe M
+
+Der Email-Trust-Anchor funktioniert nur, wenn der Token NIEMALS außer im Email-Body auftaucht. Das Listing verrät ihn an genau die Partei, der wir nicht vertrauen dürfen — den eigenen Admin.
+
+**Fix direction:** Token aus dem Response entfernen. Der Admin braucht für Cancel eh nur `{ address, createdAt, expiresAt }` — die Cancel-API müsste dann nicht per Token, sondern per `(groupId, address)` oder einer separaten internen `invitationId` arbeiten:
+
+```ts
+@Delete(':id/invitations/by-address/:address')   // state-identifying, not credential
+async cancelInvitation(...)
+```
+
+Oder: Server hält einen zweiten, server-seitigen `shortId` für Admin-Referenzen, während der eigentliche `token` nie das Backend verlässt außer im Email-Body.
+
+---
+
+### C3 — `addPending` updated `groupId` nie → stale Balance-Zeile zieht Geld in frühere Gruppe
+
+**File:** `src/services/group-solo.service.ts:440-450`
+
+```ts
+private async addPending(groupId: string, address: string, sats: number): Promise<void> {
+    const existing = await this.balanceRepo.findOneBy({ address });   // no groupId filter
+    if (existing) {
+        existing.pendingSats += sats;          // ← groupId stays on whatever it was
+        await this.balanceRepo.save(existing);
+    } else {
+        await this.balanceRepo.save(this.balanceRepo.create({
+            address, groupId, pendingSats: sats, totalPaidSats: 0,
+        }));
+    }
+}
+```
+
+Kombiniert mit `src/services/group.service.ts:347-356` (`dissolveInternal`) und `:269-305` (`internalRemove`): **Balance-Zeilen werden nie gelöscht**, weder bei Member-Leave, noch bei Dissolve. Die globale Unique-Constraint auf `pplns_group_member.address` (migration Z.30, entity Z.15) garantiert zwar dass eine Adresse zu jedem Zeitpunkt in höchstens einer Gruppe ist — aber sobald eine Adresse zwischen Gruppen wechselt, bleibt die alte Balance-Zeile mit dem alten `groupId` stehen.
+
+**Szenario:**
+1. Bob ist in Gruppe A, bekommt sub-dust Payout aus Block 1 → Zeile `{address=Bob, groupId=A, pendingSats=300}`
+2. Bob verlässt A (selfLeave oder Admin-Kick), Member-Zeile weg, **Balance-Zeile bleibt mit groupId=A**
+3. Bob wird in Gruppe B eingeladen und akzeptiert
+4. Gruppe B findet Block 2, Bob bekommt 500 sats sub-dust → `addPending(groupId=B, address=Bob, sats=500)`
+5. Der `existing`-Pfad feuert, `pendingSats` wird 800, **`groupId` bleibt `A`**
+6. Gruppe A findet irgendwann Block 3 (andere Mitglieder zahlen ein). `getPayoutDistribution(A)` Zeile 177: `this.balanceRepo.find({ where: { groupId: 'A' } })` → findet Bob's Zeile mit 800 sats. Zeile 193-201: Bob landet als "pending-only entry" in A's Coinbase. **Gruppe A zahlt 800 sats aus ihrem Block an einen Nicht-Member, davon 500 sats ursprünglich Gruppe B's Work-Share.**
+
+Spiegelbildlich in `onBlockFound` Zeile 289: `const existing = await this.balanceRepo.findOneBy({ address: d.address })` — wieder address-only. Wenn Gruppe B's Block Bob's Pending abrechnet, holt er sich die gesamte Zeile inkl. A's historischer Anteil und verbucht sie auf `totalPaidSats`. Money-Attribution bricht über Gruppenwechsel hinweg.
+
+**Impact:** Money-Math-Bug mit stillem Geldtransfer zwischen Gruppen. Nicht durch Angreifer direkt auslösbar, aber bei jedem Gruppenwechsel einer Adresse, die vorher mal sub-dust/trimmed war, **wird echtes Geld fehlallokiert**.
+
+**Reproducer:** siehe Szenario oben — reine PROP-Logik, keine Angreifer-Interaktion nötig.
+
+**Fix direction:** (a) Lookup immer mit `{ address, groupId }`; (b) Composite-PK `(address, groupId)` auf der Balance-Entity (Schema-Fix + Migration); (c) beim Member-Leave die Balance-Zeile entweder auszahlen oder löschen oder im History-Log abschließen, NICHT stehenlassen.
+
+Minimal-Invasiv:
+```ts
+// group-solo.service.ts:441
+const existing = await this.balanceRepo.findOneBy({ address, groupId });
+// und :289
+const existing = await this.balanceRepo.findOneBy({ address: d.address, groupId });
+```
+Dann sind getrennte Zeilen pro `(address, groupId)` möglich, aber die Entity-PK verbietet das aktuell. Daher muss Schema mit.
+
+---
+
+### C4 — Email-Subject-Injection via Gruppenname
+
+**File:** `src/services/email.service.ts:88` und `src/services/email.service.ts:238`
+
+```ts
+const subject = `Invitation to join ${ctx.groupName} — Blitz Pool`;
+// ...
+return shellHtml(`Invitation to join ${ctx.groupName}`, body);
+```
+
+Und die Gruppennamen-Validierung in `src/services/group.service.ts:121-124` prüft **ausschließlich Länge** (3–64 Zeichen), nicht ob Newlines/CR/NUL enthalten sind:
+
+```ts
+const trimmedName = name?.trim();
+if (!trimmedName || trimmedName.length < 3 || trimmedName.length > 64) {
+    throw new GroupServiceError('invalid-name', 'Group name must be 3–64 characters');
+}
+```
+
+`trim()` entfernt nur führende/trailing Whitespace, keine inneren `\r\n`. Nodemailer escaped zwar einiges beim Setzen von Headern, aber in der Praxis ist jedes Feld mit direkter Interpolation in `subject` ein Kandidat für Header-Splitting je nach Nodemailer-Version. Selbst wenn Nodemailer strippt: der HTML- und Text-Body (Z. 206-239, Z. 242-252) nutzt `escapeHtml(ctx.groupName)` im HTML — **aber der Text-Body `src/services/email.service.ts:243` tut das nicht**:
+
+```ts
+`You've been invited to join the payout group "${ctx.groupName}" on Blitz Pool.`,
+```
+
+Ein Gruppenname `Test"\n\nClick here evil.com for a free Bitcoin\n` landet unescaped im Text-Teil der Mail. Das ist kein HTML-XSS, aber ein Phishing-Vektor — und jeder Multipart-Client der Text rendert sieht den eingeschmuggelten Inhalt.
+
+**Fix direction:** In `createGroup` (Z. 120-146 in group.service.ts) ein Whitelist-Regex oder Ablehnen von Kontrollzeichen:
+```ts
+if (/[\r\n\0\t]/.test(trimmedName)) {
+    throw new GroupServiceError('invalid-name', 'Group name must not contain control characters');
+}
+```
+Plus: Subject-Konstruktion härten — `groupName.replace(/[\r\n]/g, ' ')` als Defence-in-Depth direkt am Sendepunkt.
+
+---
+
+## 2. High-Priority Issues
+
+### H1 — `accept()` prüft `group.dissolvedAt` nicht → Ghost-Member in aufgelöster Gruppe
+
+**File:** `src/services/pplns-group-invitation.service.ts:150-194`
+
+`getByToken` (Z. 140-142) prüft `group.dissolvedAt` und gibt `null` zurück wenn dissolved. `accept` (Z. 150-194) macht **nichts davon**: liest nur die Invitation, prüft Status/Expiry/Member-Collision, ruft dann `addMemberWithoutAdmin(invitation.groupId, invitation.address)`. `addMemberWithoutAdmin` (group.service.ts:170-192) prüft ebenfalls nicht ob die Gruppe noch existiert/dissolved ist.
+
+**Ergebnis:** Admin A erstellt Invitation an Alice → dissolved sofort Gruppe M → Alice klickt Link → `member`-Zeile wird in aufgelöster Gruppe angelegt. `rebuildCache` (Z. 53-68) filtert sie beim Cache-Rebuild zwar wieder raus (`if (active === undefined) continue`), aber die DB-Zeile bleibt. Blocke Shares, Balance-Math, UI — alles inkonsistent.
+
+Nicht direkt Money-Loss, aber Zombie-State der irgendwann jemanden Zeit kostet.
+
+**Fix:** In `accept` vor `addMemberWithoutAdmin`:
+```ts
+const group = await this.groupService.getGroup(invitation.groupId);
+if (!group || group.dissolvedAt) {
+    throw new InvitationServiceError('group-dissolved', 'Group no longer exists');
+}
+```
+
+---
+
+### H2 — Keine Redis-Cleanup bei `dissolveGroup` → Share-State lebt ewig
+
+**File:** `src/services/group.service.ts:347-356` (`dissolveInternal`)
+
+```ts
+private async dissolveInternal(groupId: string): Promise<void> {
+    await this.memberRepo.delete({ groupId });
+    const group = await this.groupRepo.findOneBy({ id: groupId });
+    if (group) {
+        group.active = false;
+        group.dissolvedAt = new Date();
+        await this.groupRepo.save(group);
+    }
+    await this.rebuildCache();
+}
+```
+
+Weder `groupsolo:{groupId}:shares` noch `:counter`/`:total`/`:rejected-shares` werden gelöscht. Unter `volatile-lru` haben diese Keys keine TTL (korrekt im Normalbetrieb) — aber nach Dissolve werden sie nie mehr angesprochen, nie evictet, belegen Redis-Memory bis Pool-Restart. Bei vielen Lifecycle-Churn (Gruppen kommen+gehen) akkumuliert das.
+
+Schlimmer im Interaktionseffekt mit C3: Falls Gruppe A dissolved, Bob zu Gruppe B wechselt, und zufällig eine neue Gruppe C später mit **derselben** UUID angelegt wird — das kann nicht passieren (UUID-Kollision = unrealistisch), also ist's nur Memory-Leak. Trotzdem sauber wegräumen.
+
+**Fix:** `resetRound(groupId)` in `dissolveInternal` aufrufen; dafür muss `GroupService` entweder `GroupSoloService` injizieren (Zirkel!) oder `dissolveInternal` Redis direkt triggern via Event/Callback.
+
+---
+
+### H3 — Snapshot-Verlust bei Pool-Restart → Coinbase/Payout-Drift
+
+**File:** `src/services/group-solo.service.ts:62-66, 275-282`
+
+```ts
+private snapshots = new Map<string, {
+    distribution: GroupSoloPayoutEntry[];
+    blockRewardSats: number;
+    consideredAddresses: Set<string>;
+}>();
+```
+
+Snapshot ist **in-Memory**. Wenn der Pool zwischen `getPayoutDistribution(groupId, ...)` (das die Coinbase-Bytes erzeugt, die an den Miner gehen) und `onBlockFound` (das die Payouts bucht) restarted, geht der Snapshot verloren. Fallback in Z. 276-279:
+
+```ts
+if (!snapshot || snapshot.distribution.length === 0) {
+    console.warn(`[GroupSolo] No snapshot for group ${groupId} — using window recalculation fallback`);
+    await this.onBlockFoundFromWindow(groupId, blockHeight, blockRewardSats);
+    return;
+}
+```
+
+`onBlockFoundFromWindow` berechnet die Verteilung aus dem **aktuellen** Redis-Fenster — nicht aus dem Fenster-Zustand, den der Miner in seiner Coinbase manifestiert hat. Wenn zwischen Job-Send und Block-Found Shares dazukamen, weicht die DB-Buchung von dem ab, was on-chain ausgezahlt wurde. Die Coinbase-Bytes sind bereits festgelegt und bergmäßig bestätigt, aber `pplns_group_block_history` und `pplns_group_balance` reflektieren eine andere Welt.
+
+Nicht alltagskritisch (Pool-Restart zwischen Job und Block ist selten + Redis überlebt via AOF), aber bei BFT des Pools ein echter Audit-Gap.
+
+**Fix direction:** Snapshot in Redis persistieren (z.B. `groupsolo:{groupId}:snapshot:{blockHeight}` als JSON mit TTL von 1h — hier ist TTL ausnahmsweise sinnvoll, weil der Key keine Geld-State-Summe trägt sondern eine Kopie einer abschließbaren Auction). Oder: Payout-Distribution im Miner-Job embedden und bei Block-Found zurücklesen.
+
+---
+
+### H4 — Keine Foreign-Key-Constraints → Orphaning nicht DB-verhindert
+
+**File:** `src/migrations/1776000000000-AddPplnsGroup.ts` (alles)
+
+Keine `createForeignKey`-Calls. Weder `pplns_group_member.groupId → pplns_group.id`, noch `pplns_group_balance.groupId`, noch `pplns_group_block_history.groupId`. Dissolve verlässt sich auf App-Code (`memberRepo.delete({ groupId })` in `group.service.ts:348`). Balance- und History-Zeilen werden gar nicht gelöscht (siehe C3/H2).
+
+Bei Transaktions-Rollbacks, App-Crashes mitten im Dissolve, oder zukünftigen Bugs wo der Delete übersehen wird → inkonsistente DB. Bitcoin-Pools laufen gern Jahre ohne Rebuild; Schema-Hardening zahlt sich aus.
+
+**Fix:** Neue Migration mit `FOREIGN KEY ... ON DELETE CASCADE` auf `groupId` der drei Child-Tabellen (und `pplns_group_invitation.groupId`).
+
+---
+
+### H5 — Invitation expiry wird nie gesweept (Code existiert, aber wird nicht gefeuert)
+
+**File:** `src/services/pplns-group-invitation.service.ts:283-289` + `src/services/address-email.service.ts`
+
+`expireOld()` existiert als Methode, wird aber nirgendwo per `@Cron` / `@Interval` / im App-Bootstrap aufgerufen. Status `expired` wird nur dann gesetzt, wenn die Invite beim `accept`-Call läuft (Z. 166-170) oder lazy beim nächsten create für dieselbe address/group (Z. 93-97).
+
+Konsequenzen: (a) Admin-Listing `/invitations` filtert zwar clientseitig auf nicht-expired (Z. 268: `r.expiresAt.getTime() >= now`), also UI zeigt's korrekt; (b) aber die `pplns_group_invitation`-Tabelle wächst endlos, mit Token-Werten im Klartext, deren Löschung irgendwann jemand manuell machen müsste; (c) `expiresAt` hat **kein** DB-Index (aus Migration `1776200000000` + Entity-File), also wird ein zukünftiger Bulk-Cleanup full-scan.
+
+**Fix:** Scheduled job via NestJS `@Interval('1h')` auf `PplnsGroupInvitationService.expireOld()` plus `AddressEmailService.purgeExpiredTokens()`. Plus Index auf `expiresAt` (beide Tabellen).
+
+---
+
+## 3. Medium-Priority Issues
+
+### M1 — Balance-Entity PK ist `address`, nicht `(address, groupId)`
+
+**File:** `src/ORM/pplns-group/pplns-group-balance.entity.ts:6-11`
+
+```ts
+@PrimaryColumn({ type: 'varchar', length: 62 })
+address: string;
+
+@Index()
+@Column({ type: 'uuid' })
+groupId: string;
+```
+
+Dies erzwingt: eine Adresse kann zu jedem Zeitpunkt höchstens **eine** Balance-Zeile haben, unabhängig davon wieviele (vergangene/aktuelle) Group-Memberships sie hat. Das ist die strukturelle Grundlage für C3. Fix ist Teil von C3 (Composite-PK oder explizite Cleanup-Logik beim Member-Wechsel).
+
+### M2 — Decline-DoS ist möglich, aber durch Design akzeptiert
+
+**File:** `src/services/pplns-group-invitation.service.ts:197-214`
+
+Jeder mit dem Token kann declinen (kein `respondedAt`-Check sperrt Re-Accept nach Decline). Kommentar begründet das. Real-world: wenn der Token leakt (Email-Breach des Empfängers, Subpoena-Spear-Phishing), kann Angreifer Invite killen → Re-Invite nötig. Nicht fatal, aber Zubehör. Dokumentieren reicht, solange es eine klare Re-Invite-Procedure gibt.
+
+### M3 — Keine Rate-Limits auf `/invitations` und `/email/register`
+
+Admin mit gültigem Token kann Batch-Invite an beliebige Adressen feuern → SMTP-Provider-Quota-Pain + potenzieller Missbrauch-Vektor wenn Spam-Analyst "Blitz Pool" auf die Blocklist setzt. Fix: NestJS `@Throttle()` auf die POST-Endpoints.
+
+### M4 — Address-Case-Inkonsistenz (Minor in Praxis)
+
+Bech32 (`bc1...`) ist protokoll-spezifiziert lowercase, Miner senden praktisch immer lowercase. Legacy P2PKH/P2SH (`1...`, `3...`) ist case-sensitive Base58. In `group.service.ts:120-137` und Invitation-create (`pplns-group-invitation.service.ts:58-89`) wird die Address ohne Normalisierung übernommen. Wenn ein Admin bewusst `BC1QALICE...` einlädt, würde Mining mit `bc1qalice...` den Cache-Lookup miss'en. Praxis-Risiko gering, aber ein Angreifer könnte im Invitation-Flow eine Adresse mit abweichender Casing hinterlegen und Shares später würden nicht matchen → Payout in unerwünschte Bucket. Ein simples `address = address.toLowerCase()` wenn das Prefix bech32 ist wäre sauber; zumindest bei bech32 Case-insensitive vergleichen.
+
+### M5 — `addMembersBatch` ist noch aktiv und bypassed den Email-Trust-Anchor
+
+**File:** `src/services/group.service.ts:201-251`
+
+Die Memory-Claim war "der alte direct-add wurde entfernt und durch invitations ersetzt". Aber `addMembersBatch` lebt noch in `group.service.ts`. Der Batch-Endpoint ist `/invitations/batch`, nicht `/members/batch` — also der Controller ruft es nicht mehr auf. Trotzdem: die Methode ist **public** auf dem Service. Wenn sie für keinen Use-Case gebraucht wird, **sollte sie weg**. Solange sie da ist, ist jeder zukünftige Code der sie aufruft ein silent-add-Regression.
+
+### M6 — Coinbase-Weight-Budget-Berechnung: `(feeOutputCount + 1)`
+
+**File:** `src/services/group-solo.service.ts:207-211`
+
+```ts
+const feeOutputCount = this.feeAddress ? 1 : 0;
+const maxMinerOutputs = Math.floor(
+    (this.coinbaseWeightBudget - COINBASE_BASE_WEIGHT - (feeOutputCount + 1) * COINBASE_OUTPUT_WEIGHT)
+    / COINBASE_OUTPUT_WEIGHT,
+);
+```
+
+`(feeOutputCount + 1)` reserviert Gewicht für Fee-Output plus vermutlich den Witness-Commitment-Output (OP_RETURN mit commitment hash). Wenn `feeAddress === ''` dann ist `feeOutputCount = 0` und es wird trotzdem `1` Output Gewicht reserviert — korrekt für den Commitment. Wenn aber die tatsächliche Coinbase-Konstruktion zusätzlich noch Outputs hat die hier nicht mitgezählt werden, ist die Reservierung zu klein. Verifikation erfordert cross-check gegen den Coinbase-Builder.
+
+### M7 — Fee-Output wird nicht gegen Dust geprüft
+
+**File:** `src/services/group-solo.service.ts:223-226, 390, 427-435`
+
+Bei kleinen Block-Rewards oder bei sehr kleinem `PPLNS_FEE_PERCENT` auf einem Regtest-Block könnte `feePercent * blockRewardSats / 100 < 546`. Der Fee-Output geht trotzdem in die Coinbase → Block ungültig wegen Dust. Bei Mainnet-Subsidy (3.125 BTC + fees) und 2% Fee nicht akut.
+
+### M8 — `maskEmail` ist dupliziert
+
+**File:** `src/services/pplns-group-invitation.service.ts:310-316` und `src/controllers/pplns-group/pplns-group.controller.ts:489-495`
+
+Identische Implementierung. Klassisches "fix-once, drift-forever"-Muster. In `src/utils/email.utils.ts` ziehen.
+
+---
+
+## 4. Nits
+
+- `pplns_group.adminTokenHash` ist `varchar(255)` (migration Z.14) obwohl SHA-256 immer 64 Hex-Zeichen ist. Cosmetic.
+- `InvitationServiceError` Status-Map (`pplns-group.controller.ts:466-478`) — Code `'inconsistent'` aus `pplns-group-invitation.service.ts:161` ist nicht gemapped → fällt auf Default `BAD_REQUEST`, besser wäre `INTERNAL_SERVER_ERROR` mit logging.
+- `pplns-group-invitation.service.ts:80-82`: Existing pending + not expired → `'invitation-pending'` throw. Aber Z. 93-97 (expired pending cleanup) läuft nur, falls `pending && expired` — **nie erreichbar**, weil Z. 80 bei `expired=false` throwt und bei `expired=true` kein throw, dann fall-through zu Z. 94. Logik korrekt aber um den Kopf zu verdrehen.
+- `group-solo.service.ts:82-85`: `|| DEFAULT_COINBASE_WEIGHT_BUDGET` nach `parseInt` — `parseInt('0')` = 0 → fallback zu default. Intentional?
+- UI: `dashboard.component.ts` hashrateWorker-Kill in payout-group-page via Type-Assertion (`this as unknown as { hashrateWorker: Worker | null }`) — funktioniert, aber bricht bei Basis-Klassen-Rename silent. Basis-Klasse mit `protected skipAutoHashrateWorker = false` aufrüsten wäre robuster.
+
+---
+
+## 5. Positive Beobachtungen
+
+- **HTML-Escaping im HTML-Template ist korrekt** — `escapeHtml` (Z. 255-261) und `escapeAttr` (Z. 263-265) werden an allen user-controlled Interpolations eingesetzt: `groupName`, `address`, `inviterAddress`, `verifyUrl`, `inviteUrl`. XSS im HTML-Body ist robust abgesichert.
+- **Token-Entropie ist stark** — 32 random bytes (256 bit) via `crypto.randomBytes`, base64url-encoded. Keine Brute-Force-Sorge.
+- **Admin-Token-Hashing ist sauber** — SHA-256 (`group.service.ts:76-78`) + `crypto.timingSafeEqual` (Z. 80-84) mit Length-Check davor. Musterhaft.
+- **`POST :id/invitations` gibt Token nicht zurück** — korrekt. Der Admin braucht ihn nicht; nur die Mail.
+- **Banner leakt Token nicht** — `listPendingForAddress` (Z. 228-256) returned bewusst nur `maskedEmail`, und der Kommentar Z. 219-226 erklärt warum.
+- **Live-Lookup der Gruppe pro Share** — `recordShare` (Z. 119-130) und `recordReject` (Z. 138-146) rufen `getGroupForAddress` bei jedem Call, statt auf einen cached groupId zu setzen.
+- **Sub-dust vs. Late-Arriver Distinction** — `onBlockFound` (Z. 312-358) macht den richtigen Split zwischen "war zur Snapshot-Zeit da, aber sub-dust" (→ pending) und "kam nach Snapshot" (→ nur Audit). Die 14 Unit-Tests locken das ein.
+- **Round-Reset räumt alle 4 Redis-Keys** — `resetRound` (Z. 452-458) inkl. `rejectedShares`.
+- **Redis-Share-Keys ohne TTL** — unter `volatile-lru` nicht evictierbar, Geld-State sicher.
+- **AOF `everysec`** — Max ~1s Verlust auf Hard-Crash.
+- **Dashboard-Banner ohne Click-Through** — nach dem Token-Leak-Fix im commit `2c25a7b` macht die UI genau das richtige: Informations-Banner, kein Link.
+- **Invitation-Email-Link geht auf Review-Page, nicht auf direct accept/decline** — Schutz vor unbeabsichtigtem Accept durch Mail-Preview.
+
+---
+
+## Priorisierungs-Empfehlung
+
+1. **Vor Mainnet:** C1 (selfLeave-Auth), C2 (Token aus Admin-Listing), C3 (Balance-Row-Scoping), C4 (Gruppenname-Validierung).
+2. **Kurz danach:** H1 (accept-dissolve-Check), H2 (Redis-Cleanup on dissolve), H5 (Expiry-Cron + Index), H4 (FK-Migration).
+3. **Im ruhigen Sprint:** H3 (Snapshot-Persistenz), M1-M8.
+4. **Docs / Refactor:** Nits.
+
+C1 und C2 sind Einzeiler / wenige Zeilen. C3 ist Schema + 2 Lookups. C4 ist Regex + eine Stripping-Zeile. Alle vier zusammen wären ein Tages-Commit.
+
+Der Rest des Systems ist — und das ist nicht selbstverständlich — sauberer als die vier Critical-Findings vermuten lassen. Die Krypto-Primitive sind richtig gewählt, der Flow denkt mit, die Tests locken das gewünschte Verhalten ein. Die Lücken sind spezifische Stellen, nicht systemische Schwächen.

--- a/full-setup/blitzpool-example.env
+++ b/full-setup/blitzpool-example.env
@@ -233,3 +233,17 @@ AGGREGATION_INTERVAL_CHART_DATA=300000
 
 # Prometheus metrics endpoint is always available at: http://localhost:3334/metrics
 # Health check endpoint is always available at: http://localhost:3334/health
+
+# ── Email (transactional invitations + verification) ──────────────────
+# Required for the invitation-by-email flow. Without these, address-binding
+# and group invitations fail at send-time.
+#SMTP_HOST=mail.example.com
+#SMTP_PORT=587
+# true for direct TLS on 465, false for STARTTLS on 587
+#SMTP_SECURE=false
+#SMTP_USER=noreply@example.com
+#SMTP_PASS=changeme
+# RFC 5322 mailbox; enclose human name in quotes
+#SMTP_FROM=Blitz Pool <noreply@example.com>
+# Public UI base URL — used to build invitation/verification links inside emails
+#POOL_BASE_URL=https://blitzpool.example.com

--- a/full-setup/docker-compose-mainnet-pg.yml
+++ b/full-setup/docker-compose-mainnet-pg.yml
@@ -85,11 +85,22 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    # Persistence: AOF + everysec fsync = max 1s of share writes lost on a
+    # hard crash (well under the durability budget for a payout-bearing pool).
+    # RDB snapshots stay enabled at default cadence as a faster restart path.
+    #
+    # Eviction policy: volatile-lru evicts only keys with an explicit TTL —
+    # i.e. application cache entries (CLIENT_INFO_*, etc., set via REDIS_TTL).
+    # Share/round state (groupsolo:* and pplns:*) is written without a TTL on
+    # purpose, so volatile-lru never touches it. Earlier `allkeys-lru` would
+    # silently evict round shares once Redis hit the maxmemory limit, which
+    # would corrupt PROP-round splits and PPLNS window math.
     command: >
       valkey-server
       --appendonly yes
+      --appendfsync everysec
       --maxmemory ${REDIS_MAX_MEMORY:-1024mb}
-      --maxmemory-policy allkeys-lru
+      --maxmemory-policy volatile-lru
       --io-threads 2
       --io-threads-do-reads yes
       ${REDIS_PASSWORD:+--requirepass ${REDIS_PASSWORD}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blitzpool",
-  "version": "2.0.1",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "blitzpool",
-      "version": "2.0.0",
+      "version": "2.0.4",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
@@ -35,6 +35,7 @@
         "firebase-admin": "^12.7.0",
         "merkle-lib": "^2.0.10",
         "node-telegram-bot-api": "^0.61.0",
+        "nodemailer": "^8.0.5",
         "pg": "^8.11.3",
         "prom-client": "^15.1.0",
         "redis": "^4.6.0",
@@ -58,6 +59,7 @@
         "@types/jest": "29.5.1",
         "@types/node": "^18.16.12",
         "@types/node-telegram-bot-api": "^0.61.6",
+        "@types/nodemailer": "^8.0.0",
         "@types/supertest": "^2.0.11",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
@@ -2890,6 +2892,16 @@
         "@types/node": "*",
         "@types/request": "*",
         "eventemitter3": ">=3.0.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/parse-json": {
@@ -9764,6 +9776,15 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/nodemailer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -15561,6 +15582,15 @@
         "eventemitter3": ">=3.0.0"
       }
     },
+    "@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -20781,6 +20811,11 @@
           }
         }
       }
+    },
+    "nodemailer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w=="
     },
     "nopt": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/core": "^9.0.0",
         "@nestjs/platform-fastify": "^9.4.2",
         "@nestjs/schedule": "^4.1.2",
+        "@nestjs/throttler": "^4.2.1",
         "@nestjs/typeorm": "^10.0.0",
         "@scure/btc-signer": "^2.0.1",
         "async-mutex": "^0.5.0",
@@ -2204,6 +2205,20 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-4.2.1.tgz",
+      "integrity": "sha512-wVPMuIyr0KdrK1RVVQceWVNesogCm9IgYC1V5EkaTZ+usIE4qxEyzdwU5IqQLgOO/Loiq98MLwReDxazX7i9Uw==",
+      "license": "MIT",
+      "dependencies": {
+        "md5": "^2.2.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.13"
       }
     },
     "node_modules/@nestjs/typeorm": {
@@ -4570,6 +4585,15 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -4993,6 +5017,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/dashdash": {
@@ -7441,6 +7474,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -9083,6 +9122,17 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/md5.js": {
@@ -15017,6 +15067,14 @@
         "tslib": "2.5.2"
       }
     },
+    "@nestjs/throttler": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-4.2.1.tgz",
+      "integrity": "sha512-wVPMuIyr0KdrK1RVVQceWVNesogCm9IgYC1V5EkaTZ+usIE4qxEyzdwU5IqQLgOO/Loiq98MLwReDxazX7i9Uw==",
+      "requires": {
+        "md5": "^2.2.1"
+      }
+    },
     "@nestjs/typeorm": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-10.0.0.tgz",
@@ -16885,6 +16943,11 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
+    },
     "chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -17207,6 +17270,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -19018,6 +19086,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
     "is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -20266,6 +20339,16 @@
       "dev": true,
       "requires": {
         "tmpl": "1.0.5"
+      }
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "md5.js": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "firebase-admin": "^12.7.0",
     "merkle-lib": "^2.0.10",
     "node-telegram-bot-api": "^0.61.0",
+    "nodemailer": "^8.0.5",
     "pg": "^8.11.3",
     "prom-client": "^15.1.0",
     "redis": "^4.6.0",
@@ -70,6 +71,7 @@
     "@types/jest": "29.5.1",
     "@types/node": "^18.16.12",
     "@types/node-telegram-bot-api": "^0.61.6",
+    "@types/nodemailer": "^8.0.0",
     "@types/supertest": "^2.0.11",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
@@ -97,7 +99,14 @@
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
-      "^.+\\.(t|j)s$": ["ts-jest", { "tsconfig": { "allowJs": true } }]
+      "^.+\\.(t|j)s$": [
+        "ts-jest",
+        {
+          "tsconfig": {
+            "allowJs": true
+          }
+        }
+      ]
     },
     "transformIgnorePatterns": [
       "node_modules/(?!(@scure|@noble|micro-packed))"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-fastify": "^9.4.2",
     "@nestjs/schedule": "^4.1.2",
+    "@nestjs/throttler": "^4.2.1",
     "@nestjs/typeorm": "^10.0.0",
     "@scure/btc-signer": "^2.0.1",
     "async-mutex": "^0.5.0",

--- a/src/ORM/address-email/address-email.entity.ts
+++ b/src/ORM/address-email/address-email.entity.ts
@@ -1,0 +1,26 @@
+import { Column, CreateDateColumn, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+
+/**
+ * Binds an email address to a BTC mining address. Verified once via a token
+ * sent to the email; the verification timestamp is then permanent until the
+ * user re-binds. Required before an admin can invite the address into a
+ * payout group.
+ */
+@Entity('pplns_address_email')
+export class AddressEmailEntity {
+
+    @PrimaryColumn({ type: 'varchar', length: 62 })
+    address: string;
+
+    @Column({ type: 'varchar', length: 320 })
+    email: string;
+
+    @Column({ type: 'timestamp', nullable: true })
+    verifiedAt: Date | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/src/ORM/address-email/email-verification.entity.ts
+++ b/src/ORM/address-email/email-verification.entity.ts
@@ -1,0 +1,26 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryColumn } from 'typeorm';
+
+/**
+ * Pending email-verification token. Created when a user submits an email for
+ * an address; consumed when they click the link sent to that email. Expires
+ * after a short window (default 24h) — the user has to re-submit if it lapses.
+ */
+@Entity('pplns_email_verification')
+export class EmailVerificationEntity {
+
+    @PrimaryColumn({ type: 'varchar', length: 64 })
+    token: string;
+
+    @Index()
+    @Column({ type: 'varchar', length: 62 })
+    address: string;
+
+    @Column({ type: 'varchar', length: 320 })
+    email: string;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @Column({ type: 'timestamp' })
+    expiresAt: Date;
+}

--- a/src/ORM/pplns-group/pplns-group-balance.entity.ts
+++ b/src/ORM/pplns-group/pplns-group-balance.entity.ts
@@ -1,5 +1,12 @@
 import { Column, Entity, Index, PrimaryColumn, UpdateDateColumn } from 'typeorm';
 
+/**
+ * Pending/paid balances per (address, groupId). Composite PK — one address
+ * can legitimately have rows for multiple groups historically (sequentially,
+ * since pplns_group_member.address is globally unique at any one time).
+ * Keying on address alone would let a new group's addPending mutate a
+ * stale row from a prior group and leak money across group boundaries.
+ */
 @Entity('pplns_group_balance')
 export class PplnsGroupBalanceEntity {
 
@@ -7,7 +14,7 @@ export class PplnsGroupBalanceEntity {
     address: string;
 
     @Index()
-    @Column({ type: 'uuid' })
+    @PrimaryColumn({ type: 'uuid' })
     groupId: string;
 
     @Column({ type: 'bigint', default: 0, transformer: { from: (v: string) => Number(v), to: (v: number) => v } })

--- a/src/ORM/pplns-group/pplns-group-invitation.entity.ts
+++ b/src/ORM/pplns-group/pplns-group-invitation.entity.ts
@@ -18,7 +18,7 @@ export class PplnsGroupInvitationEntity {
     token: string;
 
     @Index()
-    @Column({ type: 'varchar', length: 36 })
+    @Column({ type: 'uuid' })
     groupId: string;
 
     @Index()

--- a/src/ORM/pplns-group/pplns-group-invitation.entity.ts
+++ b/src/ORM/pplns-group/pplns-group-invitation.entity.ts
@@ -1,0 +1,42 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryColumn } from 'typeorm';
+
+/**
+ * Pending invitation for an address to join a payout group. Created by the
+ * group admin; the address holder accepts (or declines) via a tokenized link
+ * sent to the email bound to that address. Pending invitations do NOT make
+ * the address a member — the address is only added to the group's
+ * pplns_group_member table once the invitation is accepted.
+ *
+ * Status lifecycle: pending -> accepted | declined | expired.
+ */
+export type PplnsGroupInvitationStatus = 'pending' | 'accepted' | 'declined' | 'expired';
+
+@Entity('pplns_group_invitation')
+export class PplnsGroupInvitationEntity {
+
+    @PrimaryColumn({ type: 'varchar', length: 64 })
+    token: string;
+
+    @Index()
+    @Column({ type: 'varchar', length: 36 })
+    groupId: string;
+
+    @Index()
+    @Column({ type: 'varchar', length: 62 })
+    address: string;
+
+    @Column({ type: 'varchar', length: 320 })
+    email: string;
+
+    @Column({ type: 'varchar', length: 16, default: 'pending' })
+    status: PplnsGroupInvitationStatus;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @Column({ type: 'timestamp' })
+    expiresAt: Date;
+
+    @Column({ type: 'timestamp', nullable: true })
+    respondedAt: Date | null;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,8 @@ import { CacheModule } from '@nestjs/cache-manager';
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { redisStore } from 'cache-manager-redis-yet';
 
@@ -146,6 +148,9 @@ const ORMModules = [
             },
         }),
         ScheduleModule.forRoot(),
+        // Default 60 requests per 60 seconds per IP (throttler v4 TTL is
+        // in seconds). Individual endpoints tighten further via @Throttle.
+        ThrottlerModule.forRoot({ ttl: 60, limit: 60 }),
         HttpModule,
         TypeOrmModule.forFeature([
             PplnsBalanceEntity,
@@ -210,6 +215,8 @@ const ORMModules = [
         EmailService,
         AddressEmailService,
         PplnsGroupInvitationService,
+        // Global throttler guard — per-endpoint limits override via @Throttle().
+        { provide: APP_GUARD, useClass: ThrottlerGuard },
     ],
 })
 export class AppModule {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -56,12 +56,20 @@ import { PplnsPayoutHistoryEntity } from './ORM/pplns-balance/pplns-payout-histo
 import { PplnsController } from './controllers/pplns/pplns.controller';
 import { GroupSoloService } from './services/group-solo.service';
 import { GroupService } from './services/group.service';
+import { EmailService } from './services/email.service';
+import { AddressEmailService } from './services/address-email.service';
+import { PplnsGroupInvitationService } from './services/pplns-group-invitation.service';
 import { MiningModeService } from './services/mining-mode.service';
 import { PplnsGroupEntity } from './ORM/pplns-group/pplns-group.entity';
 import { PplnsGroupMemberEntity } from './ORM/pplns-group/pplns-group-member.entity';
 import { PplnsGroupBlockHistoryEntity } from './ORM/pplns-group/pplns-group-block-history.entity';
 import { PplnsGroupBalanceEntity } from './ORM/pplns-group/pplns-group-balance.entity';
+import { PplnsGroupInvitationEntity } from './ORM/pplns-group/pplns-group-invitation.entity';
+import { AddressEmailEntity } from './ORM/address-email/address-email.entity';
+import { EmailVerificationEntity } from './ORM/address-email/email-verification.entity';
 import { PplnsGroupController } from './controllers/pplns-group/pplns-group.controller';
+import { PplnsInvitationController } from './controllers/pplns-invitation/pplns-invitation.controller';
+import { EmailController } from './controllers/email/email.controller';
 import { DownstreamReportController } from './controllers/downstream-report/downstream-report.controller';
 import { ExternalShareController } from './controllers/external-share/external-share.controller';
 import { PushController } from './controllers/push/push.controller';
@@ -146,6 +154,9 @@ const ORMModules = [
             PplnsGroupMemberEntity,
             PplnsGroupBlockHistoryEntity,
             PplnsGroupBalanceEntity,
+            PplnsGroupInvitationEntity,
+            AddressEmailEntity,
+            EmailVerificationEntity,
         ]),
         ...ORMModules
     ],
@@ -159,6 +170,8 @@ const ORMModules = [
         InfoController,
         PplnsController,
         PplnsGroupController,
+        PplnsInvitationController,
+        EmailController,
     ],
     providers: [
         // TimeslotMigrationService, // Disabled - migration incomplete, leaving data in mixed state
@@ -194,6 +207,9 @@ const ORMModules = [
         GroupSoloService,
         GroupService,
         MiningModeService,
+        EmailService,
+        AddressEmailService,
+        PplnsGroupInvitationService,
     ],
 })
 export class AppModule {

--- a/src/controllers/email/email.controller.ts
+++ b/src/controllers/email/email.controller.ts
@@ -1,0 +1,75 @@
+import { Body, Controller, Get, HttpException, HttpStatus, Param, Post } from '@nestjs/common';
+import { AddressEmailService, AddressEmailServiceError } from '../../services/address-email.service';
+
+interface RegisterDto {
+    address: string;
+    email: string;
+}
+
+@Controller('email')
+export class EmailController {
+
+    constructor(private readonly addressEmailService: AddressEmailService) {}
+
+    /**
+     * POST /api/email/register
+     * Bind an email to a mining address. Sends a verification link to the
+     * email — the binding is not "verified" until the link is clicked.
+     */
+    @Post('register')
+    async register(@Body() body: RegisterDto): Promise<{ ok: true; verificationSent: true }> {
+        try {
+            await this.addressEmailService.register(body.address?.trim() ?? '', body.email);
+            return { ok: true, verificationSent: true };
+        } catch (e) {
+            throw this.toHttp(e);
+        }
+    }
+
+    /**
+     * GET /api/email/verify/:token
+     * Confirm an email binding via the link from the verification email.
+     * Returns the verified binding (address + email) so the UI can render
+     * confirmation + a "go back to your dashboard" link.
+     */
+    @Get('verify/:token')
+    async verify(@Param('token') token: string): Promise<{ address: string; email: string; verifiedAt: Date }> {
+        try {
+            const binding = await this.addressEmailService.verify(token);
+            return {
+                address: binding.address,
+                email: binding.email,
+                verifiedAt: binding.verifiedAt!,
+            };
+        } catch (e) {
+            throw this.toHttp(e);
+        }
+    }
+
+    /**
+     * GET /api/email/by-address/:address
+     * Lookup the verified-email binding for an address. Returns
+     * { email, verifiedAt } if bound, or { email: null } if not — used
+     * by the dashboard settings page to show the current state without
+     * leaking the email address itself unnecessarily (we only return it
+     * when explicitly requested by someone visiting that address's page,
+     * matching the existing trust model).
+     */
+    @Get('by-address/:address')
+    async byAddress(@Param('address') address: string): Promise<{ email: string | null; verifiedAt: Date | null }> {
+        const binding = await this.addressEmailService.getVerified(address);
+        if (!binding) return { email: null, verifiedAt: null };
+        return { email: binding.email, verifiedAt: binding.verifiedAt };
+    }
+
+    private toHttp(e: any): HttpException {
+        if (e instanceof AddressEmailServiceError) {
+            const status = e.code === 'not-found' ? HttpStatus.NOT_FOUND
+                : e.code === 'expired' ? HttpStatus.GONE
+                : e.code === 'email-disabled' || e.code === 'config-missing' ? HttpStatus.SERVICE_UNAVAILABLE
+                : HttpStatus.BAD_REQUEST;
+            return new HttpException({ code: e.code, message: e.message }, status);
+        }
+        return new HttpException({ code: 'internal', message: e?.message ?? 'unknown' }, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/controllers/email/email.controller.ts
+++ b/src/controllers/email/email.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Get, HttpException, HttpStatus, Param, Post } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { AddressEmailService, AddressEmailServiceError } from '../../services/address-email.service';
 
 interface RegisterDto {
@@ -16,6 +17,10 @@ export class EmailController {
      * Bind an email to a mining address. Sends a verification link to the
      * email — the binding is not "verified" until the link is clicked.
      */
+    // 5 register attempts / minute per IP. Each call sends an email —
+    // looser limits invite SMTP-quota abuse and spam-listing of the
+    // pool's sender domain.
+    @Throttle(5, 60)
     @Post('register')
     async register(@Body() body: RegisterDto): Promise<{ ok: true; verificationSent: true }> {
         try {

--- a/src/controllers/pplns-group/pplns-group.controller.spec.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.spec.ts
@@ -15,6 +15,7 @@ describe('PplnsGroupController.chart', () => {
             listMembers: jest.fn().mockResolvedValue(opts.members ?? []),
         };
         const groupSoloService = {} as any;
+        const invitationService = {} as any;
         const clientService = {} as any;
         const clientStatisticsService = {
             getChartDataForAddress: jest.fn(async (address: string) =>
@@ -25,6 +26,7 @@ describe('PplnsGroupController.chart', () => {
         const controller = new PplnsGroupController(
             groupService as any,
             groupSoloService,
+            invitationService,
             clientService,
             clientStatisticsService as any,
             clientRejectedStatisticsService,

--- a/src/controllers/pplns-group/pplns-group.controller.spec.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.spec.ts
@@ -16,6 +16,7 @@ describe('PplnsGroupController.chart', () => {
         };
         const groupSoloService = {} as any;
         const invitationService = {} as any;
+        const addressEmailService = {} as any;
         const clientService = {} as any;
         const clientStatisticsService = {
             getChartDataForAddress: jest.fn(async (address: string) =>
@@ -27,6 +28,7 @@ describe('PplnsGroupController.chart', () => {
             groupService as any,
             groupSoloService,
             invitationService,
+            addressEmailService,
             clientService,
             clientStatisticsService as any,
             clientRejectedStatisticsService,

--- a/src/controllers/pplns-group/pplns-group.controller.spec.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.spec.ts
@@ -1,0 +1,123 @@
+jest.mock('node-telegram-bot-api', () => jest.fn());
+
+import { PplnsGroupController } from './pplns-group.controller';
+import { HttpException } from '@nestjs/common';
+
+describe('PplnsGroupController.chart', () => {
+
+    function setup(opts: {
+        group?: { id: string; dissolvedAt: Date | null };
+        members?: { address: string }[];
+        chartByAddress?: Record<string, { label: string; data: number }[]>;
+    }) {
+        const groupService = {
+            getGroup: jest.fn().mockResolvedValue(opts.group ?? null),
+            listMembers: jest.fn().mockResolvedValue(opts.members ?? []),
+        };
+        const groupSoloService = {} as any;
+        const clientService = {} as any;
+        const clientStatisticsService = {
+            getChartDataForAddress: jest.fn(async (address: string) =>
+                opts.chartByAddress?.[address] ?? [],
+            ),
+        };
+        const controller = new PplnsGroupController(
+            groupService as any,
+            groupSoloService,
+            clientService,
+            clientStatisticsService as any,
+        );
+        return { controller, groupService, clientStatisticsService };
+    }
+
+    it('sums per-member time-series with matching labels', async () => {
+        const { controller } = setup({
+            group: { id: 'g1', dissolvedAt: null },
+            members: [{ address: 'bc1qalice' }, { address: 'bc1qbob' }],
+            chartByAddress: {
+                'bc1qalice': [
+                    { label: '2026-04-19T10:00:00.000Z', data: 500e9 },
+                    { label: '2026-04-19T10:10:00.000Z', data: 520e9 },
+                ],
+                'bc1qbob': [
+                    { label: '2026-04-19T10:00:00.000Z', data: 300e9 },
+                    { label: '2026-04-19T10:10:00.000Z', data: 310e9 },
+                ],
+            },
+        });
+
+        const chart = await controller.chart('g1', '1d');
+
+        expect(chart).toEqual([
+            { label: '2026-04-19T10:00:00.000Z', data: 800e9 },
+            { label: '2026-04-19T10:10:00.000Z', data: 830e9 },
+        ]);
+    });
+
+    it('handles sparse per-member data (missing slots do not create phantom zeros)', async () => {
+        const { controller } = setup({
+            group: { id: 'g1', dissolvedAt: null },
+            members: [{ address: 'bc1qalice' }, { address: 'bc1qbob' }],
+            chartByAddress: {
+                'bc1qalice': [
+                    { label: '2026-04-19T10:00:00.000Z', data: 500e9 },
+                    { label: '2026-04-19T10:10:00.000Z', data: 500e9 },
+                ],
+                'bc1qbob': [
+                    { label: '2026-04-19T10:10:00.000Z', data: 300e9 },
+                ],
+            },
+        });
+
+        const chart = await controller.chart('g1', '1d');
+
+        expect(chart).toEqual([
+            { label: '2026-04-19T10:00:00.000Z', data: 500e9 },
+            { label: '2026-04-19T10:10:00.000Z', data: 800e9 },
+        ]);
+    });
+
+    it('returns empty array when the group has no members', async () => {
+        const { controller } = setup({
+            group: { id: 'g1', dissolvedAt: null },
+            members: [],
+        });
+        expect(await controller.chart('g1', '1d')).toEqual([]);
+    });
+
+    it('returns 404 when the group does not exist', async () => {
+        const { controller } = setup({ group: undefined });
+        await expect(controller.chart('missing', '1d')).rejects.toBeInstanceOf(HttpException);
+    });
+
+    it('returns 404 when the group has been dissolved', async () => {
+        const { controller } = setup({
+            group: { id: 'g1', dissolvedAt: new Date() },
+        });
+        await expect(controller.chart('g1', '1d')).rejects.toBeInstanceOf(HttpException);
+    });
+
+    it('passes the range through unchanged for valid values', async () => {
+        const { controller, clientStatisticsService } = setup({
+            group: { id: 'g1', dissolvedAt: null },
+            members: [{ address: 'bc1qa' }],
+            chartByAddress: { 'bc1qa': [] },
+        });
+
+        await controller.chart('g1', '7d');
+
+        expect(clientStatisticsService.getChartDataForAddress).toHaveBeenCalledWith('bc1qa', '7d');
+    });
+
+    it('falls back to 1d when the range is unknown', async () => {
+        const { controller, clientStatisticsService } = setup({
+            group: { id: 'g1', dissolvedAt: null },
+            members: [{ address: 'bc1qa' }],
+            chartByAddress: { 'bc1qa': [] },
+        });
+
+        await controller.chart('g1', 'unsupported' as any);
+
+        expect(clientStatisticsService.getChartDataForAddress).toHaveBeenCalledWith('bc1qa', '1d');
+    });
+});

--- a/src/controllers/pplns-group/pplns-group.controller.spec.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.spec.ts
@@ -21,11 +21,13 @@ describe('PplnsGroupController.chart', () => {
                 opts.chartByAddress?.[address] ?? [],
             ),
         };
+        const clientRejectedStatisticsService = {} as any;
         const controller = new PplnsGroupController(
             groupService as any,
             groupSoloService,
             clientService,
             clientStatisticsService as any,
+            clientRejectedStatisticsService,
         );
         return { controller, groupService, clientStatisticsService };
     }

--- a/src/controllers/pplns-group/pplns-group.controller.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Delete, Get, Headers, HttpException, HttpStatus, Para
 import { GroupService, GroupServiceError } from '../../services/group.service';
 import { GroupSoloService } from '../../services/group-solo.service';
 import { InvitationServiceError, PplnsGroupInvitationService } from '../../services/pplns-group-invitation.service';
+import { AddressEmailService } from '../../services/address-email.service';
 import { ClientService } from '../../ORM/client/client.service';
 import { ClientStatisticsService } from '../../ORM/client-statistics/client-statistics.service';
 import { ClientRejectedStatisticsService } from '../../ORM/client-rejected-statistics/client-rejected-statistics.service';
@@ -32,6 +33,7 @@ export class PplnsGroupController {
         private readonly groupService: GroupService,
         private readonly groupSoloService: GroupSoloService,
         private readonly invitationService: PplnsGroupInvitationService,
+        private readonly addressEmailService: AddressEmailService,
         private readonly clientService: ClientService,
         private readonly clientStatisticsService: ClientStatisticsService,
         private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
@@ -52,8 +54,8 @@ export class PplnsGroupController {
     }
 
     @Get(':id')
-    async details(@Param('id') id: string) {
-        return this.detailsForGroupId(id);
+    async details(@Param('id') id: string, @Headers('x-admin-token') adminToken?: string) {
+        return this.detailsForGroupId(id, adminToken);
     }
 
     /**
@@ -64,27 +66,58 @@ export class PplnsGroupController {
      * open their group dashboard before the 2nd member joins.
      */
     @Get('by-address/:address')
-    async byAddress(@Param('address') address: string) {
+    async byAddress(@Param('address') address: string, @Headers('x-admin-token') adminToken?: string) {
         const entry = this.groupService.getGroupForAddress(address);
         if (!entry) throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
-        return this.detailsForGroupId(entry.groupId);
+        return this.detailsForGroupId(entry.groupId, adminToken);
     }
 
-    private async detailsForGroupId(id: string) {
+    /**
+     * Returns per-member rows including a `lastShareAt` (epoch-ms or null)
+     * and, for callers that supply a valid admin token, the member's
+     * verified email. The email is omitted entirely when no valid admin
+     * token is present — this endpoint doubles as the public group-page
+     * and the admin dashboard feed, and non-admins have no business seeing
+     * other members' emails.
+     */
+    private async detailsForGroupId(id: string, adminToken?: string) {
         const group = await this.groupService.getGroup(id);
         if (!group || group.dissolvedAt) throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
+
+        let isAdmin = false;
+        if (adminToken) {
+            try {
+                await this.groupService.requireAdminToken(id, adminToken);
+                isAdmin = true;
+            } catch {
+                // Invalid admin token is not a hard error here — the caller
+                // may legitimately be a non-admin fetching public details.
+                // We just don't include emails in that case.
+            }
+        }
+
         const members = await this.groupService.listMembers(id);
-        const membersWithHashrate = await Promise.all(members.map(async m => ({
-            address: m.address,
-            role: m.role,
-            joinedAt: m.joinedAt,
-            hashrate: await this.addressHashrate(m.address),
-        })));
-        const totalHashrate = membersWithHashrate.reduce((sum, m) => sum + m.hashrate, 0);
+        const membersWithStatus = await Promise.all(members.map(async m => {
+            const hashrate = await this.addressHashrate(m.address);
+            const lastShareAt = await this.groupSoloService.getMemberLastActive(id, m.address);
+            const row: any = {
+                address: m.address,
+                role: m.role,
+                joinedAt: m.joinedAt,
+                hashrate,
+                lastShareAt,
+            };
+            if (isAdmin) {
+                const binding = await this.addressEmailService.getVerified(m.address);
+                row.email = binding?.email ?? null;
+            }
+            return row;
+        }));
+        const totalHashrate = membersWithStatus.reduce((sum, m) => sum + m.hashrate, 0);
         return {
             ...this.publicGroupView(group),
             totalHashrate,
-            members: membersWithHashrate,
+            members: membersWithStatus,
         };
     }
 
@@ -285,7 +318,7 @@ export class PplnsGroupController {
     ) {
         try {
             const result = await this.invitationService.createInvitation(id, body.address ?? '', token);
-            return { invited: true, email: maskEmail(result.email), expiresAt: result.expiresAt };
+            return { invited: true, email: result.email, expiresAt: result.expiresAt };
         } catch (e) {
             throw this.toHttpError(e);
         }
@@ -319,7 +352,7 @@ export class PplnsGroupController {
             seen.add(addr);
             try {
                 const r = await this.invitationService.createInvitation(id, addr, token);
-                invited.push({ address: addr, email: maskEmail(r.email), expiresAt: r.expiresAt });
+                invited.push({ address: addr, email: r.email, expiresAt: r.expiresAt });
             } catch (e) {
                 if (e instanceof GroupServiceError && e.code === 'invalid-token') {
                     throw this.toHttpError(e);
@@ -342,6 +375,12 @@ export class PplnsGroupController {
      * GET /pplns/groups/:id/invitations
      * List pending invitations for the group. Admin-token-auth — used by
      * the admin dashboard to see who's been invited but hasn't responded.
+     *
+     * The invitation token is deliberately NOT returned. It lives only in
+     * the email body — that's what makes the email a trust anchor against
+     * silent-add. Returning it here would let a malicious admin accept
+     * the invitation on behalf of the invitee without the invitee ever
+     * seeing the mail.
      */
     @Get(':id/invitations')
     async listInvitations(
@@ -352,9 +391,8 @@ export class PplnsGroupController {
             await this.groupService.requireAdminToken(id, token);
             const rows = await this.invitationService.listPendingForGroup(id);
             return rows.map(r => ({
-                token: r.token,
                 address: r.address,
-                email: maskEmail(r.email),
+                email: r.email,
                 createdAt: r.createdAt,
                 expiresAt: r.expiresAt,
                 status: r.status,
@@ -365,24 +403,33 @@ export class PplnsGroupController {
     }
 
     /**
-     * DELETE /pplns/groups/:id/invitations/:token
+     * DELETE /pplns/groups/:id/invitations/by-address/:address
      * Cancel a pending invitation before the recipient responds.
-     * Admin-token-auth.
+     * Admin-token-auth. Addressed by (groupId, address) instead of token
+     * so the admin never needs to see the secret token.
      */
-    @Delete(':id/invitations/:token')
+    @Delete(':id/invitations/by-address/:address')
     async cancelInvitation(
         @Param('id') id: string,
-        @Param('token') invToken: string,
+        @Param('address') address: string,
         @Headers('x-admin-token') token?: string,
     ) {
         try {
-            await this.invitationService.cancelInvitation(invToken, id, token);
+            await this.invitationService.cancelInvitationByAddress(id, address, token);
             return { cancelled: true };
         } catch (e) {
             throw this.toHttpError(e);
         }
     }
 
+    /**
+     * DELETE /pplns/groups/:id/members/:address
+     * Remove a non-creator member. Admin-token-auth, AND the target must
+     * be inactive (no share submitted for ≥ GROUP_INACTIVITY_KICK_DAYS days).
+     * There is no unauthenticated "self-leave" — if a miner wants out,
+     * they repoint their miner to a different address; after the
+     * inactivity window the admin can prune the stale member row.
+     */
     @Delete(':id/members/:address')
     async removeMember(
         @Param('id') id: string,
@@ -391,16 +438,6 @@ export class PplnsGroupController {
     ) {
         try {
             await this.groupService.removeMember(id, address, token);
-            return { removed: true };
-        } catch (e) {
-            throw this.toHttpError(e);
-        }
-    }
-
-    @Delete(':id/members/:address/self')
-    async selfLeave(@Param('id') id: string, @Param('address') address: string) {
-        try {
-            await this.groupService.selfLeave(id, address);
             return { removed: true };
         } catch (e) {
             throw this.toHttpError(e);
@@ -459,7 +496,7 @@ export class PplnsGroupController {
                 'address-in-group': HttpStatus.CONFLICT,
                 'already-member': HttpStatus.CONFLICT,
                 'already-creator': HttpStatus.CONFLICT,
-                'creator-cannot-self-leave': HttpStatus.FORBIDDEN,
+                'member-still-active': HttpStatus.FORBIDDEN,
             }[e.code] ?? HttpStatus.BAD_REQUEST;
             return new HttpException({ code: e.code, message: e.message }, status);
         }
@@ -481,15 +518,3 @@ export class PplnsGroupController {
     }
 }
 
-/**
- * Don't expose full email addresses to anyone with admin-token access — the
- * admin doesn't need to read another member's email, only know that the
- * invitation reached SOMEONE. Mask everything except first char + domain.
- */
-function maskEmail(email: string): string {
-    if (!email) return '';
-    const [local, domain] = email.split('@');
-    if (!domain) return '***';
-    const head = local.slice(0, 1);
-    return `${head}***@${domain}`;
-}

--- a/src/controllers/pplns-group/pplns-group.controller.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.ts
@@ -43,6 +43,24 @@ export class PplnsGroupController {
 
     @Get(':id')
     async details(@Param('id') id: string) {
+        return this.detailsForGroupId(id);
+    }
+
+    /**
+     * GET /pplns/groups/by-address/:address
+     * Returns the (non-dissolved) group an address is a member of, if any.
+     * Unlike /api/pplns/mode/:address this intentionally returns inactive
+     * groups too — so a creator of a freshly-made 1-member group can still
+     * open their group dashboard before the 2nd member joins.
+     */
+    @Get('by-address/:address')
+    async byAddress(@Param('address') address: string) {
+        const entry = this.groupService.getGroupForAddress(address);
+        if (!entry) throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
+        return this.detailsForGroupId(entry.groupId);
+    }
+
+    private async detailsForGroupId(id: string) {
         const group = await this.groupService.getGroup(id);
         if (!group || group.dissolvedAt) throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
         const members = await this.groupService.listMembers(id);

--- a/src/controllers/pplns-group/pplns-group.controller.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Delete, Get, Headers, HttpException, HttpStatus, Param, Post, Query } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { GroupService, GroupServiceError } from '../../services/group.service';
 import { GroupSoloService } from '../../services/group-solo.service';
 import { InvitationServiceError, PplnsGroupInvitationService } from '../../services/pplns-group-invitation.service';
@@ -310,6 +311,10 @@ export class PplnsGroupController {
      * call returns 400 with code 'email-not-verified'. Replaces the old
      * direct-add endpoint, which was the silent-add attack vector.
      */
+    // 10 invites / minute per IP. An admin with a valid token could
+    // otherwise DoS the SMTP provider or spam addresses for tribunal-style
+    // harassment. Token-auth isn't a substitute for rate-limiting here.
+    @Throttle(10, 60)
     @Post(':id/invitations')
     async createInvitation(
         @Param('id') id: string,
@@ -331,6 +336,8 @@ export class PplnsGroupController {
      * `skipped` so the admin can fix them individually. Token failures
      * still abort — they're an auth issue, not per-address.
      */
+    // Tighter than single because each call can send many mails.
+    @Throttle(5, 60)
     @Post(':id/invitations/batch')
     async createInvitationsBatch(
         @Param('id') id: string,

--- a/src/controllers/pplns-group/pplns-group.controller.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.ts
@@ -16,6 +16,10 @@ interface AddMemberDto {
     address?: string;
 }
 
+interface AddMembersBatchDto {
+    addresses?: string[];
+}
+
 interface TransferDto {
     toAddress?: string;
 }
@@ -260,6 +264,25 @@ export class PplnsGroupController {
         try {
             const member = await this.groupService.addMember(id, body.address ?? '', token);
             return { address: member.address, role: member.role, joinedAt: member.joinedAt };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    /**
+     * POST /pplns/groups/:id/members/batch
+     * Adds multiple addresses in a single token check + single cache
+     * rebuild. Benign per-address failures land in `skipped`; token
+     * failures still throw (they're auth issues, not per-address).
+     */
+    @Post(':id/members/batch')
+    async addMembersBatch(
+        @Param('id') id: string,
+        @Body() body: AddMembersBatchDto,
+        @Headers('x-admin-token') token?: string,
+    ) {
+        try {
+            return await this.groupService.addMembersBatch(id, body.addresses ?? [], token);
         } catch (e) {
             throw this.toHttpError(e);
         }

--- a/src/controllers/pplns-group/pplns-group.controller.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.ts
@@ -231,6 +231,19 @@ export class PplnsGroupController {
         return this.groupSoloService.getRoundStats(id);
     }
 
+    /**
+     * GET /pplns/groups/:id/best-difficulty
+     * Highest single-share diff submitted in the current round across all
+     * group members, plus the address that submitted it. Round-based —
+     * resets on block-found together with the rest of the round state.
+     */
+    @Get(':id/best-difficulty')
+    async bestDifficulty(@Param('id') id: string) {
+        const group = await this.groupService.getGroup(id);
+        if (!group || group.dissolvedAt) throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
+        return this.groupSoloService.getRoundBestDifficulty(id);
+    }
+
     @Get(':id/history')
     async history(@Param('id') id: string, @Query('limit') limitStr?: string) {
         const group = await this.groupService.getGroup(id);

--- a/src/controllers/pplns-group/pplns-group.controller.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.ts
@@ -509,6 +509,7 @@ export class PplnsGroupController {
                 'already-member': HttpStatus.CONFLICT,
                 'address-in-group': HttpStatus.CONFLICT,
                 'already-declined': HttpStatus.CONFLICT,
+                'group-dissolved': HttpStatus.GONE,
                 'invalid-address': HttpStatus.BAD_REQUEST,
                 'config-missing': HttpStatus.SERVICE_UNAVAILABLE,
             }[e.code] ?? HttpStatus.BAD_REQUEST;

--- a/src/controllers/pplns-group/pplns-group.controller.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Delete, Get, Headers, HttpException, HttpStatus, Param, Post, Query } from '@nestjs/common';
 import { GroupService, GroupServiceError } from '../../services/group.service';
 import { GroupSoloService } from '../../services/group-solo.service';
+import { InvitationServiceError, PplnsGroupInvitationService } from '../../services/pplns-group-invitation.service';
 import { ClientService } from '../../ORM/client/client.service';
 import { ClientStatisticsService } from '../../ORM/client-statistics/client-statistics.service';
 import { ClientRejectedStatisticsService } from '../../ORM/client-rejected-statistics/client-rejected-statistics.service';
@@ -30,6 +31,7 @@ export class PplnsGroupController {
     constructor(
         private readonly groupService: GroupService,
         private readonly groupSoloService: GroupSoloService,
+        private readonly invitationService: PplnsGroupInvitationService,
         private readonly clientService: ClientService,
         private readonly clientStatisticsService: ClientStatisticsService,
         private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
@@ -268,34 +270,114 @@ export class PplnsGroupController {
         }
     }
 
-    @Post(':id/members')
-    async addMember(
+    /**
+     * POST /pplns/groups/:id/invitations
+     * Create + send a single invitation. The address must have a verified
+     * email binding (see /api/email/register + /verify) — without it the
+     * call returns 400 with code 'email-not-verified'. Replaces the old
+     * direct-add endpoint, which was the silent-add attack vector.
+     */
+    @Post(':id/invitations')
+    async createInvitation(
         @Param('id') id: string,
         @Body() body: AddMemberDto,
         @Headers('x-admin-token') token?: string,
     ) {
         try {
-            const member = await this.groupService.addMember(id, body.address ?? '', token);
-            return { address: member.address, role: member.role, joinedAt: member.joinedAt };
+            const result = await this.invitationService.createInvitation(id, body.address ?? '', token);
+            return { invited: true, email: maskEmail(result.email), expiresAt: result.expiresAt };
         } catch (e) {
             throw this.toHttpError(e);
         }
     }
 
     /**
-     * POST /pplns/groups/:id/members/batch
-     * Adds multiple addresses in a single token check + single cache
-     * rebuild. Benign per-address failures land in `skipped`; token
-     * failures still throw (they're auth issues, not per-address).
+     * POST /pplns/groups/:id/invitations/batch
+     * Create invitations for multiple addresses. Per-address failures
+     * (no email, already member, already invited, etc.) land in
+     * `skipped` so the admin can fix them individually. Token failures
+     * still abort — they're an auth issue, not per-address.
      */
-    @Post(':id/members/batch')
-    async addMembersBatch(
+    @Post(':id/invitations/batch')
+    async createInvitationsBatch(
         @Param('id') id: string,
         @Body() body: AddMembersBatchDto,
         @Headers('x-admin-token') token?: string,
     ) {
+        // Pre-validate the admin token once by attempting to create the
+        // first invitation. If that fails on token, abort the batch. All
+        // subsequent calls reuse the same token through the service.
+        const addresses = (body.addresses ?? []).map(a => (a ?? '').trim()).filter(a => !!a);
+        const invited: { address: string; email: string; expiresAt: Date }[] = [];
+        const skipped: { address: string; reason: string }[] = [];
+        const seen = new Set<string>();
+        for (const addr of addresses) {
+            if (seen.has(addr)) {
+                skipped.push({ address: addr, reason: 'duplicate-in-batch' });
+                continue;
+            }
+            seen.add(addr);
+            try {
+                const r = await this.invitationService.createInvitation(id, addr, token);
+                invited.push({ address: addr, email: maskEmail(r.email), expiresAt: r.expiresAt });
+            } catch (e) {
+                if (e instanceof GroupServiceError && e.code === 'invalid-token') {
+                    throw this.toHttpError(e);
+                }
+                if (e instanceof InvitationServiceError) {
+                    skipped.push({ address: addr, reason: e.code });
+                    continue;
+                }
+                if (e instanceof GroupServiceError) {
+                    skipped.push({ address: addr, reason: e.code });
+                    continue;
+                }
+                throw e;
+            }
+        }
+        return { invited, skipped };
+    }
+
+    /**
+     * GET /pplns/groups/:id/invitations
+     * List pending invitations for the group. Admin-token-auth — used by
+     * the admin dashboard to see who's been invited but hasn't responded.
+     */
+    @Get(':id/invitations')
+    async listInvitations(
+        @Param('id') id: string,
+        @Headers('x-admin-token') token?: string,
+    ) {
         try {
-            return await this.groupService.addMembersBatch(id, body.addresses ?? [], token);
+            await this.groupService.requireAdminToken(id, token);
+            const rows = await this.invitationService.listPendingForGroup(id);
+            return rows.map(r => ({
+                token: r.token,
+                address: r.address,
+                email: maskEmail(r.email),
+                createdAt: r.createdAt,
+                expiresAt: r.expiresAt,
+                status: r.status,
+            }));
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    /**
+     * DELETE /pplns/groups/:id/invitations/:token
+     * Cancel a pending invitation before the recipient responds.
+     * Admin-token-auth.
+     */
+    @Delete(':id/invitations/:token')
+    async cancelInvitation(
+        @Param('id') id: string,
+        @Param('token') invToken: string,
+        @Headers('x-admin-token') token?: string,
+    ) {
+        try {
+            await this.invitationService.cancelInvitation(invToken, id, token);
+            return { cancelled: true };
         } catch (e) {
             throw this.toHttpError(e);
         }
@@ -381,6 +463,33 @@ export class PplnsGroupController {
             }[e.code] ?? HttpStatus.BAD_REQUEST;
             return new HttpException({ code: e.code, message: e.message }, status);
         }
+        if (e instanceof InvitationServiceError) {
+            const status = {
+                'not-found': HttpStatus.NOT_FOUND,
+                'expired': HttpStatus.GONE,
+                'email-not-verified': HttpStatus.FAILED_DEPENDENCY,
+                'invitation-pending': HttpStatus.CONFLICT,
+                'already-member': HttpStatus.CONFLICT,
+                'address-in-group': HttpStatus.CONFLICT,
+                'already-declined': HttpStatus.CONFLICT,
+                'invalid-address': HttpStatus.BAD_REQUEST,
+                'config-missing': HttpStatus.SERVICE_UNAVAILABLE,
+            }[e.code] ?? HttpStatus.BAD_REQUEST;
+            return new HttpException({ code: e.code, message: e.message }, status);
+        }
         return new HttpException({ code: 'internal-error', message: (e as Error)?.message ?? 'Internal error' }, HttpStatus.INTERNAL_SERVER_ERROR);
     }
+}
+
+/**
+ * Don't expose full email addresses to anyone with admin-token access — the
+ * admin doesn't need to read another member's email, only know that the
+ * invitation reached SOMEONE. Mask everything except first char + domain.
+ */
+function maskEmail(email: string): string {
+    if (!email) return '';
+    const [local, domain] = email.split('@');
+    if (!domain) return '***';
+    const head = local.slice(0, 1);
+    return `${head}***@${domain}`;
 }

--- a/src/controllers/pplns-group/pplns-group.controller.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.ts
@@ -3,6 +3,9 @@ import { GroupService, GroupServiceError } from '../../services/group.service';
 import { GroupSoloService } from '../../services/group-solo.service';
 import { ClientService } from '../../ORM/client/client.service';
 import { ClientStatisticsService } from '../../ORM/client-statistics/client-statistics.service';
+import { ClientRejectedStatisticsService } from '../../ORM/client-rejected-statistics/client-rejected-statistics.service';
+import { eStratumErrorCode } from '../../models/enums/eStratumErrorCode';
+import { generateFormattedTimeSlots } from '../../utils/timeslot.utils';
 
 interface CreateGroupDto {
     name?: string;
@@ -25,6 +28,7 @@ export class PplnsGroupController {
         private readonly groupSoloService: GroupSoloService,
         private readonly clientService: ClientService,
         private readonly clientStatisticsService: ClientStatisticsService,
+        private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
     ) {}
 
     /** Sum of live hashrates across all workers of an address. Matches /api/client/:address. */
@@ -125,6 +129,95 @@ export class PplnsGroupController {
         return Array.from(sumByLabel.entries())
             .sort(([a], [b]) => a.localeCompare(b))
             .map(([label, data]) => ({ label, data }));
+    }
+
+    /**
+     * GET /pplns/groups/:id/accepted?range=1d|3d|7d
+     * Pool-side aggregate of accepted shares across all group members.
+     * Same shape as /api/client/:address/accepted so the UI can plug it
+     * into the existing accepted-chart rendering without transformation.
+     */
+    @Get(':id/accepted')
+    async accepted(
+        @Param('id') id: string,
+        @Query('range') range: '1d' | '3d' | '7d' = '1d',
+    ) {
+        const group = await this.groupService.getGroup(id);
+        if (!group || group.dissolvedAt) throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
+        const validRange: '1d' | '3d' | '7d' =
+            range === '3d' ? '3d' : range === '7d' ? '7d' : '1d';
+
+        const members = await this.groupService.listMembers(id);
+        if (members.length === 0) return { slotData: [] };
+
+        const now = Date.now();
+        const oneDay = 24 * 60 * 60 * 1000;
+        const days = validRange === '7d' ? 7 : validRange === '3d' ? 3 : 1;
+        const sinceTime = now - days * oneDay;
+
+        const perMember = await Promise.all(
+            members.map((m) => this.clientStatisticsService.getAcceptedEntriesSince(m.address, sinceTime)),
+        );
+        const slotMap = new Map<number, number>();
+        for (const entries of perMember) {
+            for (const entry of entries) {
+                slotMap.set(entry.time, (slotMap.get(entry.time) ?? 0) + entry.shares);
+            }
+        }
+
+        const slotData = generateFormattedTimeSlots(sinceTime, now, (t) => ({
+            counts: { accepted: slotMap.get(t) || 0 },
+        }));
+        return { slotData };
+    }
+
+    /**
+     * GET /pplns/groups/:id/rejected?range=1d|3d|7d
+     * Aggregated rejected share counts per reason, across group members.
+     */
+    @Get(':id/rejected')
+    async rejected(
+        @Param('id') id: string,
+        @Query('range') range: '1d' | '3d' | '7d' = '1d',
+    ) {
+        const group = await this.groupService.getGroup(id);
+        if (!group || group.dissolvedAt) throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
+        const validRange: '1d' | '3d' | '7d' =
+            range === '3d' ? '3d' : range === '7d' ? '7d' : '1d';
+
+        const members = await this.groupService.listMembers(id);
+        if (members.length === 0) return { slotData: [] };
+
+        const now = Date.now();
+        const oneDay = 24 * 60 * 60 * 1000;
+        const days = validRange === '7d' ? 7 : validRange === '3d' ? 3 : 1;
+        const sinceTime = now - days * oneDay;
+
+        const perMember = await Promise.all(
+            members.map((m) => this.clientRejectedStatisticsService.getEntriesSince(m.address, sinceTime)),
+        );
+        const slotMap = new Map<number, Record<string, { count: number; diffMinusOne: number }>>();
+        for (const entries of perMember) {
+            for (const entry of entries) {
+                if (!slotMap.has(entry.time)) slotMap.set(entry.time, {});
+                const slot = slotMap.get(entry.time)!;
+                const existing = slot[entry.reason] ?? { count: 0, diffMinusOne: 0 };
+                slot[entry.reason] = {
+                    count: existing.count + entry.count,
+                    diffMinusOne: existing.diffMinusOne + entry.shares,
+                };
+            }
+        }
+
+        const allReasons = Object.keys(eStratumErrorCode).filter((k) => isNaN(Number(k)));
+        const slotData = generateFormattedTimeSlots(sinceTime, now, (t) => {
+            const counts: Record<string, { count: number; diffMinusOne: number }> = {};
+            for (const reason of allReasons) {
+                counts[reason] = slotMap.get(t)?.[reason] ?? { count: 0, diffMinusOne: 0 };
+            }
+            return { counts };
+        });
+        return { slotData };
     }
 
     @Get(':id/distribution')

--- a/src/controllers/pplns-group/pplns-group.controller.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Delete, Get, Headers, HttpException, HttpStatus, Para
 import { GroupService, GroupServiceError } from '../../services/group.service';
 import { GroupSoloService } from '../../services/group-solo.service';
 import { ClientService } from '../../ORM/client/client.service';
+import { ClientStatisticsService } from '../../ORM/client-statistics/client-statistics.service';
 
 interface CreateGroupDto {
     name?: string;
@@ -23,6 +24,7 @@ export class PplnsGroupController {
         private readonly groupService: GroupService,
         private readonly groupSoloService: GroupSoloService,
         private readonly clientService: ClientService,
+        private readonly clientStatisticsService: ClientStatisticsService,
     ) {}
 
     /** Sum of live hashrates across all workers of an address. Matches /api/client/:address. */
@@ -72,6 +74,39 @@ export class PplnsGroupController {
             totalHashrate: memberRates.reduce((sum, m) => sum + m.hashrate, 0),
             members: memberRates,
         };
+    }
+
+    /**
+     * GET /pplns/groups/:id/chart?range=1d|3d|7d
+     * Historical hashrate time-series for a payout group — drop-in compatible
+     * with /api/info/chart and /api/pplns/chart. Each data point is the sum of
+     * each member's per-address hashrate at that 10-minute slot. Ordered by label.
+     */
+    @Get(':id/chart')
+    async chart(
+        @Param('id') id: string,
+        @Query('range') range: '1d' | '3d' | '7d' = '1d',
+    ) {
+        const group = await this.groupService.getGroup(id);
+        if (!group || group.dissolvedAt) throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
+        const validRange: '1d' | '3d' | '7d' =
+            range === '3d' ? '3d' : range === '7d' ? '7d' : '1d';
+
+        const members = await this.groupService.listMembers(id);
+        if (members.length === 0) return [];
+
+        const perAddressSeries = await Promise.all(
+            members.map(m => this.clientStatisticsService.getChartDataForAddress(m.address, validRange)),
+        );
+        const sumByLabel = new Map<string, number>();
+        for (const series of perAddressSeries) {
+            for (const point of series) {
+                sumByLabel.set(point.label, (sumByLabel.get(point.label) ?? 0) + point.data);
+            }
+        }
+        return Array.from(sumByLabel.entries())
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([label, data]) => ({ label, data }));
     }
 
     @Get(':id/distribution')

--- a/src/controllers/pplns-invitation/pplns-invitation.controller.ts
+++ b/src/controllers/pplns-invitation/pplns-invitation.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, HttpException, HttpStatus, Param, Post } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { InvitationServiceError, PplnsGroupInvitationService } from '../../services/pplns-group-invitation.service';
 
 @Controller('pplns/invitations')
@@ -48,6 +49,9 @@ export class PplnsInvitationController {
      * auth: knowing it implies access to the email account that received
      * the invitation.
      */
+    // 20 req/min per IP. Token is 256-bit so brute force isn't the concern;
+    // this just caps accidental burst / malicious retry loops.
+    @Throttle(20, 60)
     @Post(':token/accept')
     async accept(@Param('token') token: string) {
         try {
@@ -64,6 +68,7 @@ export class PplnsInvitationController {
      * to decline on someone's behalf, and it lets the recipient dispose
      * of an unwanted invitation even without email access.
      */
+    @Throttle(20, 60)
     @Post(':token/decline')
     async decline(@Param('token') token: string) {
         try {

--- a/src/controllers/pplns-invitation/pplns-invitation.controller.ts
+++ b/src/controllers/pplns-invitation/pplns-invitation.controller.ts
@@ -77,7 +77,7 @@ export class PplnsInvitationController {
     private toHttp(e: any): HttpException {
         if (e instanceof InvitationServiceError) {
             const status = e.code === 'not-found' ? HttpStatus.NOT_FOUND
-                : e.code === 'expired' ? HttpStatus.GONE
+                : e.code === 'expired' || e.code === 'group-dissolved' ? HttpStatus.GONE
                 : e.code === 'already-declined' || e.code === 'already-member' ? HttpStatus.CONFLICT
                 : HttpStatus.BAD_REQUEST;
             return new HttpException({ code: e.code, message: e.message }, status);

--- a/src/controllers/pplns-invitation/pplns-invitation.controller.ts
+++ b/src/controllers/pplns-invitation/pplns-invitation.controller.ts
@@ -1,0 +1,87 @@
+import { Controller, Get, HttpException, HttpStatus, Param, Post } from '@nestjs/common';
+import { InvitationServiceError, PplnsGroupInvitationService } from '../../services/pplns-group-invitation.service';
+
+@Controller('pplns/invitations')
+export class PplnsInvitationController {
+
+    constructor(private readonly invitationService: PplnsGroupInvitationService) {}
+
+    /**
+     * GET /api/pplns/invitations/by-address/:address
+     * Pending invitations for a mining address. Drives the dashboard
+     * banner so the user can see they've been invited even if the email
+     * went to spam.
+     */
+    @Get('by-address/:address')
+    async listForAddress(@Param('address') address: string) {
+        return this.invitationService.listPendingForAddress(address);
+    }
+
+    /**
+     * GET /api/pplns/invitations/:token
+     * Invitation details — group name, inviter, expiry — used by the
+     * accept/decline page to render context before the user commits.
+     */
+    @Get(':token')
+    async byToken(@Param('token') token: string) {
+        const result = await this.invitationService.getByToken(token);
+        if (!result) {
+            throw new HttpException({ code: 'not-found', message: 'Invitation not found' }, HttpStatus.NOT_FOUND);
+        }
+        return {
+            token: result.invitation.token,
+            groupId: result.group.id,
+            groupName: result.group.name,
+            inviterAddress: result.group.creatorAddress,
+            address: result.invitation.address,
+            email: result.invitation.email,
+            status: result.invitation.status,
+            createdAt: result.invitation.createdAt,
+            expiresAt: result.invitation.expiresAt,
+            respondedAt: result.invitation.respondedAt,
+        };
+    }
+
+    /**
+     * POST /api/pplns/invitations/:token/accept
+     * Accept the invitation — creates the membership. Token is the only
+     * auth: knowing it implies access to the email account that received
+     * the invitation.
+     */
+    @Post(':token/accept')
+    async accept(@Param('token') token: string) {
+        try {
+            const member = await this.invitationService.accept(token);
+            return { address: member.address, role: member.role, joinedAt: member.joinedAt, groupId: member.groupId };
+        } catch (e) {
+            throw this.toHttp(e);
+        }
+    }
+
+    /**
+     * POST /api/pplns/invitations/:token/decline
+     * Decline (or revoke pending state). No auth — there's no incentive
+     * to decline on someone's behalf, and it lets the recipient dispose
+     * of an unwanted invitation even without email access.
+     */
+    @Post(':token/decline')
+    async decline(@Param('token') token: string) {
+        try {
+            await this.invitationService.decline(token);
+            return { ok: true };
+        } catch (e) {
+            throw this.toHttp(e);
+        }
+    }
+
+    private toHttp(e: any): HttpException {
+        if (e instanceof InvitationServiceError) {
+            const status = e.code === 'not-found' ? HttpStatus.NOT_FOUND
+                : e.code === 'expired' ? HttpStatus.GONE
+                : e.code === 'already-declined' || e.code === 'already-member' ? HttpStatus.CONFLICT
+                : HttpStatus.BAD_REQUEST;
+            return new HttpException({ code: e.code, message: e.message }, status);
+        }
+        return new HttpException({ code: 'internal', message: e?.message ?? 'unknown' }, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/controllers/pplns/pplns.controller.ts
+++ b/src/controllers/pplns/pplns.controller.ts
@@ -38,6 +38,19 @@ export class PplnsController {
     }
 
     /**
+     * GET /pplns/fees
+     * Pool-side fee configuration shared by PPLNS and group-solo payout paths.
+     * The UI reads this to render current fees on the groups-landing page
+     * without having to re-deploy when fees change. `feePercent` is a human
+     * percentage (e.g. 2 for 2%), `feeAddress` is the BTC address where the
+     * pool fee output lands in the coinbase transaction.
+     */
+    @Get('fees')
+    getFees() {
+        return this.pplnsService.getFeeConfig();
+    }
+
+    /**
      * GET /pplns/distribution
      * Current share distribution across all miners in the PPLNS window.
      */

--- a/src/migrations/1776200000000-AddEmailAndGroupInvitation.ts
+++ b/src/migrations/1776200000000-AddEmailAndGroupInvitation.ts
@@ -1,0 +1,82 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+/**
+ * Tables for the email-required payout-group invitation flow:
+ *   pplns_address_email      — verified address↔email bindings
+ *   pplns_email_verification — pending email-verify tokens (24h TTL)
+ *   pplns_group_invitation   — pending group invitations (7d TTL)
+ */
+export class AddEmailAndGroupInvitation1776200000000 implements MigrationInterface {
+    name = 'AddEmailAndGroupInvitation1776200000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // ── pplns_address_email ───────────────────────────────────────
+        await queryRunner.createTable(
+            new Table({
+                name: 'pplns_address_email',
+                columns: [
+                    { name: 'address', type: 'varchar', length: '62', isPrimary: true },
+                    { name: 'email', type: 'varchar', length: '320' },
+                    { name: 'verifiedAt', type: 'timestamp', isNullable: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                    { name: 'updatedAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                ],
+            }),
+            true,
+        );
+
+        // ── pplns_email_verification ──────────────────────────────────
+        await queryRunner.createTable(
+            new Table({
+                name: 'pplns_email_verification',
+                columns: [
+                    { name: 'token', type: 'varchar', length: '64', isPrimary: true },
+                    { name: 'address', type: 'varchar', length: '62' },
+                    { name: 'email', type: 'varchar', length: '320' },
+                    { name: 'createdAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                    { name: 'expiresAt', type: 'timestamp' },
+                ],
+            }),
+            true,
+        );
+
+        await queryRunner.createIndex(
+            'pplns_email_verification',
+            new TableIndex({ columnNames: ['address'] }),
+        );
+
+        // ── pplns_group_invitation ────────────────────────────────────
+        await queryRunner.createTable(
+            new Table({
+                name: 'pplns_group_invitation',
+                columns: [
+                    { name: 'token', type: 'varchar', length: '64', isPrimary: true },
+                    { name: 'groupId', type: 'varchar', length: '36' },
+                    { name: 'address', type: 'varchar', length: '62' },
+                    { name: 'email', type: 'varchar', length: '320' },
+                    { name: 'status', type: 'varchar', length: '16', default: "'pending'" },
+                    { name: 'createdAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                    { name: 'expiresAt', type: 'timestamp' },
+                    { name: 'respondedAt', type: 'timestamp', isNullable: true },
+                ],
+            }),
+            true,
+        );
+
+        await queryRunner.createIndex(
+            'pplns_group_invitation',
+            new TableIndex({ columnNames: ['groupId'] }),
+        );
+
+        await queryRunner.createIndex(
+            'pplns_group_invitation',
+            new TableIndex({ columnNames: ['address'] }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('pplns_group_invitation', true);
+        await queryRunner.dropTable('pplns_email_verification', true);
+        await queryRunner.dropTable('pplns_address_email', true);
+    }
+}

--- a/src/migrations/1776400000000-MakePplnsGroupBalancePkComposite.ts
+++ b/src/migrations/1776400000000-MakePplnsGroupBalancePkComposite.ts
@@ -1,0 +1,46 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Converts `pplns_group_balance` primary key from `address` to the composite
+ * `(address, groupId)`.
+ *
+ * Before the change, a miner moving between groups over time would mutate a
+ * single row (keyed by address alone) with whichever `groupId` happened to
+ * be written last by the application code. That coupled pending-balance
+ * rows across unrelated groups and caused sats earned in group B to be
+ * paid out from group A's next block.
+ *
+ * The composite key lets every (address, groupId) historical pairing keep
+ * its own row. At any one point in time a miner is a member of at most one
+ * group (enforced by the global unique index on pplns_group_member.address),
+ * so no single-point-in-time duplicates can occur — the migration can run
+ * on live data without a dedup step.
+ */
+export class MakePplnsGroupBalancePkComposite1776400000000 implements MigrationInterface {
+    name = 'MakePplnsGroupBalancePkComposite1776400000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('pplns_group_balance');
+        if (!table) return;
+
+        if (table.primaryColumns.length === 1 && table.primaryColumns[0].name === 'address') {
+            // Drop the single-column PK. TypeORM's dropPrimaryKey wants the
+            // current primary column names.
+            await queryRunner.dropPrimaryKey('pplns_group_balance');
+        }
+
+        // Re-create as composite. createPrimaryKey is idempotent-friendly:
+        // it just issues the ALTER TABLE ADD PRIMARY KEY.
+        await queryRunner.createPrimaryKey('pplns_group_balance', ['address', 'groupId']);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('pplns_group_balance');
+        if (!table) return;
+
+        if (table.primaryColumns.length > 0) {
+            await queryRunner.dropPrimaryKey('pplns_group_balance');
+        }
+        await queryRunner.createPrimaryKey('pplns_group_balance', ['address']);
+    }
+}

--- a/src/migrations/1776600000000-AddPplnsGroupForeignKeysAndExpiryIndexes.ts
+++ b/src/migrations/1776600000000-AddPplnsGroupForeignKeysAndExpiryIndexes.ts
@@ -20,6 +20,15 @@ export class AddPplnsGroupForeignKeysAndExpiryIndexes1776600000000 implements Mi
     name = 'AddPplnsGroupForeignKeysAndExpiryIndexes1776600000000';
 
     public async up(queryRunner: QueryRunner): Promise<void> {
+        // pplns_group_invitation.groupId was originally created as varchar(36)
+        // while pplns_group.id is uuid. Postgres refuses to FK across
+        // non-identical types, so convert the column first. The cast is
+        // safe because the only writer is GroupService.createGroup which
+        // always uses crypto.randomUUID().
+        await queryRunner.query(
+            `ALTER TABLE "pplns_group_invitation" ALTER COLUMN "groupId" TYPE uuid USING "groupId"::uuid`,
+        );
+
         const addGroupFk = async (tableName: string) => {
             const table = await queryRunner.getTable(tableName);
             if (!table) return;
@@ -87,5 +96,11 @@ export class AddPplnsGroupForeignKeysAndExpiryIndexes1776600000000 implements Mi
 
         await dropIndex('pplns_email_verification', 'IDX_pplns_email_verification_expiresAt');
         await dropIndex('pplns_group_invitation', 'IDX_pplns_group_invitation_expiresAt');
+
+        // Cast the invitation.groupId column back to varchar(36) to match
+        // the pre-migration schema.
+        await queryRunner.query(
+            `ALTER TABLE "pplns_group_invitation" ALTER COLUMN "groupId" TYPE varchar(36) USING "groupId"::text`,
+        );
     }
 }

--- a/src/migrations/1776600000000-AddPplnsGroupForeignKeysAndExpiryIndexes.ts
+++ b/src/migrations/1776600000000-AddPplnsGroupForeignKeysAndExpiryIndexes.ts
@@ -1,0 +1,91 @@
+import { MigrationInterface, QueryRunner, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Adds database-level referential integrity to the payout-group tables
+ * and speed-up indexes for the expiry-sweep cron.
+ *
+ * H4 (foreign keys): prior migrations created pplns_group_member,
+ * pplns_group_balance, pplns_group_block_history and pplns_group_invitation
+ * with a `groupId` column but no FK constraint. Deletion was app-enforced,
+ * which works today but leaves every future code path one forgotten
+ * cascade-delete away from orphans. With ON DELETE CASCADE the database
+ * guarantees children go when their group goes, regardless of which code
+ * path initiated the dissolve.
+ *
+ * H5 (expiresAt indexes): the hourly expiry-sweep cron filters by
+ * `expiresAt < NOW()`. Without an index that's a full scan on tables
+ * that grow linearly with invitation/verification volume.
+ */
+export class AddPplnsGroupForeignKeysAndExpiryIndexes1776600000000 implements MigrationInterface {
+    name = 'AddPplnsGroupForeignKeysAndExpiryIndexes1776600000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const addGroupFk = async (tableName: string) => {
+            const table = await queryRunner.getTable(tableName);
+            if (!table) return;
+            const already = table.foreignKeys.find(fk =>
+                fk.columnNames.length === 1
+                && fk.columnNames[0] === 'groupId'
+                && fk.referencedTableName === 'pplns_group',
+            );
+            if (already) return;
+            await queryRunner.createForeignKey(
+                tableName,
+                new TableForeignKey({
+                    columnNames: ['groupId'],
+                    referencedColumnNames: ['id'],
+                    referencedTableName: 'pplns_group',
+                    onDelete: 'CASCADE',
+                }),
+            );
+        };
+
+        await addGroupFk('pplns_group_member');
+        await addGroupFk('pplns_group_balance');
+        await addGroupFk('pplns_group_block_history');
+        await addGroupFk('pplns_group_invitation');
+
+        const addIndex = async (tableName: string, columnName: string, name: string) => {
+            const table = await queryRunner.getTable(tableName);
+            if (!table) return;
+            const already = table.indices.find(i => i.columnNames.length === 1 && i.columnNames[0] === columnName);
+            if (already) return;
+            await queryRunner.createIndex(
+                tableName,
+                new TableIndex({ name, columnNames: [columnName] }),
+            );
+        };
+
+        await addIndex('pplns_group_invitation', 'expiresAt', 'IDX_pplns_group_invitation_expiresAt');
+        await addIndex('pplns_email_verification', 'expiresAt', 'IDX_pplns_email_verification_expiresAt');
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const dropGroupFk = async (tableName: string) => {
+            const table = await queryRunner.getTable(tableName);
+            if (!table) return;
+            const fk = table.foreignKeys.find(f =>
+                f.columnNames.length === 1
+                && f.columnNames[0] === 'groupId'
+                && f.referencedTableName === 'pplns_group',
+            );
+            if (fk) await queryRunner.dropForeignKey(tableName, fk);
+        };
+
+        await dropGroupFk('pplns_group_invitation');
+        await dropGroupFk('pplns_group_block_history');
+        await dropGroupFk('pplns_group_balance');
+        await dropGroupFk('pplns_group_member');
+
+        const dropIndex = async (tableName: string, name: string) => {
+            const table = await queryRunner.getTable(tableName);
+            if (!table) return;
+            if (table.indices.find(i => i.name === name)) {
+                await queryRunner.dropIndex(tableName, name);
+            }
+        };
+
+        await dropIndex('pplns_email_verification', 'IDX_pplns_email_verification_expiresAt');
+        await dropIndex('pplns_group_invitation', 'IDX_pplns_group_invitation_expiresAt');
+    }
+}

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -60,8 +60,6 @@ export class StratumV1Client {
     private pendingSessionDifficulty: number | null = null;
     private deviceOnlineNotified = false;
     private deviceOfflineNotified = false;
-    /** Set during authorize if the address belongs to an active group. Activates group-solo mode for this session. */
-    private groupSoloGroupId: string | null = null;
 
     private entity: ClientEntity;
     private creatingEntity: Promise<void>;
@@ -443,16 +441,6 @@ export class StratumV1Client {
                     return;
                 }
 
-                // Group-solo detection: if this address is in an active group,
-                // switch this session into group-solo payout regardless of the port mode.
-                if (this.groupSoloService?.isEnabled()) {
-                    const groupEntry = this.groupSoloService.getGroupForAddress(authorizationMessage.address);
-                    if (groupEntry?.active) {
-                        this.groupSoloGroupId = groupEntry.groupId;
-                        console.log(`[StratumV1Client] Address ${authorizationMessage.address} is in active group ${groupEntry.groupId} — enabling group-solo payout`);
-                    }
-                }
-
                 {
                     this.clientAuthorization = authorizationMessage;
 
@@ -730,6 +718,29 @@ export class StratumV1Client {
         );
     }
 
+    /**
+     * Live lookup of the active group-id for this session's address. Returns null
+     * if group-solo isn't enabled, the address hasn't been authorized yet, or the
+     * address isn't a member of an active group. Called per-share/per-job because
+     * membership can change after connect (miner added to group while connected).
+     */
+    private activeGroupId(): string | null {
+        if (!this.groupSoloService?.isEnabled()) return null;
+        const address = this.clientAuthorization?.address;
+        if (!address) return null;
+        const entry = this.groupSoloService.getGroupForAddress(address);
+        return entry?.active ? entry.groupId : null;
+    }
+
+    /** Dispatch a rejected share to group-solo if the miner is currently in an active group. */
+    private async dispatchGroupReject(): Promise<void> {
+        if (!this.activeGroupId()) return;
+        await this.groupSoloService!.recordReject(
+            this.clientAuthorization.address,
+            this.sessionDifficulty,
+        );
+    }
+
     private async sendNewMiningJob(jobTemplate: IJobTemplate) {
         const jobStartTime = Date.now();
 
@@ -744,10 +755,11 @@ export class StratumV1Client {
             this.hashRate = this.statistics.hashRate;
         }
 
-        if (this.groupSoloGroupId && this.groupSoloService?.isEnabled()) {
+        const jobGroupId = this.activeGroupId();
+        if (jobGroupId) {
             // Group-solo takes precedence: per-group shared coinbase, PROP-style
-            payoutInformation = await this.groupSoloService.getPayoutDistribution(
-                this.groupSoloGroupId,
+            payoutInformation = await this.groupSoloService!.getPayoutDistribution(
+                jobGroupId,
                 jobTemplate.blockData.coinbasevalue,
             );
             this.noFee = false;
@@ -887,6 +899,7 @@ export class StratumV1Client {
                 eStratumErrorCode[eStratumErrorCode.DuplicateShare],
                 this.sessionDifficulty,
             );
+            await this.dispatchGroupReject();
             const err = new StratumErrorMessage(
                 submission.id,
                 eStratumErrorCode.DuplicateShare,
@@ -922,6 +935,7 @@ export class StratumV1Client {
                 eStratumErrorCode[eStratumErrorCode.JobNotFound],
                 this.sessionDifficulty,
             );
+            await this.dispatchGroupReject();
             const err = new StratumErrorMessage(
                 submission.id,
                 eStratumErrorCode.JobNotFound,
@@ -954,6 +968,7 @@ export class StratumV1Client {
                 eStratumErrorCode[eStratumErrorCode.JobNotFound],
                 this.sessionDifficulty,
             );
+            await this.dispatchGroupReject();
             console.warn(`Job template ${job.jobTemplateId} not found for job ${submission.jobId}`);
             delete this.stratumV1JobsService.jobs[submission.jobId];
             const err = new StratumErrorMessage(
@@ -1012,8 +1027,9 @@ export class StratumV1Client {
                     await this.addressSettingsCacheService.clear();
 
                     // Process group-solo payouts (finder's group gets the coinbase, round resets)
-                    if (this.groupSoloGroupId && this.groupSoloService?.isEnabled() && this.clientAuthorization) {
-                        await this.groupSoloService.onBlockFound(
+                    const foundGroupId = this.activeGroupId();
+                    if (foundGroupId) {
+                        await this.groupSoloService!.onBlockFound(
                             jobTemplate.blockData.height,
                             jobTemplate.blockData.coinbasevalue,
                             this.clientAuthorization.address,
@@ -1035,8 +1051,9 @@ export class StratumV1Client {
                 await this.clientStatisticsService.addAcceptedShare(this.entity, this.sessionDifficulty);
 
                 // Record share — group-solo takes precedence over port's payoutMode
-                if (this.groupSoloGroupId && this.groupSoloService?.isEnabled()) {
-                    await this.groupSoloService.recordShare(
+                const shareGroupId = this.activeGroupId();
+                if (shareGroupId) {
+                    await this.groupSoloService!.recordShare(
                         this.clientAuthorization.address,
                         this.sessionDifficulty,
                     );
@@ -1134,6 +1151,7 @@ export class StratumV1Client {
                 eStratumErrorCode[eStratumErrorCode.LowDifficultyShare],
                 this.sessionDifficulty,
             );
+            await this.dispatchGroupReject();
             const err = new StratumErrorMessage(
                 submission.id,
                 eStratumErrorCode.LowDifficultyShare,

--- a/src/models/StratumV2Client.ts
+++ b/src/models/StratumV2Client.ts
@@ -150,8 +150,6 @@ export class StratumV2Client {
 
   // Connection-level state
   private address: string | null = null;
-  /** Set during channel-open if the address belongs to an active group. Activates group-solo mode for this session. */
-  private groupSoloGroupId: string | null = null;
   private workerName: string = 'default';
   private userAgent: string = '';
   private vendorInfo: string = '';
@@ -519,8 +517,6 @@ export class StratumV2Client {
       return;
     }
 
-    this.detectGroupSoloMembership(rawAddress);
-
     // Multi-channel: subsequent channels must use same address
     if (this.address && this.address !== rawAddress) {
       const errorPayload = serializeOpenMiningChannelError({
@@ -657,8 +653,6 @@ export class StratumV2Client {
       this.destroySocket();
       return;
     }
-
-    this.detectGroupSoloMembership(rawAddress);
 
     // Multi-channel: subsequent channels must use same address
     if (this.address && this.address !== rawAddress) {
@@ -1460,11 +1454,12 @@ export class StratumV2Client {
         await this.addressSettingsCacheService.clear();
 
         // Group-solo takes precedence — finder's group gets the coinbase, round resets
-        if (this.groupSoloGroupId && this.groupSoloService?.isEnabled() && jobTemplate && this.address) {
-          await this.groupSoloService.onBlockFound(
+        const foundGroupId = this.activeGroupId();
+        if (foundGroupId && jobTemplate) {
+          await this.groupSoloService!.onBlockFound(
             jobTemplate.blockData.height,
             jobTemplate.blockData.coinbasevalue,
-            this.address,
+            this.address!,
           );
         } else if (this.portConfig.payoutMode === 'pplns' && this.pplnsService?.isEnabled() && jobTemplate) {
           // Process PPLNS payouts (update pending balances)
@@ -1482,8 +1477,9 @@ export class StratumV2Client {
       await this.clientStatisticsService.addAcceptedShare(this.entity!, jobDifficulty);
 
       // Record share — group-solo takes precedence over port's payoutMode
-      if (this.groupSoloGroupId && this.groupSoloService?.isEnabled()) {
-        await this.groupSoloService.recordShare(this.address!, jobDifficulty);
+      const shareGroupId = this.activeGroupId();
+      if (shareGroupId) {
+        await this.groupSoloService!.recordShare(this.address!, jobDifficulty);
       } else if (this.portConfig.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
         await this.pplnsService.recordShare(this.address!, jobDifficulty);
       }
@@ -1729,7 +1725,7 @@ export class StratumV2Client {
     }
 
     // Group-solo mode: per-group shared coinbase — also async
-    if (this.groupSoloGroupId && this.groupSoloService?.isEnabled() && blockRewardSats) {
+    if (blockRewardSats && this.activeGroupId()) {
       this.noFee = false;
       return null;
     }
@@ -1756,8 +1752,9 @@ export class StratumV2Client {
 
   private async buildPayoutInformationAsync(blockRewardSats: number): Promise<{ address: string; percent: number }[] | null> {
     // Group-solo takes precedence over PPLNS.
-    if (this.groupSoloGroupId && this.groupSoloService?.isEnabled()) {
-      const distribution = await this.groupSoloService.getPayoutDistribution(this.groupSoloGroupId, blockRewardSats);
+    const asyncGroupId = this.activeGroupId();
+    if (asyncGroupId) {
+      const distribution = await this.groupSoloService!.getPayoutDistribution(asyncGroupId, blockRewardSats);
       if (distribution && distribution.length > 0) {
         this.noFee = false;
         return distribution;
@@ -1774,16 +1771,16 @@ export class StratumV2Client {
   }
 
   /**
-   * If the address is in an active group, switch this session into group-solo payout.
-   * Otherwise fall back to the port's configured payoutMode (solo/pplns).
+   * Live lookup of the active group-id for this session's address. Returns null
+   * if group-solo isn't enabled, no address is set yet, or the address isn't in
+   * an active group. Called per-share/per-job because membership can change
+   * after channel-open (miner added to group while connected).
    */
-  private detectGroupSoloMembership(address: string): void {
-    if (!this.groupSoloService?.isEnabled()) return;
-    const entry = this.groupSoloService.getGroupForAddress(address);
-    if (entry?.active) {
-      this.groupSoloGroupId = entry.groupId;
-      console.log(`[SV2 ${this.sessionId}] Address ${address} is in active group ${entry.groupId} — enabling group-solo payout`);
-    }
+  private activeGroupId(): string | null {
+    if (!this.groupSoloService?.isEnabled()) return null;
+    if (!this.address) return null;
+    const entry = this.groupSoloService.getGroupForAddress(this.address);
+    return entry?.active ? entry.groupId : null;
   }
 
   private async sendNewMiningJob(jobTemplate: IJobTemplate, sendPrevHash: boolean, channelId?: number): Promise<void> {
@@ -2089,6 +2086,13 @@ export class StratumV2Client {
         errorType,
         diff,
       );
+    }
+    // Group-solo: record against the group's round counters if this miner is
+    // currently a member of an active group (live lookup — membership can
+    // change after channel-open).
+    const rejGroupId = this.activeGroupId();
+    if (rejGroupId && this.address) {
+      await this.groupSoloService!.recordReject(this.address, diff);
     }
   }
 

--- a/src/services/address-email.service.ts
+++ b/src/services/address-email.service.ts
@@ -7,6 +7,7 @@ import * as crypto from 'crypto';
 import { AddressEmailEntity } from '../ORM/address-email/address-email.entity';
 import { EmailVerificationEntity } from '../ORM/address-email/email-verification.entity';
 import { EmailService } from './email.service';
+import { normalizeBtcAddress } from '../utils/btc-address.utils';
 
 const VERIFICATION_TTL_HOURS = 24;
 // Loose RFC 5322 sanity check, not a full validator. The MX/handshake
@@ -47,7 +48,9 @@ export class AddressEmailService {
      * an already-verified binding until the new one is confirmed.
      */
     async register(address: string, email: string): Promise<{ token: string }> {
-        if (!address) throw new AddressEmailServiceError('invalid-address', 'Address required');
+        const normalizedAddress = normalizeBtcAddress(address);
+        if (!normalizedAddress) throw new AddressEmailServiceError('invalid-address', 'Address required');
+        address = normalizedAddress;
         const normalizedEmail = (email ?? '').trim().toLowerCase();
         if (!EMAIL_RE.test(normalizedEmail)) {
             throw new AddressEmailServiceError('invalid-email', 'Email format invalid');
@@ -125,7 +128,7 @@ export class AddressEmailService {
      * count.
      */
     async getVerified(address: string): Promise<AddressEmailEntity | null> {
-        const row = await this.bindingRepo.findOneBy({ address });
+        const row = await this.bindingRepo.findOneBy({ address: normalizeBtcAddress(address) });
         if (!row || !row.verifiedAt) return null;
         return row;
     }

--- a/src/services/address-email.service.ts
+++ b/src/services/address-email.service.ts
@@ -1,0 +1,151 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThan } from 'typeorm';
+import * as crypto from 'crypto';
+import { AddressEmailEntity } from '../ORM/address-email/address-email.entity';
+import { EmailVerificationEntity } from '../ORM/address-email/email-verification.entity';
+import { EmailService } from './email.service';
+
+const VERIFICATION_TTL_HOURS = 24;
+// Loose RFC 5322 sanity check, not a full validator. The MX/handshake
+// happens at SMTP-send time anyway — this just rejects obvious garbage.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export class AddressEmailServiceError extends Error {
+    constructor(public readonly code: string, message: string) {
+        super(message);
+    }
+}
+
+/**
+ * Manages the bidirectional binding between a BTC mining address and an
+ * email account.  An address is "email-verified" once the user has clicked
+ * the link sent to the email they submitted.  Group invitations require a
+ * verified email — that's the out-of-band trust anchor that prevents a
+ * malicious admin from silently adding random addresses.
+ */
+@Injectable()
+export class AddressEmailService {
+
+    constructor(
+        @InjectRepository(AddressEmailEntity)
+        private readonly bindingRepo: Repository<AddressEmailEntity>,
+        @InjectRepository(EmailVerificationEntity)
+        private readonly verificationRepo: Repository<EmailVerificationEntity>,
+        private readonly emailService: EmailService,
+        private readonly config: ConfigService,
+    ) {}
+
+    /**
+     * Submit an email for an address. Sends a verification email and stores
+     * a pending token. Re-submitting a different email overwrites any
+     * existing pending verifications for the address but does NOT erase
+     * an already-verified binding until the new one is confirmed.
+     */
+    async register(address: string, email: string): Promise<{ token: string }> {
+        if (!address) throw new AddressEmailServiceError('invalid-address', 'Address required');
+        const normalizedEmail = (email ?? '').trim().toLowerCase();
+        if (!EMAIL_RE.test(normalizedEmail)) {
+            throw new AddressEmailServiceError('invalid-email', 'Email format invalid');
+        }
+        if (!this.emailService.isEnabled()) {
+            throw new AddressEmailServiceError('email-disabled', 'Email service not configured on server');
+        }
+
+        // Drop prior pending tokens for this address — only the latest one is
+        // valid. Existing verified binding (if any) stays until the new one
+        // is confirmed.
+        await this.verificationRepo.delete({ address });
+
+        const token = this.generateToken();
+        const expiresAt = new Date(Date.now() + VERIFICATION_TTL_HOURS * 60 * 60 * 1000);
+        await this.verificationRepo.save(this.verificationRepo.create({
+            token,
+            address,
+            email: normalizedEmail,
+            expiresAt,
+        }));
+
+        const verifyUrl = `${this.poolBaseUrl()}/email/verify/${token}`;
+        await this.emailService.sendVerification({
+            to: normalizedEmail,
+            address,
+            verifyUrl,
+            expiresAt,
+        });
+        return { token };
+    }
+
+    /**
+     * Confirm an email by consuming a verification token. Idempotent on
+     * the resulting binding (re-clicking the same link after success
+     * returns the binding without erroring).
+     */
+    async verify(token: string): Promise<AddressEmailEntity> {
+        const pending = await this.verificationRepo.findOneBy({ token });
+        if (!pending) {
+            throw new AddressEmailServiceError('not-found', 'Verification token unknown or already used');
+        }
+        if (pending.expiresAt.getTime() < Date.now()) {
+            await this.verificationRepo.delete({ token });
+            throw new AddressEmailServiceError('expired', 'Verification link expired — request a new one');
+        }
+
+        // Replace any existing binding for this address.
+        const existing = await this.bindingRepo.findOneBy({ address: pending.address });
+        let saved: AddressEmailEntity;
+        if (existing) {
+            existing.email = pending.email;
+            existing.verifiedAt = new Date();
+            saved = await this.bindingRepo.save(existing);
+        } else {
+            saved = await this.bindingRepo.save(this.bindingRepo.create({
+                address: pending.address,
+                email: pending.email,
+                verifiedAt: new Date(),
+            }));
+        }
+
+        // Consume token and any stale tokens for the same address (defensive).
+        await this.verificationRepo.delete({ address: pending.address });
+        return saved;
+    }
+
+    /**
+     * Lookup the verified-email binding for an address, or null if none.
+     * Pending (un-verified) tokens are ignored — only confirmed bindings
+     * count.
+     */
+    async getVerified(address: string): Promise<AddressEmailEntity | null> {
+        const row = await this.bindingRepo.findOneBy({ address });
+        if (!row || !row.verifiedAt) return null;
+        return row;
+    }
+
+    /**
+     * Periodic cleanup hook — drops expired verification tokens. Not wired
+     * to a scheduler here; call from a cron or accept the small DB bloat
+     * (rows are tiny). Returns count of deleted rows for logging.
+     */
+    async purgeExpiredTokens(): Promise<number> {
+        const result = await this.verificationRepo.delete({
+            expiresAt: LessThan(new Date()),
+        });
+        return result.affected ?? 0;
+    }
+
+    private generateToken(): string {
+        // 32 bytes = 256 bits, base64url-encoded → 43 chars, URL-safe, fits
+        // in our 64-char column with margin.
+        return crypto.randomBytes(32).toString('base64url');
+    }
+
+    private poolBaseUrl(): string {
+        const url = this.config.get<string>('POOL_BASE_URL');
+        if (!url) {
+            throw new AddressEmailServiceError('config-missing', 'POOL_BASE_URL is not set');
+        }
+        return url.replace(/\/+$/, '');
+    }
+}

--- a/src/services/address-email.service.ts
+++ b/src/services/address-email.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { Interval } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThan } from 'typeorm';
 import * as crypto from 'crypto';
@@ -27,6 +28,8 @@ export class AddressEmailServiceError extends Error {
  */
 @Injectable()
 export class AddressEmailService {
+
+    private readonly logger = new Logger(AddressEmailService.name);
 
     constructor(
         @InjectRepository(AddressEmailEntity)
@@ -128,15 +131,22 @@ export class AddressEmailService {
     }
 
     /**
-     * Periodic cleanup hook — drops expired verification tokens. Not wired
-     * to a scheduler here; call from a cron or accept the small DB bloat
-     * (rows are tiny). Returns count of deleted rows for logging.
+     * Periodic cleanup — drops expired verification tokens. Fires hourly
+     * via @Interval; also safe to call directly.
      */
+    @Interval(60 * 60 * 1000)
     async purgeExpiredTokens(): Promise<number> {
-        const result = await this.verificationRepo.delete({
-            expiresAt: LessThan(new Date()),
-        });
-        return result.affected ?? 0;
+        try {
+            const result = await this.verificationRepo.delete({
+                expiresAt: LessThan(new Date()),
+            });
+            const n = result.affected ?? 0;
+            if (n > 0) this.logger.log(`Purged ${n} expired verification tokens`);
+            return n;
+        } catch (err) {
+            this.logger.warn(`purgeExpiredTokens failed: ${(err as Error).message}`);
+            return 0;
+        }
     }
 
     private generateToken(): string {

--- a/src/services/address-email.service.ts
+++ b/src/services/address-email.service.ts
@@ -67,7 +67,11 @@ export class AddressEmailService {
             expiresAt,
         }));
 
-        const verifyUrl = `${this.poolBaseUrl()}/email/verify/${token}`;
+        // UI uses HashLocationStrategy — the routable path has to live in
+        // the URL fragment (after `#`). Without the hash, Caddy+Angular
+        // resolve only the bare "/" and land the user on the homepage,
+        // because the path part is never read by the router.
+        const verifyUrl = `${this.poolBaseUrl()}/#/email/verify/${token}`;
         await this.emailService.sendVerification({
             to: normalizedEmail,
             address,

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -1,0 +1,272 @@
+import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as nodemailer from 'nodemailer';
+import type { Transporter } from 'nodemailer';
+
+interface InvitationEmailContext {
+    to: string;
+    address: string;
+    groupName: string;
+    inviterAddress: string;
+    acceptUrl: string;
+    declineUrl: string;
+    expiresAt: Date;
+}
+
+interface VerificationEmailContext {
+    to: string;
+    address: string;
+    verifyUrl: string;
+    expiresAt: Date;
+}
+
+/**
+ * Sends transactional emails for the address-email-binding and group-invitation
+ * flows. Reads SMTP credentials from env (SMTP_HOST/PORT/USER/PASS/FROM) and
+ * the public UI base URL from POOL_BASE_URL. Uses inline-styled HTML templates
+ * matching the dashboard's dark indigo theme so the email feels like part of
+ * the app, not a separate service.
+ */
+@Injectable()
+export class EmailService implements OnModuleInit {
+
+    private readonly logger = new Logger(EmailService.name);
+    private transport: Transporter | null = null;
+    private fromAddress: string;
+    private enabled = false;
+
+    constructor(private readonly config: ConfigService) {}
+
+    onModuleInit(): void {
+        const host = this.config.get<string>('SMTP_HOST');
+        const port = parseInt(this.config.get<string>('SMTP_PORT') ?? '587', 10);
+        const secure = (this.config.get<string>('SMTP_SECURE') ?? 'false').toLowerCase() === 'true';
+        const user = this.config.get<string>('SMTP_USER');
+        const pass = this.config.get<string>('SMTP_PASS');
+        const from = this.config.get<string>('SMTP_FROM');
+
+        if (!host || !user || !pass || !from) {
+            this.logger.warn('EmailService disabled: SMTP_HOST/USER/PASS/FROM not all set. Invitation + verification emails will fail until configured.');
+            return;
+        }
+
+        this.transport = nodemailer.createTransport({
+            host,
+            port,
+            secure,
+            auth: { user, pass },
+        });
+        this.fromAddress = from;
+        this.enabled = true;
+        this.logger.log(`EmailService configured (host=${host}:${port}, secure=${secure}, from=${from})`);
+    }
+
+    isEnabled(): boolean {
+        return this.enabled;
+    }
+
+    async sendVerification(ctx: VerificationEmailContext): Promise<void> {
+        if (!this.enabled || !this.transport) {
+            throw new Error('EmailService not configured');
+        }
+        const subject = 'Confirm your email address — Blitz Pool';
+        const html = renderVerificationHtml(ctx);
+        const text = renderVerificationText(ctx);
+        await this.transport.sendMail({
+            from: this.fromAddress,
+            to: ctx.to,
+            subject,
+            html,
+            text,
+        });
+    }
+
+    async sendInvitation(ctx: InvitationEmailContext): Promise<void> {
+        if (!this.enabled || !this.transport) {
+            throw new Error('EmailService not configured');
+        }
+        const subject = `Invitation to join ${ctx.groupName} — Blitz Pool`;
+        const html = renderInvitationHtml(ctx);
+        const text = renderInvitationText(ctx);
+        await this.transport.sendMail({
+            from: this.fromAddress,
+            to: ctx.to,
+            subject,
+            html,
+            text,
+        });
+    }
+}
+
+// ── Theme ────────────────────────────────────────────────────────────
+//
+// Inline-styled HTML — email clients strip <style> tags, so colours/fonts
+// have to live on each element. Palette mirrors the dashboard's
+// mdc-dark-indigo theme:
+//   surface: #1e1e1e (page bg)
+//   card:    #2a2a2a
+//   border:  #3a3a3a
+//   primary: #9FA8DA
+//   text:    #ffffff / #cfd8dc / #888
+
+const COLOR_BG = '#1e1e1e';
+const COLOR_CARD = '#2a2a2a';
+const COLOR_BORDER = '#3a3a3a';
+const COLOR_PRIMARY = '#9FA8DA';
+const COLOR_PRIMARY_TEXT = '#1a1a1a';
+const COLOR_TEXT = '#ffffff';
+const COLOR_MUTED = '#9e9e9e';
+
+function shellHtml(title: string, bodyHtml: string): string {
+    return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+</head>
+<body style="margin:0;padding:0;background:${COLOR_BG};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:${COLOR_TEXT};">
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background:${COLOR_BG};padding:32px 16px;">
+  <tr><td align="center">
+    <table role="presentation" width="600" cellspacing="0" cellpadding="0" border="0" style="max-width:600px;width:100%;background:${COLOR_CARD};border:1px solid ${COLOR_BORDER};border-radius:8px;overflow:hidden;">
+      <tr><td style="padding:24px 32px;border-bottom:1px solid ${COLOR_BORDER};">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+          <tr>
+            <td style="font-size:20px;font-weight:600;color:${COLOR_TEXT};">⚡ Blitz Pool</td>
+            <td align="right" style="font-size:12px;color:${COLOR_MUTED};">Mining Pool</td>
+          </tr>
+        </table>
+      </td></tr>
+      <tr><td style="padding:32px;">
+        ${bodyHtml}
+      </td></tr>
+      <tr><td style="padding:20px 32px;border-top:1px solid ${COLOR_BORDER};font-size:11px;color:${COLOR_MUTED};line-height:1.5;">
+        This is a transactional email from Blitz Pool. If you did not expect this message you can safely ignore it — no action will be taken.
+      </td></tr>
+    </table>
+  </td></tr>
+</table>
+</body>
+</html>`;
+}
+
+function buttonHtml(href: string, label: string, primary = true): string {
+    if (primary) {
+        return `<a href="${escapeAttr(href)}" style="display:inline-block;background:${COLOR_PRIMARY};color:${COLOR_PRIMARY_TEXT};padding:12px 28px;border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;">${escapeHtml(label)}</a>`;
+    }
+    return `<a href="${escapeAttr(href)}" style="display:inline-block;background:transparent;color:${COLOR_TEXT};padding:12px 28px;border-radius:6px;text-decoration:none;font-weight:500;font-size:14px;border:1px solid ${COLOR_BORDER};">${escapeHtml(label)}</a>`;
+}
+
+function renderVerificationHtml(ctx: VerificationEmailContext): string {
+    const expires = ctx.expiresAt.toUTCString();
+    const body = `
+<h1 style="margin:0 0 16px;font-size:22px;font-weight:600;color:${COLOR_TEXT};">Confirm your email address</h1>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.6;color:${COLOR_TEXT};">
+  This email is being bound to mining address:
+</p>
+<p style="margin:0 0 24px;padding:12px 16px;background:${COLOR_BG};border-radius:6px;font-family:'Roboto Mono',monospace;font-size:13px;color:${COLOR_PRIMARY};word-break:break-all;">
+  ${escapeHtml(ctx.address)}
+</p>
+<p style="margin:0 0 24px;font-size:14px;line-height:1.6;color:${COLOR_TEXT};">
+  Click the button below to confirm. Once confirmed, payout-group admins will be able to invite this address into their group.
+</p>
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin:0 0 24px;">
+  <tr><td>${buttonHtml(ctx.verifyUrl, 'Confirm email')}</td></tr>
+</table>
+<p style="margin:0 0 8px;font-size:12px;color:${COLOR_MUTED};">
+  Or paste this link into your browser:
+</p>
+<p style="margin:0 0 24px;font-size:12px;color:${COLOR_MUTED};word-break:break-all;">
+  <a href="${escapeAttr(ctx.verifyUrl)}" style="color:${COLOR_PRIMARY};text-decoration:underline;">${escapeHtml(ctx.verifyUrl)}</a>
+</p>
+<p style="margin:0;font-size:12px;color:${COLOR_MUTED};">
+  Link expires ${escapeHtml(expires)}.
+</p>
+`;
+    return shellHtml('Confirm your email address', body);
+}
+
+function renderVerificationText(ctx: VerificationEmailContext): string {
+    return [
+        `Confirm your email for Blitz Pool`,
+        ``,
+        `Address: ${ctx.address}`,
+        ``,
+        `Click to confirm: ${ctx.verifyUrl}`,
+        ``,
+        `Link expires ${ctx.expiresAt.toUTCString()}.`,
+        ``,
+        `If you didn't request this, ignore the email.`,
+    ].join('\n');
+}
+
+function renderInvitationHtml(ctx: InvitationEmailContext): string {
+    const expires = ctx.expiresAt.toUTCString();
+    const body = `
+<h1 style="margin:0 0 16px;font-size:22px;font-weight:600;color:${COLOR_TEXT};">Group invitation</h1>
+<p style="margin:0 0 24px;font-size:14px;line-height:1.6;color:${COLOR_TEXT};">
+  You've been invited to join the payout group <strong style="color:${COLOR_PRIMARY};">${escapeHtml(ctx.groupName)}</strong>.
+</p>
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="margin:0 0 24px;background:${COLOR_BG};border-radius:6px;">
+  <tr><td style="padding:16px;">
+    <p style="margin:0 0 8px;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:${COLOR_MUTED};">Your address</p>
+    <p style="margin:0 0 16px;font-family:'Roboto Mono',monospace;font-size:13px;color:${COLOR_PRIMARY};word-break:break-all;">
+      ${escapeHtml(ctx.address)}
+    </p>
+    <p style="margin:0 0 8px;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:${COLOR_MUTED};">Invited by</p>
+    <p style="margin:0;font-family:'Roboto Mono',monospace;font-size:13px;color:${COLOR_TEXT};word-break:break-all;">
+      ${escapeHtml(ctx.inviterAddress)}
+    </p>
+  </td></tr>
+</table>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.6;color:${COLOR_TEXT};">
+  When you accept, your mining address joins this group and future blocks you find will be paid out via the group's PROP-style coinbase split.
+</p>
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin:0 0 24px;">
+  <tr>
+    <td style="padding-right:12px;">${buttonHtml(ctx.acceptUrl, 'Accept invitation')}</td>
+    <td>${buttonHtml(ctx.declineUrl, 'Decline', false)}</td>
+  </tr>
+</table>
+<p style="margin:0 0 8px;font-size:12px;color:${COLOR_MUTED};">
+  Or copy these links:
+</p>
+<p style="margin:0 0 6px;font-size:12px;color:${COLOR_MUTED};word-break:break-all;">
+  Accept: <a href="${escapeAttr(ctx.acceptUrl)}" style="color:${COLOR_PRIMARY};text-decoration:underline;">${escapeHtml(ctx.acceptUrl)}</a>
+</p>
+<p style="margin:0 0 24px;font-size:12px;color:${COLOR_MUTED};word-break:break-all;">
+  Decline: <a href="${escapeAttr(ctx.declineUrl)}" style="color:${COLOR_PRIMARY};text-decoration:underline;">${escapeHtml(ctx.declineUrl)}</a>
+</p>
+<p style="margin:0;font-size:12px;color:${COLOR_MUTED};">
+  Invitation expires ${escapeHtml(expires)}. If you don't recognise the inviter, decline.
+</p>
+`;
+    return shellHtml(`Invitation to join ${ctx.groupName}`, body);
+}
+
+function renderInvitationText(ctx: InvitationEmailContext): string {
+    return [
+        `You've been invited to join the payout group "${ctx.groupName}" on Blitz Pool.`,
+        ``,
+        `Your address: ${ctx.address}`,
+        `Invited by:   ${ctx.inviterAddress}`,
+        ``,
+        `Accept:  ${ctx.acceptUrl}`,
+        `Decline: ${ctx.declineUrl}`,
+        ``,
+        `Invitation expires ${ctx.expiresAt.toUTCString()}.`,
+        `If you don't recognise the inviter, decline.`,
+    ].join('\n');
+}
+
+function escapeHtml(s: string): string {
+    return s.replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function escapeAttr(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -85,7 +85,7 @@ export class EmailService implements OnModuleInit {
         if (!this.enabled || !this.transport) {
             throw new Error('EmailService not configured');
         }
-        const subject = `Invitation to join ${ctx.groupName} — Blitz Pool`;
+        const subject = `Invitation to join ${sanitizeHeader(ctx.groupName)} — Blitz Pool`;
         const html = renderInvitationHtml(ctx);
         const text = renderInvitationText(ctx);
         await this.transport.sendMail({
@@ -235,12 +235,12 @@ function renderInvitationHtml(ctx: InvitationEmailContext): string {
   Invitation expires ${escapeHtml(expires)}. If you don't recognise the inviter, decline.
 </p>
 `;
-    return shellHtml(`Invitation to join ${ctx.groupName}`, body);
+    return shellHtml(`Invitation to join ${sanitizeHeader(ctx.groupName)}`, body);
 }
 
 function renderInvitationText(ctx: InvitationEmailContext): string {
     return [
-        `You've been invited to join the payout group "${ctx.groupName}" on Blitz Pool.`,
+        `You've been invited to join the payout group "${sanitizeHeader(ctx.groupName)}" on Blitz Pool.`,
         ``,
         `Your address: ${ctx.address}`,
         `Invited by:   ${ctx.inviterAddress}`,
@@ -250,6 +250,16 @@ function renderInvitationText(ctx: InvitationEmailContext): string {
         `Invitation expires ${ctx.expiresAt.toUTCString()}.`,
         `If you don't recognise the inviter, decline.`,
     ].join('\n');
+}
+
+/**
+ * Strip characters that could break email headers (Subject, body section
+ * markers). Defense-in-depth — the group-name input is already validated
+ * at `GroupService.createGroup`, but any future caller that forgets to
+ * validate would still produce a safe header through this helper.
+ */
+function sanitizeHeader(s: string): string {
+    return (s ?? '').replace(/[\r\n\0]/g, ' ').slice(0, 200);
 }
 
 function escapeHtml(s: string): string {

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -8,8 +8,8 @@ interface InvitationEmailContext {
     address: string;
     groupName: string;
     inviterAddress: string;
-    acceptUrl: string;
-    declineUrl: string;
+    /** UI page where the recipient reviews the invitation and clicks Accept or Decline. */
+    inviteUrl: string;
     expiresAt: Date;
 }
 
@@ -220,22 +220,16 @@ function renderInvitationHtml(ctx: InvitationEmailContext): string {
   </td></tr>
 </table>
 <p style="margin:0 0 16px;font-size:14px;line-height:1.6;color:${COLOR_TEXT};">
-  When you accept, your mining address joins this group and future blocks you find will be paid out via the group's PROP-style coinbase split.
+  Open the invitation page to review it and accept or decline. When you accept, your mining address joins this group and future blocks you find will be paid out via the group's PROP-style coinbase split.
 </p>
 <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin:0 0 24px;">
-  <tr>
-    <td style="padding-right:12px;">${buttonHtml(ctx.acceptUrl, 'Accept invitation')}</td>
-    <td>${buttonHtml(ctx.declineUrl, 'Decline', false)}</td>
-  </tr>
+  <tr><td>${buttonHtml(ctx.inviteUrl, 'Open invitation')}</td></tr>
 </table>
 <p style="margin:0 0 8px;font-size:12px;color:${COLOR_MUTED};">
-  Or copy these links:
-</p>
-<p style="margin:0 0 6px;font-size:12px;color:${COLOR_MUTED};word-break:break-all;">
-  Accept: <a href="${escapeAttr(ctx.acceptUrl)}" style="color:${COLOR_PRIMARY};text-decoration:underline;">${escapeHtml(ctx.acceptUrl)}</a>
+  Or paste this link into your browser:
 </p>
 <p style="margin:0 0 24px;font-size:12px;color:${COLOR_MUTED};word-break:break-all;">
-  Decline: <a href="${escapeAttr(ctx.declineUrl)}" style="color:${COLOR_PRIMARY};text-decoration:underline;">${escapeHtml(ctx.declineUrl)}</a>
+  <a href="${escapeAttr(ctx.inviteUrl)}" style="color:${COLOR_PRIMARY};text-decoration:underline;">${escapeHtml(ctx.inviteUrl)}</a>
 </p>
 <p style="margin:0;font-size:12px;color:${COLOR_MUTED};">
   Invitation expires ${escapeHtml(expires)}. If you don't recognise the inviter, decline.
@@ -251,8 +245,7 @@ function renderInvitationText(ctx: InvitationEmailContext): string {
         `Your address: ${ctx.address}`,
         `Invited by:   ${ctx.inviterAddress}`,
         ``,
-        `Accept:  ${ctx.acceptUrl}`,
-        `Decline: ${ctx.declineUrl}`,
+        `Open the invitation: ${ctx.inviteUrl}`,
         ``,
         `Invitation expires ${ctx.expiresAt.toUTCString()}.`,
         `If you don't recognise the inviter, decline.`,

--- a/src/services/group-solo-regtest-lifecycle.spec.ts
+++ b/src/services/group-solo-regtest-lifecycle.spec.ts
@@ -1,0 +1,434 @@
+/**
+ * Group-Solo Regtest Integration Tests — Lifecycle scenarios.
+ *
+ * Three scenarios exercised against a live Bitcoin Core regtest node,
+ * each ending in a block submit so we prove the coinbase math matches
+ * what bitcoind will accept:
+ *
+ *   1. kick-redistribute  — kicking a member flushes their pending into
+ *                            the remaining members; on the next block
+ *                            the coinbase has no output for the kicked
+ *                            miner and the survivors' pending carries
+ *                            the redistribution.
+ *
+ *   2. dust-fee-gate      — when feePercent * blockRewardSats < 546 sat
+ *                            the fee output is silently dropped and
+ *                            miners keep 100 % of the block. The block
+ *                            must still validate with the reduced
+ *                            output set.
+ *
+ *   3. snapshot-persist   — getPayoutDistribution writes the snapshot to
+ *                            Redis; we spin up a fresh GroupSoloService
+ *                            instance (simulating a pool restart), feed
+ *                            it the same Redis backing store, and call
+ *                            onBlockFound. It must use the persisted
+ *                            snapshot, not the current-window fallback.
+ *
+ * Block builder copied from group-solo-regtest.spec.ts — same
+ * invariants: height ≥ 17 for BIP34 scriptSig encoding, witness
+ * commitment computed over (dummyCoinbase + template transactions),
+ * block submitted with block.toHex(false) (no witnesses on outer
+ * serialization; Core picks up witnesses from the txs themselves).
+ */
+
+import * as bitcoinjs from 'bitcoinjs-lib';
+import * as http from 'http';
+import { GroupSoloService } from './group-solo.service';
+
+const RPC_URL = 'http://127.0.0.1:18443';
+const RPC_USER = 'test';
+const RPC_PASS = 'test';
+const NETWORK = bitcoinjs.networks.regtest;
+
+const ADDR_FEE = 'bcrt1qqj0r5w2ua3pe0sh6gthvfeegvwsa3t4edumqzf';
+const ADDR_ALICE = 'bcrt1q2jf90sp25mt4pte5swkr4cujpj5d8zzwdt09fq';
+const ADDR_BOB = 'bcrt1qt2amqww2n3dcz3ckx6nlentvm9e6rpxqrfmvl7';
+const ADDR_CHARLIE = 'bcrt1qlppw7cnqspnky6qzv8p2n468lpvwuct7ehp7l2';
+
+// ── RPC ────────────────────────────────────────────────────────────
+
+function rpcCall(method: string, params: any[] = []): Promise<any> {
+    return new Promise((resolve, reject) => {
+        const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method, params });
+        const auth = Buffer.from(`${RPC_USER}:${RPC_PASS}`).toString('base64');
+        const req = http.request(RPC_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Basic ${auth}` },
+        }, (res) => {
+            let data = '';
+            res.on('data', (c) => data += c);
+            res.on('end', () => {
+                try {
+                    const parsed = JSON.parse(data);
+                    if (parsed.error) reject(new Error(`RPC: ${JSON.stringify(parsed.error)}`));
+                    else resolve(parsed.result);
+                } catch (e) {
+                    reject(new Error(`Invalid JSON: ${data}`));
+                }
+            });
+        });
+        req.on('error', reject);
+        req.write(body);
+        req.end();
+    });
+}
+
+// ── Shared mock stack ──────────────────────────────────────────────
+
+function createMockRedis() {
+    const store = new Map<string, string>();
+    const zsets = new Map<string, { score: number; value: string }[]>();
+    const hashes = new Map<string, Map<string, string>>();
+    const getZ = (key: string) => {
+        if (!zsets.has(key)) zsets.set(key, []);
+        return zsets.get(key)!;
+    };
+    const getH = (key: string) => {
+        if (!hashes.has(key)) hashes.set(key, new Map());
+        return hashes.get(key)!;
+    };
+    return {
+        incr: async (key: string) => {
+            const v = parseInt(store.get(key) ?? '0', 10) + 1;
+            store.set(key, v.toString());
+            return v;
+        },
+        get: async (key: string) => store.get(key) ?? null,
+        set: async (key: string, value: string, _opts?: any) => { store.set(key, value); },
+        del: async (key: string) => { store.delete(key); zsets.delete(key); hashes.delete(key); },
+        expire: async () => 1,
+        incrByFloat: async (key: string, amount: number) => {
+            const v = parseFloat(store.get(key) ?? '0') + amount;
+            store.set(key, v.toString());
+            return v;
+        },
+        zAdd: async (key: string, entry: { score: number; value: string }) => {
+            const z = getZ(key);
+            z.push(entry);
+            z.sort((a, b) => a.score - b.score);
+        },
+        zRange: async (key: string, start: number, end: number) => {
+            const z = getZ(key);
+            const e = end === -1 ? z.length - 1 : end;
+            return z.slice(start, e + 1).map(x => x.value);
+        },
+        zRem: async (key: string, value: string) => {
+            const z = getZ(key);
+            const idx = z.findIndex(e => e.value === value);
+            if (idx >= 0) z.splice(idx, 1);
+        },
+        hSet: async (key: string, field: string, value: string) => { getH(key).set(field, value); },
+        hGet: async (key: string, field: string) => hashes.get(key)?.get(field) ?? null,
+        hDel: async (key: string, field: string) => { hashes.get(key)?.delete(field); },
+        hGetAll: async (key: string) => {
+            const h = hashes.get(key);
+            return h ? Object.fromEntries(h.entries()) : {};
+        },
+        hIncrByFloat: async (key: string, field: string, amount: number) => {
+            const h = getH(key);
+            const v = parseFloat(h.get(field) ?? '0') + amount;
+            h.set(field, v.toString());
+            return v;
+        },
+        _store: store,
+        _zsets: zsets,
+        _hashes: hashes,
+    };
+}
+
+function createMockRepo<T>() {
+    const rows: T[] = [];
+    return {
+        save: async (row: T) => { rows.push({ ...row }); return row; },
+        create: (partial: Partial<T>) => ({ ...partial }) as T,
+        find: async (query?: any) => {
+            if (!query?.where) return [...rows];
+            return (rows as any[]).filter(r =>
+                Object.entries(query.where).every(([k, v]) => r[k] === v),
+            );
+        },
+        findOneBy: async (where: any) =>
+            (rows as any[]).find(r => Object.entries(where).every(([k, v]) => r[k] === v)) ?? null,
+        delete: async (where: any) => {
+            for (let i = rows.length - 1; i >= 0; i--) {
+                if (Object.entries(where).every(([k, v]) => (rows[i] as any)[k] === v)) {
+                    rows.splice(i, 1);
+                }
+            }
+        },
+        _rows: rows,
+    };
+}
+
+function makeService(env: Record<string, string>) {
+    const addressToGroup = new Map<string, { groupId: string; active: boolean }>();
+    addressToGroup.set(ADDR_ALICE, { groupId: 'grp-1', active: true });
+    addressToGroup.set(ADDR_BOB, { groupId: 'grp-1', active: true });
+    addressToGroup.set(ADDR_CHARLIE, { groupId: 'grp-1', active: true });
+
+    const balanceRepo = createMockRepo();
+    const historyRepo = createMockRepo();
+    const service = new GroupSoloService(
+        { get: (k: string) => env[k] } as any,
+        { store: {} } as any,
+        historyRepo as any,
+        balanceRepo as any,
+        { getGroupForAddress: (a: string) => addressToGroup.get(a) } as any,
+    );
+    const redis = createMockRedis();
+    (service as any).redis = redis;
+    (service as any).enabled = true;
+    return { service, redis, balanceRepo, historyRepo, addressToGroup };
+}
+
+// ── Block Builder (same pattern as group-solo-regtest.spec.ts) ──
+
+function buildCoinbase(
+    payouts: { address: string; sats: number }[],
+    height: number,
+    witnessCommit: Buffer,
+): bitcoinjs.Transaction {
+    const tx = new bitcoinjs.Transaction();
+    tx.version = 2;
+    tx.addInput(Buffer.alloc(32, 0), 0xffffffff, 0xffffffff);
+    const heightEncoded = bitcoinjs.script.number.encode(height);
+    tx.ins[0].script = Buffer.concat([
+        Buffer.from([heightEncoded.length]),
+        heightEncoded,
+        Buffer.from('blitzpool-lifecycle-test'),
+        Buffer.alloc(4, 0),
+    ]);
+    tx.ins[0].witness = [Buffer.alloc(32, 0)];
+    for (const payout of payouts) {
+        const script = bitcoinjs.address.toOutputScript(payout.address, NETWORK);
+        tx.addOutput(script, payout.sats);
+    }
+    const commitmentHeader = Buffer.from('aa21a9ed', 'hex');
+    tx.addOutput(
+        bitcoinjs.script.compile([
+            bitcoinjs.opcodes.OP_RETURN,
+            Buffer.concat([commitmentHeader, witnessCommit]),
+        ]),
+        0,
+    );
+    return tx;
+}
+
+function buildBlock(template: any, coinbaseTx: bitcoinjs.Transaction, transactions: bitcoinjs.Transaction[]): bitcoinjs.Block {
+    const block = new bitcoinjs.Block();
+    block.version = template.version;
+    block.prevHash = Buffer.from(template.previousblockhash, 'hex').reverse();
+    block.timestamp = template.curtime;
+    block.bits = parseInt(template.bits, 16);
+    block.nonce = 0;
+    block.transactions = [coinbaseTx, ...transactions];
+    block.merkleRoot = bitcoinjs.Block.calculateMerkleRoot(block.transactions, false);
+    return block;
+}
+
+function mineBlock(block: bitcoinjs.Block, targetHex: string): boolean {
+    const target = Buffer.from(targetHex.padStart(64, '0'), 'hex');
+    for (let nonce = 0; nonce < 0xffffffff; nonce++) {
+        block.nonce = nonce;
+        const hash = bitcoinjs.crypto.hash256(block.toBuffer(true));
+        if (Buffer.from(hash).reverse().compare(target) <= 0) return true;
+    }
+    return false;
+}
+
+/**
+ * Pull a fresh getblocktemplate, build coinbase from the distribution,
+ * compute the right witness commitment, mine and submit the block.
+ * Returns the template + decision result; verify null == success.
+ */
+async function assembleAndSubmitBlock(distribution: { address: string; percent: number }[]) {
+    const template = await rpcCall('getblocktemplate', [{ rules: ['segwit'] }]);
+    const blockReward = template.coinbasevalue;
+
+    const payouts = distribution.map(d => ({
+        address: d.address,
+        sats: Math.floor((d.percent / 100) * blockReward),
+    }));
+    const totalAssigned = payouts.reduce((s, p) => s + p.sats, 0);
+    if (totalAssigned < blockReward && payouts.length > 0) {
+        payouts[0].sats += blockReward - totalAssigned;
+    }
+
+    const txs = template.transactions.map((t: any) => bitcoinjs.Transaction.fromHex(t.data));
+    const dummyCoinbase = new bitcoinjs.Transaction();
+    dummyCoinbase.version = 2;
+    dummyCoinbase.addInput(Buffer.alloc(32, 0), 0xffffffff, 0xffffffff);
+    dummyCoinbase.addOutput(Buffer.alloc(22, 0), 0);
+    dummyCoinbase.ins[0].witness = [Buffer.alloc(32, 0)];
+    const witnessCommit = bitcoinjs.Block.calculateMerkleRoot([dummyCoinbase, ...txs], true);
+
+    const coinbaseTx = buildCoinbase(payouts, template.height, witnessCommit);
+    const block = buildBlock(template, coinbaseTx, txs);
+    const mined = mineBlock(block, template.target);
+    if (!mined) throw new Error('mineBlock exhausted nonce range');
+
+    const submitResult = await rpcCall('submitblock', [block.toHex(false)]);
+    return { template, blockReward, payouts, submitResult };
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════
+
+describe('Group-Solo Regtest Lifecycle', () => {
+
+    beforeAll(async () => {
+        try {
+            const info = await rpcCall('getblockchaininfo');
+            expect(info.chain).toBe('regtest');
+            // Need chain height ≥ 17 for BIP34 scriptSig encoding.
+            if (info.blocks < 17) {
+                try { await rpcCall('createwallet', ['default']); } catch { /* already */ }
+                const addr = await rpcCall('getnewaddress');
+                await rpcCall('generatetoaddress', [17 - info.blocks, addr]);
+            }
+        } catch (e) {
+            throw new Error(`Bitcoin Core regtest not running at localhost:18443 — ${(e as Error).message}`);
+        }
+    });
+
+    // ── 1. Kick redistributes pending; next block validates without kicked output ───
+    it('kick-redistribute: survivors absorb pending, block validates without kicked output', async () => {
+        const { service, balanceRepo, addressToGroup } = makeService({
+            GROUP_SOLO_PORT: '3340',
+            PPLNS_FEE_ADDRESS: ADDR_FEE,
+            PPLNS_FEE_PERCENT: '2',
+        });
+
+        // Seed Charlie with pending from an earlier sub-dust round.
+        (balanceRepo._rows as any[]).push({
+            address: ADDR_CHARLIE, groupId: 'grp-1', pendingSats: 900, totalPaidSats: 0,
+        });
+
+        // Alice + Bob + Charlie all mine this round.
+        await service.recordShare(ADDR_ALICE, 100);
+        await service.recordShare(ADDR_BOB, 200);
+        await service.recordShare(ADDR_CHARLIE, 300);
+
+        // Admin kicks Charlie; survivors are Alice + Bob.
+        await service.removeMemberState('grp-1', ADDR_CHARLIE, [ADDR_ALICE, ADDR_BOB]);
+
+        // Charlie's 900 sats pending splits 450/450 into Alice + Bob.
+        const aliceRow = (balanceRepo._rows as any[]).find(r => r.address === ADDR_ALICE);
+        const bobRow = (balanceRepo._rows as any[]).find(r => r.address === ADDR_BOB);
+        expect(aliceRow?.pendingSats).toBe(450);
+        expect(bobRow?.pendingSats).toBe(450);
+        expect((balanceRepo._rows as any[]).find(r => r.address === ADDR_CHARLIE)).toBeUndefined();
+
+        // Charlie stops mining.
+        addressToGroup.delete(ADDR_CHARLIE);
+
+        // Build distribution → submit block to Core.
+        const template = await rpcCall('getblocktemplate', [{ rules: ['segwit'] }]);
+        const distribution = await service.getPayoutDistribution('grp-1', template.coinbasevalue);
+
+        // No Charlie in the distribution.
+        const addrs = distribution.map(d => d.address);
+        expect(addrs).not.toContain(ADDR_CHARLIE);
+        expect(addrs.sort()).toEqual([ADDR_ALICE, ADDR_BOB, ADDR_FEE].sort());
+
+        const { submitResult, template: usedTemplate } = await assembleAndSubmitBlock(distribution);
+        expect(submitResult).toBeNull();
+
+        // onBlockFound rolls Alice + Bob pending into totalPaidSats.
+        await service.onBlockFound(usedTemplate.height, usedTemplate.coinbasevalue, ADDR_ALICE);
+        const aliceAfter = (balanceRepo._rows as any[]).find(r => r.address === ADDR_ALICE);
+        const bobAfter = (balanceRepo._rows as any[]).find(r => r.address === ADDR_BOB);
+        expect(aliceAfter?.pendingSats).toBe(0);
+        expect(aliceAfter?.totalPaidSats).toBe(450);
+        expect(bobAfter?.pendingSats).toBe(0);
+        expect(bobAfter?.totalPaidSats).toBe(450);
+
+        console.log('✅ kick-redistribute: survivors absorbed charlie\'s pending, block validated');
+    }, 120000);
+
+    // ── 2. Dust-fee gate drops the fee output; block still validates ──
+    it('dust-fee-gate: tiny feePercent → fee omitted, miners keep 100 %, block valid', async () => {
+        // On regtest the subsidy is 50 BTC = 5_000_000_000 sats at early
+        // heights. 0.00001 % → 0.0000001 × 5e9 = 500 sats < DUST_LIMIT 546.
+        const { service } = makeService({
+            GROUP_SOLO_PORT: '3340',
+            PPLNS_FEE_ADDRESS: ADDR_FEE,
+            PPLNS_FEE_PERCENT: '0.00001',
+        });
+
+        await service.recordShare(ADDR_ALICE, 100);
+        await service.recordShare(ADDR_BOB, 200);
+
+        const template = await rpcCall('getblocktemplate', [{ rules: ['segwit'] }]);
+        const distribution = await service.getPayoutDistribution('grp-1', template.coinbasevalue);
+
+        // Dust-gate must drop the fee output.
+        const addrs = distribution.map(d => d.address);
+        expect(addrs).not.toContain(ADDR_FEE);
+        expect(addrs.sort()).toEqual([ADDR_ALICE, ADDR_BOB].sort());
+
+        // Miners together should receive effectively 100 % (remainder
+        // sweep into the first miner when no fee address).
+        const totalPercent = distribution.reduce((s, d) => s + d.percent, 0);
+        expect(totalPercent).toBeCloseTo(100, 5);
+
+        const { submitResult } = await assembleAndSubmitBlock(distribution);
+        expect(submitResult).toBeNull();
+
+        console.log('✅ dust-fee-gate: fee omitted from coinbase, block accepted');
+    }, 120000);
+
+    // ── 3. Snapshot persists across service-instance restart ──────
+    it('snapshot-persist: distribution snapshot survives service restart via Redis', async () => {
+        const env = {
+            GROUP_SOLO_PORT: '3340',
+            PPLNS_FEE_ADDRESS: ADDR_FEE,
+            PPLNS_FEE_PERCENT: '2',
+        };
+        const { service: svcA, redis, balanceRepo, historyRepo, addressToGroup } = makeService(env);
+
+        await svcA.recordShare(ADDR_ALICE, 100);
+        await svcA.recordShare(ADDR_BOB, 200);
+
+        const template = await rpcCall('getblocktemplate', [{ rules: ['segwit'] }]);
+        const blockReward = template.coinbasevalue;
+
+        // svcA writes the snapshot (simulating the moment the miner
+        // receives the coinbase template).
+        const distributionA = await svcA.getPayoutDistribution('grp-1', blockReward);
+        expect(redis._store.get(`groupsolo:grp-1:snapshot`)).toBeTruthy();
+
+        // Simulate pool restart: new service instance, same Redis.
+        const svcB = new GroupSoloService(
+            { get: (k: string) => env[k] } as any,
+            { store: {} } as any,
+            historyRepo as any,
+            balanceRepo as any,
+            { getGroupForAddress: (a: string) => addressToGroup.get(a) } as any,
+        );
+        (svcB as any).redis = redis;
+        (svcB as any).enabled = true;
+        // svcB.snapshots is a fresh empty Map — if the service used
+        // only in-memory state, it would fall back to
+        // onBlockFoundFromWindow and book payouts differently.
+
+        const { submitResult, template: usedTemplate } = await assembleAndSubmitBlock(distributionA);
+        expect(submitResult).toBeNull();
+
+        // onBlockFound on svcB must read from Redis.
+        await svcB.onBlockFound(usedTemplate.height, usedTemplate.coinbasevalue, ADDR_ALICE);
+
+        const historyForBlock = (historyRepo._rows as any[]).filter(
+            r => r.blockHeight === usedTemplate.height && r.inCoinbase === true,
+        );
+        expect(historyForBlock.length).toBe(distributionA.length);
+        expect(historyForBlock.map(r => r.address).sort())
+            .toEqual(distributionA.map(d => d.address).sort());
+
+        // Snapshot key consumed.
+        expect(redis._store.get(`groupsolo:grp-1:snapshot`)).toBeUndefined();
+
+        console.log('✅ snapshot-persist: fresh service instance consumed Redis snapshot');
+    }, 120000);
+});

--- a/src/services/group-solo-regtest.spec.ts
+++ b/src/services/group-solo-regtest.spec.ts
@@ -59,6 +59,7 @@ function rpcCall(method: string, params: any[] = []): Promise<any> {
 function createMockRedis() {
   const store = new Map<string, string>();
   const zsets = new Map<string, { score: number; value: string }[]>();
+  const hashes = new Map<string, Map<string, string>>();
   const getZ = (key: string) => {
     if (!zsets.has(key)) zsets.set(key, []);
     return zsets.get(key)!;
@@ -88,8 +89,32 @@ function createMockRedis() {
       return z.slice(start, e + 1).map(x => x.value);
     },
     zCard: async (key: string) => getZ(key).length,
+    zRem: async (key: string, value: string) => {
+      const z = getZ(key);
+      const idx = z.findIndex(e => e.value === value);
+      if (idx >= 0) z.splice(idx, 1);
+    },
+    hSet: async (key: string, field: string, value: string) => {
+      if (!hashes.has(key)) hashes.set(key, new Map());
+      hashes.get(key)!.set(field, value);
+    },
+    hGet: async (key: string, field: string) => hashes.get(key)?.get(field) ?? null,
+    hDel: async (key: string, field: string) => { hashes.get(key)?.delete(field); },
+    hGetAll: async (key: string) => {
+      const h = hashes.get(key);
+      return h ? Object.fromEntries(h.entries()) : {};
+    },
+    hIncrByFloat: async (key: string, field: string, amount: number) => {
+      if (!hashes.has(key)) hashes.set(key, new Map());
+      const h = hashes.get(key)!;
+      const val = parseFloat(h.get(field) ?? '0') + amount;
+      h.set(field, val.toString());
+      return val;
+    },
+    expire: async (_key: string, _seconds: number) => 1,
     _store: store,
     _zsets: zsets,
+    _hashes: hashes,
   };
 }
 

--- a/src/services/group-solo.service.spec.ts
+++ b/src/services/group-solo.service.spec.ts
@@ -7,9 +7,14 @@ import { GroupSoloService } from './group-solo.service';
 function createMockRedis() {
     const store = new Map<string, string>();
     const zsets = new Map<string, { score: number; value: string }[]>();
+    const hashes = new Map<string, Map<string, string>>();
     const getZ = (key: string) => {
         if (!zsets.has(key)) zsets.set(key, []);
         return zsets.get(key)!;
+    };
+    const getH = (key: string) => {
+        if (!hashes.has(key)) hashes.set(key, new Map());
+        return hashes.get(key)!;
     };
 
     return {
@@ -20,7 +25,7 @@ function createMockRedis() {
         }),
         get: jest.fn(async (key: string) => store.get(key) ?? null),
         set: jest.fn(async (key: string, value: string) => { store.set(key, value); }),
-        del: jest.fn(async (key: string) => { store.delete(key); zsets.delete(key); }),
+        del: jest.fn(async (key: string) => { store.delete(key); zsets.delete(key); hashes.delete(key); }),
         incrByFloat: jest.fn(async (key: string, amount: number) => {
             const val = parseFloat(store.get(key) ?? '0') + amount;
             store.set(key, val.toString());
@@ -37,8 +42,26 @@ function createMockRedis() {
             return z.slice(start, e + 1).map(x => x.value);
         }),
         zCard: jest.fn(async (key: string) => getZ(key).length),
+        hIncrByFloat: jest.fn(async (key: string, field: string, amount: number) => {
+            const h = getH(key);
+            const val = parseFloat(h.get(field) ?? '0') + amount;
+            h.set(field, val.toString());
+            return val;
+        }),
+        hIncrBy: jest.fn(async (key: string, field: string, amount: number) => {
+            const h = getH(key);
+            const val = parseInt(h.get(field) ?? '0', 10) + amount;
+            h.set(field, val.toString());
+            return val;
+        }),
+        hGetAll: jest.fn(async (key: string) => {
+            const h = hashes.get(key);
+            if (!h) return {};
+            return Object.fromEntries(h.entries());
+        }),
         _store: store,
         _zsets: zsets,
+        _hashes: hashes,
     };
 }
 
@@ -297,5 +320,56 @@ describe('GroupSoloService', () => {
         expect(stats.perAddress).toHaveLength(1);
         expect(stats.perAddress[0].address).toBe('bc1qalice');
         expect(stats.perAddress[0].percent).toBe(100);
+        expect(stats.totalRejectedDifficulty).toBe(0);
+        expect(stats.rejectedShareCount).toBe(0);
+        expect(stats.perAddress[0].rejectedDifficulty).toBe(0);
+        expect(stats.perAddress[0].rejectedShareCount).toBe(0);
+    });
+
+    it('recordReject rejects addresses not in an active group', async () => {
+        const { service, groupService } = makeService();
+        const ok = await service.recordReject('bc1qstranger', 100);
+        expect(ok).toBe(false);
+        groupService._setMembership('bc1qalice', 'g1', false);
+        const ok2 = await service.recordReject('bc1qalice', 100);
+        expect(ok2).toBe(false);
+    });
+
+    it('recordReject aggregates per-address and getRoundStats exposes it', async () => {
+        const { service, groupService } = makeService();
+        groupService._setMembership('bc1qalice', 'g1', true);
+        groupService._setMembership('bc1qbob', 'g1', true);
+        await service.recordShare('bc1qalice', 100);
+        await service.recordReject('bc1qalice', 50);
+        await service.recordReject('bc1qalice', 50);
+        await service.recordReject('bc1qbob', 200);
+
+        const stats = await service.getRoundStats('g1');
+        expect(stats.totalRejectedDifficulty).toBe(300);
+        expect(stats.rejectedShareCount).toBe(3);
+
+        const alice = stats.perAddress.find(p => p.address === 'bc1qalice')!;
+        expect(alice.rejectedDifficulty).toBe(100);
+        expect(alice.rejectedShareCount).toBe(2);
+        const bob = stats.perAddress.find(p => p.address === 'bc1qbob')!;
+        expect(bob.rejectedDifficulty).toBe(200);
+        expect(bob.rejectedShareCount).toBe(1);
+        // Bob had no accepted shares but still shows up because of rejects
+        expect(bob.difficulty).toBe(0);
+    });
+
+    it('onBlockFound also clears rejected counters', async () => {
+        const { service, redis, groupService } = makeService();
+        groupService._setMembership('bc1qalice', 'g1', true);
+        await service.recordShare('bc1qalice', 100);
+        await service.recordReject('bc1qalice', 50);
+        await service.getPayoutDistribution('g1', 100_000_000);
+
+        await service.onBlockFound(900_000, 100_000_000, 'bc1qalice');
+
+        expect(redis._hashes.size).toBe(0);
+        const stats = await service.getRoundStats('g1');
+        expect(stats.rejectedShareCount).toBe(0);
+        expect(stats.totalRejectedDifficulty).toBe(0);
     });
 });

--- a/src/services/group-solo.service.spec.ts
+++ b/src/services/group-solo.service.spec.ts
@@ -24,7 +24,8 @@ function createMockRedis() {
             return val;
         }),
         get: jest.fn(async (key: string) => store.get(key) ?? null),
-        set: jest.fn(async (key: string, value: string) => { store.set(key, value); }),
+        set: jest.fn(async (key: string, value: string, _opts?: any) => { store.set(key, value); }),
+        expire: jest.fn(async (_key: string, _seconds: number) => 1),
         del: jest.fn(async (key: string) => { store.delete(key); zsets.delete(key); hashes.delete(key); }),
         incrByFloat: jest.fn(async (key: string, amount: number) => {
             const val = parseFloat(store.get(key) ?? '0') + amount;

--- a/src/services/group-solo.service.spec.ts
+++ b/src/services/group-solo.service.spec.ts
@@ -428,4 +428,38 @@ describe('GroupSoloService', () => {
         expect(best.bestDifficulty).toBe(0);
         expect(best.address).toBeNull();
     });
+
+    it('removeMemberState redistributes pending balance + in-round shares to remaining members', async () => {
+        const { service, redis, groupService, balanceRepo } = makeService();
+        groupService._setMembership('bc1qalice', 'g1', true);
+        groupService._setMembership('bc1qbob', 'g1', true);
+        groupService._setMembership('bc1qcharlie', 'g1', true);
+
+        // Seed: alice + bob + charlie all mined this round.
+        await service.recordShare('bc1qalice', 100);
+        await service.recordShare('bc1qbob', 200);
+        await service.recordShare('bc1qcharlie', 300);
+
+        // Bob had accumulated 900 sats pending from prior sub-dust rounds.
+        (balanceRepo._rows as any[]).push({
+            address: 'bc1qbob', groupId: 'g1', pendingSats: 900, totalPaidSats: 0,
+        });
+
+        // Kick Bob — pending 900 splits evenly to alice + charlie (450 each),
+        // bob's row deleted, bob's in-round diff 200 removed from total.
+        await service.removeMemberState('g1', 'bc1qbob', ['bc1qalice', 'bc1qcharlie']);
+
+        // In-round total went 600 → 400.
+        expect(parseFloat((redis._store.get('groupsolo:g1:total') ?? '0') as string)).toBeCloseTo(400);
+
+        // Bob's row gone.
+        const bobRow = (balanceRepo._rows as any[]).find(r => r.address === 'bc1qbob');
+        expect(bobRow).toBeUndefined();
+
+        // Alice + Charlie got +450 each in pending.
+        const aliceRow = (balanceRepo._rows as any[]).find(r => r.address === 'bc1qalice');
+        const charlieRow = (balanceRepo._rows as any[]).find(r => r.address === 'bc1qcharlie');
+        expect(aliceRow?.pendingSats).toBe(450);
+        expect(charlieRow?.pendingSats).toBe(450);
+    });
 });

--- a/src/services/group-solo.service.spec.ts
+++ b/src/services/group-solo.service.spec.ts
@@ -315,15 +315,13 @@ describe('GroupSoloService', () => {
         await service.recordShare('bc1qalice', 200);
 
         const stats = await service.getRoundStats('g1');
-        expect(stats.shareCount).toBe(2);
-        expect(stats.totalDifficulty).toBe(300);
+        expect(stats.totalShares).toBe(300);
+        expect(stats.totalRejected).toBe(0);
         expect(stats.perAddress).toHaveLength(1);
         expect(stats.perAddress[0].address).toBe('bc1qalice');
+        expect(stats.perAddress[0].totalShares).toBe(300);
         expect(stats.perAddress[0].percent).toBe(100);
-        expect(stats.totalRejectedDifficulty).toBe(0);
-        expect(stats.rejectedShareCount).toBe(0);
-        expect(stats.perAddress[0].rejectedDifficulty).toBe(0);
-        expect(stats.perAddress[0].rejectedShareCount).toBe(0);
+        expect(stats.perAddress[0].totalRejected).toBe(0);
     });
 
     it('recordReject rejects addresses not in an active group', async () => {
@@ -345,17 +343,14 @@ describe('GroupSoloService', () => {
         await service.recordReject('bc1qbob', 200);
 
         const stats = await service.getRoundStats('g1');
-        expect(stats.totalRejectedDifficulty).toBe(300);
-        expect(stats.rejectedShareCount).toBe(3);
+        expect(stats.totalRejected).toBe(300);
 
         const alice = stats.perAddress.find(p => p.address === 'bc1qalice')!;
-        expect(alice.rejectedDifficulty).toBe(100);
-        expect(alice.rejectedShareCount).toBe(2);
+        expect(alice.totalRejected).toBe(100);
         const bob = stats.perAddress.find(p => p.address === 'bc1qbob')!;
-        expect(bob.rejectedDifficulty).toBe(200);
-        expect(bob.rejectedShareCount).toBe(1);
+        expect(bob.totalRejected).toBe(200);
         // Bob had no accepted shares but still shows up because of rejects
-        expect(bob.difficulty).toBe(0);
+        expect(bob.totalShares).toBe(0);
     });
 
     it('onBlockFound also clears rejected counters', async () => {
@@ -369,7 +364,38 @@ describe('GroupSoloService', () => {
 
         expect(redis._hashes.size).toBe(0);
         const stats = await service.getRoundStats('g1');
-        expect(stats.rejectedShareCount).toBe(0);
-        expect(stats.totalRejectedDifficulty).toBe(0);
+        expect(stats.totalRejected).toBe(0);
+    });
+
+    it('getRoundBestDifficulty returns max single-share diff and submitter', async () => {
+        const { service, groupService } = makeService();
+        groupService._setMembership('bc1qalice', 'g1', true);
+        groupService._setMembership('bc1qbob', 'g1', true);
+
+        // No shares yet
+        const empty = await service.getRoundBestDifficulty('g1');
+        expect(empty.bestDifficulty).toBe(0);
+        expect(empty.address).toBeNull();
+
+        await service.recordShare('bc1qalice', 100);
+        await service.recordShare('bc1qbob', 500_000);
+        await service.recordShare('bc1qalice', 250);
+
+        const best = await service.getRoundBestDifficulty('g1');
+        expect(best.bestDifficulty).toBe(500_000);
+        expect(best.address).toBe('bc1qbob');
+        expect(typeof best.time).toBe('number');
+    });
+
+    it('getRoundBestDifficulty resets after onBlockFound', async () => {
+        const { service, groupService } = makeService();
+        groupService._setMembership('bc1qalice', 'g1', true);
+        await service.recordShare('bc1qalice', 100);
+        await service.getPayoutDistribution('g1', 100_000_000);
+        await service.onBlockFound(900_000, 100_000_000, 'bc1qalice');
+
+        const best = await service.getRoundBestDifficulty('g1');
+        expect(best.bestDifficulty).toBe(0);
+        expect(best.address).toBeNull();
     });
 });

--- a/src/services/group-solo.service.spec.ts
+++ b/src/services/group-solo.service.spec.ts
@@ -54,10 +54,25 @@ function createMockRedis() {
             h.set(field, val.toString());
             return val;
         }),
+        hSet: jest.fn(async (key: string, field: string, value: string) => {
+            getH(key).set(field, value);
+        }),
+        hGet: jest.fn(async (key: string, field: string) => {
+            const h = hashes.get(key);
+            return h?.get(field) ?? null;
+        }),
+        hDel: jest.fn(async (key: string, field: string) => {
+            hashes.get(key)?.delete(field);
+        }),
         hGetAll: jest.fn(async (key: string) => {
             const h = hashes.get(key);
             if (!h) return {};
             return Object.fromEntries(h.entries());
+        }),
+        zRem: jest.fn(async (key: string, value: string) => {
+            const z = getZ(key);
+            const idx = z.findIndex(e => e.value === value);
+            if (idx >= 0) z.splice(idx, 1);
         }),
         _store: store,
         _zsets: zsets,
@@ -84,11 +99,23 @@ function createMockRepo<T>() {
     return {
         save: jest.fn(async (row: T) => { rows.push({ ...row }); return row; }),
         create: jest.fn((partial: Partial<T>) => ({ ...partial }) as T),
-        find: jest.fn(async () => [...rows]),
+        find: jest.fn(async (query?: any) => {
+            if (!query?.where) return [...rows];
+            return (rows as any[]).filter(r =>
+                Object.entries(query.where).every(([k, v]) => r[k] === v),
+            );
+        }),
         findOneBy: jest.fn(async (where: any) => {
             return (rows as any[]).find(r =>
                 Object.entries(where).every(([k, v]) => r[k] === v),
             ) ?? null;
+        }),
+        delete: jest.fn(async (where: any) => {
+            for (let i = rows.length - 1; i >= 0; i--) {
+                if (Object.entries(where).every(([k, v]) => (rows[i] as any)[k] === v)) {
+                    rows.splice(i, 1);
+                }
+            }
         }),
         _rows: rows,
     };
@@ -362,7 +389,9 @@ describe('GroupSoloService', () => {
 
         await service.onBlockFound(900_000, 100_000_000, 'bc1qalice');
 
-        expect(redis._hashes.size).toBe(0);
+        // rejected-shares hash is cleared on round reset; lastShareAt is NOT
+        // (it survives across rounds, powering the admin kick inactivity gate).
+        expect(redis._hashes.get('groupsolo:g1:rejected-shares')?.size ?? 0).toBe(0);
         const stats = await service.getRoundStats('g1');
         expect(stats.totalRejected).toBe(0);
     });

--- a/src/services/group-solo.service.ts
+++ b/src/services/group-solo.service.ts
@@ -23,8 +23,25 @@ import { GroupService } from './group.service';
 
 const DUST_LIMIT_SATS = 546;
 const DEFAULT_COINBASE_WEIGHT_BUDGET = 50_000;
+
+// Coinbase structural weight constants, calibrated against the real builder
+// in src/models/MiningJob.ts (createCoinbaseTransaction).
+//
+// BASE: version + input(coinbase prev-out, script, sequence) + output-count
+// byte + locktime + witness-reserved-value. ~420 WU on the wire; 320 is a
+// conservative-low estimate that leaves small headroom.
+//
+// OUTPUT: we size for P2TR (34-byte scriptPubKey → 43 bytes serialized →
+// 172 WU) rather than P2WPKH (22 bytes → 124 WU) so a group made entirely
+// of Taproot miners doesn't overshoot the budget.
+//
+// WITNESS_OUTPUT: the segwit-commitment OP_RETURN added by MiningJob at
+// line 69 is ~38 bytes script → ~47 bytes serialized → ~188 WU. Reserving
+// 124 for it (as earlier code did by treating it as a regular output)
+// underestimated by ~64 WU. Reserve the real figure.
 const COINBASE_BASE_WEIGHT = 320;
-const COINBASE_OUTPUT_WEIGHT = 124;
+const COINBASE_OUTPUT_WEIGHT = 172;
+const COINBASE_WITNESS_COMMITMENT_WEIGHT = 188;
 
 function redisKeys(groupId: string) {
     return {
@@ -229,8 +246,15 @@ export class GroupSoloService implements OnModuleInit {
             .sort((a, b) => b.sats - a.sats);
 
         const feeOutputCount = this.feeAddress ? 1 : 0;
+        // Budget layout: BASE + OP_RETURN (witness commitment) + feeOutput?
+        //   → rest splits into miner outputs of COINBASE_OUTPUT_WEIGHT each.
+        // The OP_RETURN is always present (segwit commitment), the fee
+        // output only when feeAddress is configured.
         const maxMinerOutputs = Math.floor(
-            (this.coinbaseWeightBudget - COINBASE_BASE_WEIGHT - (feeOutputCount + 1) * COINBASE_OUTPUT_WEIGHT)
+            (this.coinbaseWeightBudget
+                - COINBASE_BASE_WEIGHT
+                - COINBASE_WITNESS_COMMITMENT_WEIGHT
+                - feeOutputCount * COINBASE_OUTPUT_WEIGHT)
             / COINBASE_OUTPUT_WEIGHT,
         );
 
@@ -245,8 +269,23 @@ export class GroupSoloService implements OnModuleInit {
         let total = trimmed.reduce((sum, m) => sum + m.percent, 0);
 
         if (this.feeAddress) {
-            payouts.unshift({ address: this.feeAddress, percent: feePercent });
-            total += feePercent;
+            // Only emit the fee output if the resulting on-chain amount
+            // clears dust. Below ~546 sats (depends on output type) the
+            // output would be rejected by Bitcoin Core policy and the
+            // whole block invalidated. In practice on mainnet at the
+            // current 3.125 BTC subsidy this never triggers for any
+            // feePercent > 0, but a regtest / low-subsidy / configured-
+            // down scenario can hit it. When dust, fold the fee silently
+            // into the miner pool so the block is still valid — the pool
+            // operator loses that block's fee, which is the right
+            // tradeoff over a bricked block.
+            const feeSats = Math.floor((feePercent / 100) * blockRewardSats);
+            if (feeSats >= DUST_LIMIT_SATS) {
+                payouts.unshift({ address: this.feeAddress, percent: feePercent });
+                total += feePercent;
+            } else {
+                console.warn(`[GroupSolo] Fee output ${feeSats} sats < dust — omitting fee, miners keep 100% this block`);
+            }
         }
 
         // Sweep remainder into fee (or last miner if no fee address).
@@ -493,12 +532,18 @@ export class GroupSoloService implements OnModuleInit {
 
         if (this.feeAddress) {
             const feeSats = blockRewardSats - rewardForMiners;
-            await this.historyRepo.save(this.historyRepo.create({
-                groupId, blockHeight, address: this.feeAddress,
-                paidSats: feeSats, percent: this.feePercent,
-                sharesInRound: 0, totalSharesInRound: 0,
-                inCoinbase: true,
-            }));
+            if (feeSats >= DUST_LIMIT_SATS) {
+                await this.historyRepo.save(this.historyRepo.create({
+                    groupId, blockHeight, address: this.feeAddress,
+                    paidSats: feeSats, percent: this.feePercent,
+                    sharesInRound: 0, totalSharesInRound: 0,
+                    inCoinbase: true,
+                }));
+            } else {
+                // Dust — fee was omitted from the coinbase to keep the
+                // block valid. See dust-gate in getPayoutDistribution.
+                console.warn(`[GroupSolo] Fallback: fee output ${feeSats} sats < dust — not recording fee history row`);
+            }
         }
 
         await this.resetRound(groupId);

--- a/src/services/group-solo.service.ts
+++ b/src/services/group-solo.service.ts
@@ -31,6 +31,8 @@ function redisKeys(groupId: string) {
         shares: `groupsolo:${groupId}:shares`,
         counter: `groupsolo:${groupId}:counter`,
         total: `groupsolo:${groupId}:total`,
+        rejectedDiff: `groupsolo:${groupId}:rejected-diff`,
+        rejectedCount: `groupsolo:${groupId}:rejected-count`,
     };
 }
 
@@ -123,6 +125,22 @@ export class GroupSoloService implements OnModuleInit {
         const payload = `${address}:${difficulty}:${Date.now()}`;
         await this.redis.zAdd(keys.shares, { score: counter, value: payload });
         await this.redis.incrByFloat(keys.total, difficulty);
+        return true;
+    }
+
+    /**
+     * Record a rejected share. Aggregated per-address into two hashes so the
+     * distribution endpoint can show rejected stats per member. Reset with the
+     * rest of the round on block-found.
+     */
+    async recordReject(address: string, difficulty: number): Promise<boolean> {
+        if (!this.isEnabled()) return false;
+        const entry = this.groupService.getGroupForAddress(address);
+        if (!entry || !entry.active) return false;
+
+        const keys = redisKeys(entry.groupId);
+        await this.redis.hIncrByFloat(keys.rejectedDiff, address, difficulty);
+        await this.redis.hIncrBy(keys.rejectedCount, address, 1);
         return true;
     }
 
@@ -435,6 +453,8 @@ export class GroupSoloService implements OnModuleInit {
         await this.redis.del(keys.shares);
         await this.redis.del(keys.counter);
         await this.redis.del(keys.total);
+        await this.redis.del(keys.rejectedDiff);
+        await this.redis.del(keys.rejectedCount);
     }
 
     // ── Stats (for API) ──────────────────────────────────────────
@@ -442,10 +462,24 @@ export class GroupSoloService implements OnModuleInit {
     async getRoundStats(groupId: string): Promise<{
         totalDifficulty: number;
         shareCount: number;
-        perAddress: { address: string; difficulty: number; percent: number }[];
+        totalRejectedDifficulty: number;
+        rejectedShareCount: number;
+        perAddress: {
+            address: string;
+            difficulty: number;
+            percent: number;
+            rejectedDifficulty: number;
+            rejectedShareCount: number;
+        }[];
     }> {
         if (!this.isEnabled()) {
-            return { totalDifficulty: 0, shareCount: 0, perAddress: [] };
+            return {
+                totalDifficulty: 0,
+                shareCount: 0,
+                totalRejectedDifficulty: 0,
+                rejectedShareCount: 0,
+                perAddress: [],
+            };
         }
         const keys = redisKeys(groupId);
         const entries = await this.redis.zRange(keys.shares, 0, -1);
@@ -457,17 +491,45 @@ export class GroupSoloService implements OnModuleInit {
             addressDiff.set(addr, (addressDiff.get(addr) ?? 0) + diff);
             totalDiff += diff;
         }
-        const perAddress = Array.from(addressDiff.entries())
-            .map(([address, difficulty]) => ({
+
+        const rejectedDiffMap = (await this.redis.hGetAll(keys.rejectedDiff)) ?? {};
+        const rejectedCountMap = (await this.redis.hGetAll(keys.rejectedCount)) ?? {};
+        const addressRejDiff = new Map<string, number>();
+        const addressRejCount = new Map<string, number>();
+        let totalRejDiff = 0;
+        let totalRejCount = 0;
+        for (const [addr, v] of Object.entries(rejectedDiffMap)) {
+            const d = parseFloat(v as string) || 0;
+            addressRejDiff.set(addr, d);
+            totalRejDiff += d;
+        }
+        for (const [addr, v] of Object.entries(rejectedCountMap)) {
+            const c = parseInt(v as string, 10) || 0;
+            addressRejCount.set(addr, c);
+            totalRejCount += c;
+        }
+
+        const allAddresses = new Set<string>([
+            ...addressDiff.keys(),
+            ...addressRejDiff.keys(),
+            ...addressRejCount.keys(),
+        ]);
+        const perAddress = Array.from(allAddresses).map((address) => {
+            const difficulty = addressDiff.get(address) ?? 0;
+            return {
                 address,
                 difficulty,
                 percent: totalDiff > 0 ? (difficulty / totalDiff) * 100 : 0,
-            }))
-            .sort((a, b) => b.percent - a.percent);
+                rejectedDifficulty: addressRejDiff.get(address) ?? 0,
+                rejectedShareCount: addressRejCount.get(address) ?? 0,
+            };
+        }).sort((a, b) => b.percent - a.percent);
 
         return {
             totalDifficulty: totalDiff,
             shareCount: (entries ?? []).length,
+            totalRejectedDifficulty: totalRejDiff,
+            rejectedShareCount: totalRejCount,
             perAddress,
         };
     }

--- a/src/services/group-solo.service.ts
+++ b/src/services/group-solo.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, OnModuleInit } from '@nestjs/common';
+import { Injectable, Inject, OnModuleInit, forwardRef } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
@@ -34,6 +34,10 @@ function redisKeys(groupId: string) {
         // Per-address rejected shares for the current round (diff-1 weighted).
         // No separate count key — the share value already captures real work.
         rejectedShares: `groupsolo:${groupId}:rejected-shares`,
+        // Per-address last-accepted-share epoch-ms. Persists across rounds
+        // (NOT cleared on block-found) so the admin-kick inactivity gate
+        // can look back weeks.
+        lastShareAt: `groupsolo:${groupId}:last-share-at`,
     };
 }
 
@@ -75,6 +79,7 @@ export class GroupSoloService implements OnModuleInit {
         private readonly historyRepo: Repository<PplnsGroupBlockHistoryEntity>,
         @InjectRepository(PplnsGroupBalanceEntity)
         private readonly balanceRepo: Repository<PplnsGroupBalanceEntity>,
+        @Inject(forwardRef(() => GroupService))
         private readonly groupService: GroupService,
     ) {
         this.feeAddress = this.configService.get('PPLNS_FEE_ADDRESS') ?? '';
@@ -122,10 +127,12 @@ export class GroupSoloService implements OnModuleInit {
         if (!entry || !entry.active) return false;
 
         const keys = redisKeys(entry.groupId);
+        const now = Date.now();
         const counter = await this.redis.incr(keys.counter);
-        const payload = `${address}:${difficulty}:${Date.now()}`;
+        const payload = `${address}:${difficulty}:${now}`;
         await this.redis.zAdd(keys.shares, { score: counter, value: payload });
         await this.redis.incrByFloat(keys.total, difficulty);
+        await this.redis.hSet(keys.lastShareAt, address, String(now));
         return true;
     }
 
@@ -286,7 +293,7 @@ export class GroupSoloService implements OnModuleInit {
                 const paidSats = Math.floor((d.percent / 100) * reward);
                 const isFee = d.address === this.feeAddress;
                 if (!isFee) {
-                    const existing = await this.balanceRepo.findOneBy({ address: d.address });
+                    const existing = await this.balanceRepo.findOneBy({ address: d.address, groupId });
                     if (existing && existing.pendingSats > 0) {
                         existing.totalPaidSats += existing.pendingSats;
                         existing.pendingSats = 0;
@@ -392,7 +399,7 @@ export class GroupSoloService implements OnModuleInit {
         for (const [addr, diff] of addressDiff) {
             const ratio = diff / totalDiff;
             const sats = Math.floor(ratio * rewardForMiners);
-            const existing = await this.balanceRepo.findOneBy({ address: addr });
+            const existing = await this.balanceRepo.findOneBy({ address: addr, groupId });
             const pending = existing?.pendingSats ?? 0;
             const totalSats = sats + pending;
             const percent = ratio * (100 - this.feePercent);
@@ -438,7 +445,7 @@ export class GroupSoloService implements OnModuleInit {
     }
 
     private async addPending(groupId: string, address: string, sats: number): Promise<void> {
-        const existing = await this.balanceRepo.findOneBy({ address });
+        const existing = await this.balanceRepo.findOneBy({ address, groupId });
         if (existing) {
             existing.pendingSats += sats;
             await this.balanceRepo.save(existing);
@@ -455,6 +462,72 @@ export class GroupSoloService implements OnModuleInit {
         await this.redis.del(keys.counter);
         await this.redis.del(keys.total);
         await this.redis.del(keys.rejectedShares);
+        // lastShareAt is intentionally NOT cleared on round reset — it
+        // survives across blocks so the inactivity gate measures actual
+        // time since last work, not time since last round start.
+    }
+
+    // ── Member lifecycle (called by GroupService) ──────────────
+
+    /**
+     * Milliseconds-since-epoch of the most recent accepted share from
+     * `address` in `groupId`, or null if no share has ever been recorded
+     * (member was invited but never mined to this group).
+     */
+    async getMemberLastActive(groupId: string, address: string): Promise<number | null> {
+        if (!this.isEnabled()) return null;
+        const keys = redisKeys(groupId);
+        const raw = await this.redis.hGet(keys.lastShareAt, address);
+        if (!raw) return null;
+        const n = parseInt(raw, 10);
+        return Number.isFinite(n) ? n : null;
+    }
+
+    /**
+     * Remove all round-state for a single member in a group: their shares
+     * in the current Redis window, their rejected counter, their pending
+     * balance row, and their last-share timestamp. Called by GroupService
+     * before deleting the member row during an admin kick.
+     *
+     * Effect on the remaining members: their share of the round's total
+     * grows proportionally because `total` is decremented by exactly the
+     * diff we remove. On the next block, the distribution picks up the
+     * freed-up percentage automatically.
+     */
+    async removeMemberState(groupId: string, address: string): Promise<void> {
+        if (this.isEnabled()) {
+            const keys = redisKeys(groupId);
+            const entries = await this.redis.zRange(keys.shares, 0, -1);
+            let removedDiff = 0;
+            for (const e of (entries ?? [])) {
+                const [addr, diffStr] = e.split(':');
+                if (addr === address) {
+                    await this.redis.zRem(keys.shares, e);
+                    removedDiff += parseFloat(diffStr) || 0;
+                }
+            }
+            if (removedDiff > 0) {
+                await this.redis.incrByFloat(keys.total, -removedDiff);
+            }
+            await this.redis.hDel(keys.rejectedShares, address);
+            await this.redis.hDel(keys.lastShareAt, address);
+        }
+        await this.balanceRepo.delete({ address, groupId });
+    }
+
+    /**
+     * Remove all round-state for every member of a group. Called by
+     * GroupService.dissolveInternal so no orphan keys/rows survive the
+     * dissolve event.
+     */
+    async removeGroupState(groupId: string): Promise<void> {
+        if (this.isEnabled()) {
+            await this.resetRound(groupId);
+            const keys = redisKeys(groupId);
+            await this.redis.del(keys.lastShareAt);
+        }
+        await this.balanceRepo.delete({ groupId });
+        await this.historyRepo.delete({ groupId });
     }
 
     // ── Stats (for API) ──────────────────────────────────────────

--- a/src/services/group-solo.service.ts
+++ b/src/services/group-solo.service.ts
@@ -219,10 +219,21 @@ export class GroupSoloService implements OnModuleInit {
         const pendingMap = new Map<string, number>();
         for (const p of pendingEntities) pendingMap.set(p.address, p.pendingSats);
 
+        // Pending balances are IOUs to members from prior sub-dust / trim
+        // rounds (and, with group-solo, from kick-redistribute). They have
+        // to be settled out of THIS block's miner cut — not on top of it —
+        // otherwise the sum of coinbase outputs exceeds blockRewardSats
+        // and Bitcoin Core rejects the block with bad-cb-amount. Subtract
+        // the total pending from rewardForMiners before distributing by
+        // share ratio; each miner still gets their own pending credited
+        // on top of their reduced base-share.
+        const totalPending = Array.from(pendingMap.values()).reduce((s, v) => s + v, 0);
+        const effectiveMinerReward = Math.max(0, rewardForMiners - totalPending);
+
         const minerShares: { address: string; sats: number; percent: number }[] = [];
         for (const [addr, diff] of addressDiff) {
             const ratio = diff / totalDiff;
-            const baseSats = Math.floor(ratio * rewardForMiners);
+            const baseSats = Math.floor(ratio * effectiveMinerReward);
             const totalSats = baseSats + (pendingMap.get(addr) ?? 0);
             minerShares.push({
                 address: addr,
@@ -494,14 +505,20 @@ export class GroupSoloService implements OnModuleInit {
         }
 
         const rewardForMiners = Math.floor(((100 - this.feePercent) / 100) * blockRewardSats);
+        // Same pending-settlement rule as getPayoutDistribution: pending
+        // comes out of the miner cut, not on top. Otherwise total outputs
+        // exceed blockReward and Core rejects with bad-cb-amount.
+        const pendingEntities = await this.balanceRepo.find({ where: { groupId } });
+        const totalPending = pendingEntities.reduce((s, p) => s + (p.pendingSats ?? 0), 0);
+        const effectiveMinerReward = Math.max(0, rewardForMiners - totalPending);
 
         for (const [addr, diff] of addressDiff) {
             const ratio = diff / totalDiff;
-            const sats = Math.floor(ratio * rewardForMiners);
+            const sats = Math.floor(ratio * effectiveMinerReward);
             const existing = await this.balanceRepo.findOneBy({ address: addr, groupId });
             const pending = existing?.pendingSats ?? 0;
             const totalSats = sats + pending;
-            const percent = ratio * (100 - this.feePercent);
+            const percent = (totalSats / blockRewardSats) * 100;
 
             if (totalSats >= DUST_LIMIT_SATS) {
                 if (existing && pending > 0) {

--- a/src/services/group-solo.service.ts
+++ b/src/services/group-solo.service.ts
@@ -38,7 +38,20 @@ function redisKeys(groupId: string) {
         // (NOT cleared on block-found) so the admin-kick inactivity gate
         // can look back weeks.
         lastShareAt: `groupsolo:${groupId}:last-share-at`,
+        // Coinbase-time distribution snapshot, JSON-encoded. Created by
+        // getPayoutDistribution, consumed by onBlockFound. Persists across
+        // pool restart (AOF) so a crash between job-send and block-found
+        // doesn't cause payouts to drift from the on-chain coinbase.
+        snapshot: `groupsolo:${groupId}:snapshot`,
     };
+}
+
+const SNAPSHOT_TTL_SECONDS = 60 * 60; // 1h — covers worst-case block+restart delay.
+
+interface StoredSnapshot {
+    distribution: GroupSoloPayoutEntry[];
+    blockRewardSats: number;
+    consideredAddresses: string[];
 }
 
 export interface GroupSoloPayoutEntry {
@@ -56,18 +69,22 @@ export class GroupSoloService implements OnModuleInit {
     private readonly coinbaseWeightBudget: number;
 
     /**
-     * Coinbase snapshot per group.  `distribution` = what goes into the coinbase;
-     * `consideredAddresses` = every address that was in the Redis window at the moment
-     * the snapshot was built (including sub-dust miners that were filtered out).  This
-     * lets onBlockFound tell apart two classes of "not in coinbase" miners:
+     * Coinbase snapshot per group, persisted in Redis (see redisKeys().snapshot).
+     * `distribution` = what goes into the coinbase; `consideredAddresses` = every
+     * address that was in the Redis window at the moment the snapshot was built
+     * (including sub-dust miners filtered out). This lets onBlockFound distinguish
+     * two classes of "not in coinbase" miners:
      *   - sub-dust: was in the window at snapshot time → credit to pending so they accumulate
      *   - late arriver: submitted after snapshot was built → don't credit (would double-count)
+     *
+     * Persistence in Redis (not an in-memory Map) is critical: a pool restart
+     * between the miner receiving the coinbase template and the block landing
+     * would otherwise lose the snapshot, forcing onBlockFound onto the
+     * current-window fallback whose distribution can differ from the on-chain
+     * coinbase. 1h TTL covers worst-case block-find + restart windows; long
+     * enough that a normal-case outage is fine, short enough that stale
+     * snapshots don't pile up forever.
      */
-    private snapshots = new Map<string, {
-        distribution: GroupSoloPayoutEntry[];
-        blockRewardSats: number;
-        consideredAddresses: Set<string>;
-    }>();
 
     /** Per-group block-found reentrancy guard. */
     private blockFoundLocks = new Set<string>();
@@ -248,8 +265,51 @@ export class GroupSoloService implements OnModuleInit {
         // doc for why this distinction matters.
         const consideredAddresses = new Set<string>(addressDiff.keys());
         for (const addr of pendingMap.keys()) consideredAddresses.add(addr);
-        this.snapshots.set(groupId, { distribution: result, blockRewardSats, consideredAddresses });
+        await this.writeSnapshot(groupId, {
+            distribution: result,
+            blockRewardSats,
+            consideredAddresses: Array.from(consideredAddresses),
+        });
         return result;
+    }
+
+    private async writeSnapshot(groupId: string, snapshot: StoredSnapshot): Promise<void> {
+        const keys = redisKeys(groupId);
+        try {
+            await this.redis.set(keys.snapshot, JSON.stringify(snapshot), { EX: SNAPSHOT_TTL_SECONDS });
+        } catch {
+            // Some ioredis / node-redis variants don't accept the options
+            // object — fall back to set + expire.
+            await this.redis.set(keys.snapshot, JSON.stringify(snapshot));
+            if (typeof this.redis.expire === 'function') {
+                await this.redis.expire(keys.snapshot, SNAPSHOT_TTL_SECONDS);
+            }
+        }
+    }
+
+    private async readSnapshot(groupId: string): Promise<{
+        distribution: GroupSoloPayoutEntry[];
+        blockRewardSats: number;
+        consideredAddresses: Set<string>;
+    } | null> {
+        const keys = redisKeys(groupId);
+        const raw = await this.redis.get(keys.snapshot);
+        if (!raw) return null;
+        try {
+            const parsed: StoredSnapshot = JSON.parse(raw);
+            return {
+                distribution: parsed.distribution,
+                blockRewardSats: parsed.blockRewardSats,
+                consideredAddresses: new Set(parsed.consideredAddresses),
+            };
+        } catch {
+            return null;
+        }
+    }
+
+    private async deleteSnapshot(groupId: string): Promise<void> {
+        const keys = redisKeys(groupId);
+        await this.redis.del(keys.snapshot);
     }
 
     private fallback(): GroupSoloPayoutEntry[] {
@@ -279,13 +339,13 @@ export class GroupSoloService implements OnModuleInit {
         try {
             console.log(`[GroupSolo] Block ${blockHeight} found by group ${groupId} (finder=${finderAddress})`);
 
-            const snapshot = this.snapshots.get(groupId);
+            const snapshot = await this.readSnapshot(groupId);
             if (!snapshot || snapshot.distribution.length === 0) {
                 console.warn(`[GroupSolo] No snapshot for group ${groupId} — using window recalculation fallback`);
                 await this.onBlockFoundFromWindow(groupId, blockHeight, blockRewardSats);
                 return;
             }
-            this.snapshots.delete(groupId);
+            await this.deleteSnapshot(groupId);
             const reward = snapshot.blockRewardSats;
 
             // Miners in the snapshot get paid via coinbase; clear any prior pending.
@@ -525,6 +585,7 @@ export class GroupSoloService implements OnModuleInit {
             await this.resetRound(groupId);
             const keys = redisKeys(groupId);
             await this.redis.del(keys.lastShareAt);
+            await this.redis.del(keys.snapshot);
         }
         await this.balanceRepo.delete({ groupId });
         await this.historyRepo.delete({ groupId });

--- a/src/services/group-solo.service.ts
+++ b/src/services/group-solo.service.ts
@@ -31,8 +31,9 @@ function redisKeys(groupId: string) {
         shares: `groupsolo:${groupId}:shares`,
         counter: `groupsolo:${groupId}:counter`,
         total: `groupsolo:${groupId}:total`,
-        rejectedDiff: `groupsolo:${groupId}:rejected-diff`,
-        rejectedCount: `groupsolo:${groupId}:rejected-count`,
+        // Per-address rejected shares for the current round (diff-1 weighted).
+        // No separate count key — the share value already captures real work.
+        rejectedShares: `groupsolo:${groupId}:rejected-shares`,
     };
 }
 
@@ -129,18 +130,18 @@ export class GroupSoloService implements OnModuleInit {
     }
 
     /**
-     * Record a rejected share. Aggregated per-address into two hashes so the
-     * distribution endpoint can show rejected stats per member. Reset with the
-     * rest of the round on block-found.
+     * Record a rejected share. Aggregated per-address into a single hash so
+     * the distribution endpoint can show rejected stats per member. Value
+     * is diff-1 weighted (real work units). Reset with the rest of the
+     * round on block-found.
      */
-    async recordReject(address: string, difficulty: number): Promise<boolean> {
+    async recordReject(address: string, shares: number): Promise<boolean> {
         if (!this.isEnabled()) return false;
         const entry = this.groupService.getGroupForAddress(address);
         if (!entry || !entry.active) return false;
 
         const keys = redisKeys(entry.groupId);
-        await this.redis.hIncrByFloat(keys.rejectedDiff, address, difficulty);
-        await this.redis.hIncrBy(keys.rejectedCount, address, 1);
+        await this.redis.hIncrByFloat(keys.rejectedShares, address, shares);
         return true;
     }
 
@@ -453,85 +454,99 @@ export class GroupSoloService implements OnModuleInit {
         await this.redis.del(keys.shares);
         await this.redis.del(keys.counter);
         await this.redis.del(keys.total);
-        await this.redis.del(keys.rejectedDiff);
-        await this.redis.del(keys.rejectedCount);
+        await this.redis.del(keys.rejectedShares);
     }
 
     // ── Stats (for API) ──────────────────────────────────────────
 
     async getRoundStats(groupId: string): Promise<{
-        totalDifficulty: number;
-        shareCount: number;
-        totalRejectedDifficulty: number;
-        rejectedShareCount: number;
+        totalShares: number;
+        totalRejected: number;
         perAddress: {
             address: string;
-            difficulty: number;
+            totalShares: number;
             percent: number;
-            rejectedDifficulty: number;
-            rejectedShareCount: number;
+            totalRejected: number;
         }[];
     }> {
         if (!this.isEnabled()) {
             return {
-                totalDifficulty: 0,
-                shareCount: 0,
-                totalRejectedDifficulty: 0,
-                rejectedShareCount: 0,
+                totalShares: 0,
+                totalRejected: 0,
                 perAddress: [],
             };
         }
         const keys = redisKeys(groupId);
         const entries = await this.redis.zRange(keys.shares, 0, -1);
-        const addressDiff = new Map<string, number>();
-        let totalDiff = 0;
+        const addressShares = new Map<string, number>();
+        let totalShares = 0;
+        // All values are diff-1 weighted (real work units), not raw share counts.
         for (const e of (entries ?? [])) {
-            const [addr, diffStr] = e.split(':');
-            const diff = parseFloat(diffStr) || 0;
-            addressDiff.set(addr, (addressDiff.get(addr) ?? 0) + diff);
-            totalDiff += diff;
+            const [addr, sharesStr] = e.split(':');
+            const shares = parseFloat(sharesStr) || 0;
+            addressShares.set(addr, (addressShares.get(addr) ?? 0) + shares);
+            totalShares += shares;
         }
 
-        const rejectedDiffMap = (await this.redis.hGetAll(keys.rejectedDiff)) ?? {};
-        const rejectedCountMap = (await this.redis.hGetAll(keys.rejectedCount)) ?? {};
-        const addressRejDiff = new Map<string, number>();
-        const addressRejCount = new Map<string, number>();
-        let totalRejDiff = 0;
-        let totalRejCount = 0;
-        for (const [addr, v] of Object.entries(rejectedDiffMap)) {
-            const d = parseFloat(v as string) || 0;
-            addressRejDiff.set(addr, d);
-            totalRejDiff += d;
-        }
-        for (const [addr, v] of Object.entries(rejectedCountMap)) {
-            const c = parseInt(v as string, 10) || 0;
-            addressRejCount.set(addr, c);
-            totalRejCount += c;
+        const rejectedSharesMap = (await this.redis.hGetAll(keys.rejectedShares)) ?? {};
+        const addressRejected = new Map<string, number>();
+        let totalRejected = 0;
+        for (const [addr, v] of Object.entries(rejectedSharesMap)) {
+            const r = parseFloat(v as string) || 0;
+            addressRejected.set(addr, r);
+            totalRejected += r;
         }
 
         const allAddresses = new Set<string>([
-            ...addressDiff.keys(),
-            ...addressRejDiff.keys(),
-            ...addressRejCount.keys(),
+            ...addressShares.keys(),
+            ...addressRejected.keys(),
         ]);
         const perAddress = Array.from(allAddresses).map((address) => {
-            const difficulty = addressDiff.get(address) ?? 0;
+            const shares = addressShares.get(address) ?? 0;
             return {
                 address,
-                difficulty,
-                percent: totalDiff > 0 ? (difficulty / totalDiff) * 100 : 0,
-                rejectedDifficulty: addressRejDiff.get(address) ?? 0,
-                rejectedShareCount: addressRejCount.get(address) ?? 0,
+                totalShares: shares,
+                percent: totalShares > 0 ? (shares / totalShares) * 100 : 0,
+                totalRejected: addressRejected.get(address) ?? 0,
             };
         }).sort((a, b) => b.percent - a.percent);
 
         return {
-            totalDifficulty: totalDiff,
-            shareCount: (entries ?? []).length,
-            totalRejectedDifficulty: totalRejDiff,
-            rejectedShareCount: totalRejCount,
+            totalShares,
+            totalRejected,
             perAddress,
         };
+    }
+
+    /**
+     * Best single share submitted in the current round across all group
+     * members — i.e. the highest diff-1-weighted share in the Redis window.
+     * Returns the value plus the address that submitted it. Resets when
+     * the round resets (block-found).
+     */
+    async getRoundBestDifficulty(groupId: string): Promise<{
+        bestDifficulty: number;
+        address: string | null;
+        time: number | null;
+    }> {
+        if (!this.isEnabled()) {
+            return { bestDifficulty: 0, address: null, time: null };
+        }
+        const keys = redisKeys(groupId);
+        const entries = await this.redis.zRange(keys.shares, 0, -1);
+        let bestDiff = 0;
+        let bestAddr: string | null = null;
+        let bestTime: number | null = null;
+        for (const e of (entries ?? [])) {
+            const [addr, diffStr, timeStr] = e.split(':');
+            const diff = parseFloat(diffStr) || 0;
+            if (diff > bestDiff) {
+                bestDiff = diff;
+                bestAddr = addr;
+                bestTime = parseInt(timeStr, 10) || null;
+            }
+        }
+        return { bestDifficulty: bestDiff, address: bestAddr, time: bestTime };
     }
 
     async getBlockHistory(groupId: string, limit = 100): Promise<PplnsGroupBlockHistoryEntity[]> {

--- a/src/services/group-solo.service.ts
+++ b/src/services/group-solo.service.ts
@@ -549,12 +549,27 @@ export class GroupSoloService implements OnModuleInit {
      * balance row, and their last-share timestamp. Called by GroupService
      * before deleting the member row during an admin kick.
      *
-     * Effect on the remaining members: their share of the round's total
-     * grows proportionally because `total` is decremented by exactly the
-     * diff we remove. On the next block, the distribution picks up the
-     * freed-up percentage automatically.
+     * Effect on the remaining members:
+     *   - Shares in the current Redis round: the kicked miner's entries
+     *     are removed and `total` is decremented by their diff. Others'
+     *     share of the round grows proportionally on the next block.
+     *   - Accumulated pending balance (sub-dust from prior rounds): split
+     *     equally among `remainingAddresses` and credited to each of
+     *     their pplns_group_balance rows. The kicked miner's row is then
+     *     deleted. Integer-division remainder (< N sats) is dropped.
+     *
+     * `remainingAddresses` is passed in by the caller (GroupService, which
+     * already read the member list for other reasons) so we don't need a
+     * second query inside this service. An empty list triggers forfeit —
+     * the only case where the group has literally no one left is on
+     * dissolveInternal, which uses removeGroupState instead anyway.
      */
-    async removeMemberState(groupId: string, address: string): Promise<void> {
+    async removeMemberState(groupId: string, address: string, remainingAddresses: string[] = []): Promise<void> {
+        // Read the kicked member's pending balance before we clear anything,
+        // so we can redistribute it on the way out.
+        const existing = await this.balanceRepo.findOneBy({ address, groupId });
+        const pendingToRedistribute = existing?.pendingSats ?? 0;
+
         if (this.isEnabled()) {
             const keys = redisKeys(groupId);
             const entries = await this.redis.zRange(keys.shares, 0, -1);
@@ -572,7 +587,18 @@ export class GroupSoloService implements OnModuleInit {
             await this.redis.hDel(keys.rejectedShares, address);
             await this.redis.hDel(keys.lastShareAt, address);
         }
+
         await this.balanceRepo.delete({ address, groupId });
+
+        if (pendingToRedistribute > 0 && remainingAddresses.length > 0) {
+            const perMember = Math.floor(pendingToRedistribute / remainingAddresses.length);
+            if (perMember > 0) {
+                for (const recipient of remainingAddresses) {
+                    await this.addPending(groupId, recipient, perMember);
+                }
+                console.log(`[GroupSolo] Kicked ${address} from ${groupId}: redistributed ${pendingToRedistribute} sats pending to ${remainingAddresses.length} member(s) (${perMember} each)`);
+            }
+        }
     }
 
     /**

--- a/src/services/group.service.spec.ts
+++ b/src/services/group.service.spec.ts
@@ -210,4 +210,61 @@ describe('GroupService', () => {
         // New token works
         await expect(service.requireAdminToken(group.id, newToken)).resolves.toBeDefined();
     });
+
+    // ── Batch add ────────────────────────────────────────────────
+
+    it('addMembersBatch adds multiple valid addresses in one call', async () => {
+        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
+        const result = await service.addMembersBatch(
+            group.id,
+            ['bc1qbob', 'bc1qcharlie', 'bc1qdan'],
+            adminToken,
+        );
+        expect(result.added.length).toBe(3);
+        expect(result.skipped.length).toBe(0);
+        expect(result.added.map(m => m.address)).toEqual(['bc1qbob', 'bc1qcharlie', 'bc1qdan']);
+    });
+
+    it('addMembersBatch skips already-member and continues with the rest', async () => {
+        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
+        await service.addMember(group.id, 'bc1qbob', adminToken);
+        const result = await service.addMembersBatch(
+            group.id,
+            ['bc1qbob', 'bc1qcharlie'],
+            adminToken,
+        );
+        expect(result.added.length).toBe(1);
+        expect(result.added[0].address).toBe('bc1qcharlie');
+        expect(result.skipped.length).toBe(1);
+        expect(result.skipped[0]).toMatchObject({ address: 'bc1qbob', reason: 'already-member' });
+    });
+
+    it('addMembersBatch skips address already in a different group', async () => {
+        const { group: g1, adminToken: t1 } = await service.createGroup('group-alpha', 'bc1qalice');
+        await service.addMember(g1.id, 'bc1qbob', t1);
+        const { group: g2, adminToken: t2 } = await service.createGroup('group-beta', 'bc1qcharlie');
+        const result = await service.addMembersBatch(g2.id, ['bc1qbob', 'bc1qdan'], t2);
+        expect(result.added.map(m => m.address)).toEqual(['bc1qdan']);
+        expect(result.skipped).toEqual([{ address: 'bc1qbob', reason: 'address-in-group' }]);
+    });
+
+    it('addMembersBatch collapses duplicates in the same submission', async () => {
+        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
+        const result = await service.addMembersBatch(
+            group.id,
+            ['bc1qbob', 'bc1qbob', 'bc1qcharlie'],
+            adminToken,
+        );
+        expect(result.added.map(m => m.address)).toEqual(['bc1qbob', 'bc1qcharlie']);
+        expect(result.skipped).toEqual([{ address: 'bc1qbob', reason: 'duplicate-in-batch' }]);
+    });
+
+    it('addMembersBatch rejects invalid admin token without adding anything', async () => {
+        const { group } = await service.createGroup('group-one', 'bc1qalice');
+        await expect(
+            service.addMembersBatch(group.id, ['bc1qbob'], 'GRP-wrong'),
+        ).rejects.toMatchObject({ code: 'invalid-token' });
+        const members = Array.from(memberRepo._rows.values()) as any[];
+        expect(members.length).toBe(1); // creator only
+    });
 });

--- a/src/services/group.service.spec.ts
+++ b/src/services/group.service.spec.ts
@@ -66,6 +66,27 @@ function createMockRepo<T extends { id?: any }>() {
                 }
             }
         }),
+        update: jest.fn(async (where: any, patch: any) => {
+            for (const row of rows.values()) {
+                if (Object.entries(where).every(([k, v]) => (row as any)[k] === v)) {
+                    Object.assign(row, patch);
+                }
+            }
+        }),
+    };
+}
+
+function createMockConfig(overrides: Record<string, string | undefined> = {}) {
+    return {
+        get: jest.fn((key: string) => overrides[key]),
+    };
+}
+
+function createMockGroupSolo() {
+    return {
+        getMemberLastActive: jest.fn(async () => null),
+        removeMemberState: jest.fn(async () => undefined),
+        removeGroupState: jest.fn(async () => undefined),
     };
 }
 
@@ -78,12 +99,20 @@ jest.mock('typeorm', () => ({
 describe('GroupService', () => {
     let groupRepo: ReturnType<typeof createMockRepo>;
     let memberRepo: ReturnType<typeof createMockRepo>;
+    let groupSolo: ReturnType<typeof createMockGroupSolo>;
     let service: GroupService;
 
     beforeEach(async () => {
         groupRepo = createMockRepo();
         memberRepo = createMockRepo();
-        service = new GroupService(groupRepo as any, memberRepo as any);
+        groupSolo = createMockGroupSolo();
+        const config = createMockConfig();
+        service = new GroupService(
+            groupRepo as any,
+            memberRepo as any,
+            config as any,
+            groupSolo as any,
+        );
         await service.onModuleInit();
     });
 
@@ -145,7 +174,9 @@ describe('GroupService', () => {
     it('deactivates group when member count drops below 2', async () => {
         const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
         await service.addMember(group.id, 'bc1qbob', adminToken);
-        await service.selfLeave(group.id, 'bc1qbob');
+        // Simulate inactivity by backdating joinedAt past the kick threshold.
+        await memberRepo.update({ address: 'bc1qbob' }, { joinedAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) });
+        await service.removeMember(group.id, 'bc1qbob', adminToken);
         const updated: any = await groupRepo.findOneBy({ id: group.id });
         expect(updated.active).toBe(false);
     });
@@ -167,36 +198,30 @@ describe('GroupService', () => {
     it('cache reflects inactive state when only one member remains', async () => {
         const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
         await service.addMember(group.id, 'bc1qbob', adminToken);
-        await service.selfLeave(group.id, 'bc1qbob');
+        await memberRepo.update({ address: 'bc1qbob' }, { joinedAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) });
+        await service.removeMember(group.id, 'bc1qbob', adminToken);
         // Creator still present but group inactive
         expect(service.getGroupForAddress('bc1qalice')).toEqual({ groupId: group.id, active: false });
     });
 
     // ── Creator leave / transfer ────────────────────────────────
 
-    it('blocks creator self-leave', async () => {
+    it('blocks removeMember when target is the creator', async () => {
         const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
         await service.addMember(group.id, 'bc1qbob', adminToken);
-        await expect(service.selfLeave(group.id, 'bc1qalice'))
-            .rejects.toMatchObject({ code: 'creator-cannot-self-leave' });
+        await expect(service.removeMember(group.id, 'bc1qalice', adminToken))
+            .rejects.toMatchObject({ code: 'creator-cannot-be-removed' });
     });
 
-    it('auto-transfers creator role to oldest member when creator is kicked by token', async () => {
-        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
-        await service.addMember(group.id, 'bc1qbob', adminToken);
-        await service.addMember(group.id, 'bc1qcharlie', adminToken);
-        await service.removeMember(group.id, 'bc1qalice', adminToken);
-
+    it('transferCreator + then the old creator is removable after inactivity window', async () => {
+        const { group, adminToken: oldToken } = await service.createGroup('group-one', 'bc1qalice');
+        await service.addMember(group.id, 'bc1qbob', oldToken);
+        const { adminToken: newToken } = await service.transferCreator(group.id, 'bc1qbob', oldToken);
+        // Backdate alice's join so she's eligible for removal under the 14d gate.
+        await memberRepo.update({ address: 'bc1qalice' }, { joinedAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) });
+        await service.removeMember(group.id, 'bc1qalice', newToken);
         const members = Array.from(memberRepo._rows.values()) as any[];
-        const creator = members.find(m => m.role === 'creator');
-        expect(creator.address).toBe('bc1qbob'); // oldest remaining
-    });
-
-    it('dissolves group when last creator leaves alone', async () => {
-        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
-        await service.removeMember(group.id, 'bc1qalice', adminToken);
-        const updated: any = await groupRepo.findOneBy({ id: group.id });
-        expect(updated.dissolvedAt).toBeDefined();
+        expect(members.find(m => m.address === 'bc1qalice')).toBeUndefined();
     });
 
     it('transferCreator rotates admin token', async () => {
@@ -211,60 +236,4 @@ describe('GroupService', () => {
         await expect(service.requireAdminToken(group.id, newToken)).resolves.toBeDefined();
     });
 
-    // ── Batch add ────────────────────────────────────────────────
-
-    it('addMembersBatch adds multiple valid addresses in one call', async () => {
-        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
-        const result = await service.addMembersBatch(
-            group.id,
-            ['bc1qbob', 'bc1qcharlie', 'bc1qdan'],
-            adminToken,
-        );
-        expect(result.added.length).toBe(3);
-        expect(result.skipped.length).toBe(0);
-        expect(result.added.map(m => m.address)).toEqual(['bc1qbob', 'bc1qcharlie', 'bc1qdan']);
-    });
-
-    it('addMembersBatch skips already-member and continues with the rest', async () => {
-        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
-        await service.addMember(group.id, 'bc1qbob', adminToken);
-        const result = await service.addMembersBatch(
-            group.id,
-            ['bc1qbob', 'bc1qcharlie'],
-            adminToken,
-        );
-        expect(result.added.length).toBe(1);
-        expect(result.added[0].address).toBe('bc1qcharlie');
-        expect(result.skipped.length).toBe(1);
-        expect(result.skipped[0]).toMatchObject({ address: 'bc1qbob', reason: 'already-member' });
-    });
-
-    it('addMembersBatch skips address already in a different group', async () => {
-        const { group: g1, adminToken: t1 } = await service.createGroup('group-alpha', 'bc1qalice');
-        await service.addMember(g1.id, 'bc1qbob', t1);
-        const { group: g2, adminToken: t2 } = await service.createGroup('group-beta', 'bc1qcharlie');
-        const result = await service.addMembersBatch(g2.id, ['bc1qbob', 'bc1qdan'], t2);
-        expect(result.added.map(m => m.address)).toEqual(['bc1qdan']);
-        expect(result.skipped).toEqual([{ address: 'bc1qbob', reason: 'address-in-group' }]);
-    });
-
-    it('addMembersBatch collapses duplicates in the same submission', async () => {
-        const { group, adminToken } = await service.createGroup('group-one', 'bc1qalice');
-        const result = await service.addMembersBatch(
-            group.id,
-            ['bc1qbob', 'bc1qbob', 'bc1qcharlie'],
-            adminToken,
-        );
-        expect(result.added.map(m => m.address)).toEqual(['bc1qbob', 'bc1qcharlie']);
-        expect(result.skipped).toEqual([{ address: 'bc1qbob', reason: 'duplicate-in-batch' }]);
-    });
-
-    it('addMembersBatch rejects invalid admin token without adding anything', async () => {
-        const { group } = await service.createGroup('group-one', 'bc1qalice');
-        await expect(
-            service.addMembersBatch(group.id, ['bc1qbob'], 'GRP-wrong'),
-        ).rejects.toMatchObject({ code: 'invalid-token' });
-        const members = Array.from(memberRepo._rows.values()) as any[];
-        expect(members.length).toBe(1); // creator only
-    });
 });

--- a/src/services/group.service.ts
+++ b/src/services/group.service.ts
@@ -181,6 +181,65 @@ export class GroupService implements OnModuleInit {
         return member;
     }
 
+    /**
+     * Adds multiple members in a single token check + single cache rebuild.
+     * Benign per-address failures (already-member, address-in-group, empty
+     * address) are collected into `skipped` instead of aborting the batch.
+     * Token failures still throw and abort — they're not a per-address
+     * issue but a missing/invalid auth credential.
+     */
+    async addMembersBatch(
+        groupId: string,
+        addresses: string[],
+        token: string | undefined,
+    ): Promise<{
+        added: { address: string; role: 'member'; joinedAt: Date }[];
+        skipped: { address: string; reason: 'already-member' | 'address-in-group' | 'invalid-address' | 'duplicate-in-batch' }[];
+    }> {
+        await this.requireAdminToken(groupId, token);
+
+        const added: { address: string; role: 'member'; joinedAt: Date }[] = [];
+        const skipped: { address: string; reason: 'already-member' | 'address-in-group' | 'invalid-address' | 'duplicate-in-batch' }[] = [];
+        const seen = new Set<string>();
+        let anyAdded = false;
+
+        for (const raw of addresses) {
+            const address = (raw ?? '').trim();
+            if (!address) {
+                skipped.push({ address: raw, reason: 'invalid-address' });
+                continue;
+            }
+            if (seen.has(address)) {
+                skipped.push({ address, reason: 'duplicate-in-batch' });
+                continue;
+            }
+            seen.add(address);
+
+            const existing = await this.memberRepo.findOneBy({ address });
+            if (existing) {
+                skipped.push({
+                    address,
+                    reason: existing.groupId === groupId ? 'already-member' : 'address-in-group',
+                });
+                continue;
+            }
+
+            const saved = await this.memberRepo.save(this.memberRepo.create({
+                groupId,
+                address,
+                role: 'member',
+            }));
+            added.push({ address: saved.address, role: 'member', joinedAt: saved.joinedAt });
+            anyAdded = true;
+        }
+
+        if (anyAdded) {
+            await this.recomputeActive(groupId);
+            await this.rebuildCache();
+        }
+        return { added, skipped };
+    }
+
     async removeMember(groupId: string, address: string, token: string | undefined): Promise<void> {
         await this.requireAdminToken(groupId, token);
         await this.internalRemove(groupId, address, /*fromCreator*/ true);

--- a/src/services/group.service.ts
+++ b/src/services/group.service.ts
@@ -1,9 +1,11 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { IsNull, Repository } from 'typeorm';
 import * as crypto from 'crypto';
 import { PplnsGroupEntity } from '../ORM/pplns-group/pplns-group.entity';
 import { PplnsGroupMemberEntity } from '../ORM/pplns-group/pplns-group-member.entity';
+import { GroupSoloService } from './group-solo.service';
 
 /**
  * Manages group lifecycle (create/transfer/dissolve), membership (add/kick/self-leave),
@@ -14,6 +16,8 @@ import { PplnsGroupMemberEntity } from '../ORM/pplns-group/pplns-group-member.en
  */
 
 const MIN_MEMBERS_ACTIVE = 2;
+const DEFAULT_KICK_INACTIVITY_DAYS = 14;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export class GroupServiceError extends Error {
     constructor(public readonly code: string, message: string) {
@@ -37,13 +41,23 @@ export class GroupService implements OnModuleInit {
 
     /** address → { groupId, active }. Refreshed on every membership change. */
     private addressCache = new Map<string, GroupCacheEntry>();
+    private readonly kickInactivityDays: number;
 
     constructor(
         @InjectRepository(PplnsGroupEntity)
         private readonly groupRepo: Repository<PplnsGroupEntity>,
         @InjectRepository(PplnsGroupMemberEntity)
         private readonly memberRepo: Repository<PplnsGroupMemberEntity>,
-    ) {}
+        private readonly configService: ConfigService,
+        @Inject(forwardRef(() => GroupSoloService))
+        private readonly groupSoloService: GroupSoloService,
+    ) {
+        const raw = this.configService.get<string>('GROUP_INACTIVITY_KICK_DAYS');
+        const parsed = raw ? parseInt(raw, 10) : NaN;
+        this.kickInactivityDays = Number.isFinite(parsed) && parsed >= 0
+            ? parsed
+            : DEFAULT_KICK_INACTIVITY_DAYS;
+    }
 
     async onModuleInit(): Promise<void> {
         await this.rebuildCache();
@@ -122,6 +136,12 @@ export class GroupService implements OnModuleInit {
         if (!trimmedName || trimmedName.length < 3 || trimmedName.length > 64) {
             throw new GroupServiceError('invalid-name', 'Group name must be 3–64 characters');
         }
+        // Control characters (CR, LF, NUL, TAB, …) break email Subject headers
+        // — reject them at the create boundary so the group name is safe to
+        // interpolate into transactional emails without further escaping.
+        if (/[\x00-\x1f\x7f]/.test(trimmedName)) {
+            throw new GroupServiceError('invalid-name', 'Group name must not contain control characters');
+        }
         if (!creatorAddress) {
             throw new GroupServiceError('invalid-address', 'Creator address required');
         }
@@ -192,78 +212,21 @@ export class GroupService implements OnModuleInit {
     }
 
     /**
-     * Adds multiple members in a single token check + single cache rebuild.
-     * Benign per-address failures (already-member, address-in-group, empty
-     * address) are collected into `skipped` instead of aborting the batch.
-     * Token failures still throw and abort — they're not a per-address
-     * issue but a missing/invalid auth credential.
+     * Remove a non-creator member. The target must be inactive for at least
+     * `GROUP_INACTIVITY_KICK_DAYS` days (default 14) measured from their last
+     * accepted share, or from `joinedAt` if they never mined. This keeps the
+     * admin from unilaterally evicting actively-mining members, while still
+     * allowing cleanup of abandoned memberships on long-lived groups.
+     *
+     * Before the member row is deleted the in-flight round state for that
+     * address (Redis shares, rejected counter, pending balance row) is
+     * cleared through `GroupSoloService.removeMemberState`, so their work
+     * evaporates from the current round and the remaining members' shares
+     * grow proportionally on the next block.
      */
-    async addMembersBatch(
-        groupId: string,
-        addresses: string[],
-        token: string | undefined,
-    ): Promise<{
-        added: { address: string; role: 'member'; joinedAt: Date }[];
-        skipped: { address: string; reason: 'already-member' | 'address-in-group' | 'invalid-address' | 'duplicate-in-batch' }[];
-    }> {
-        await this.requireAdminToken(groupId, token);
-
-        const added: { address: string; role: 'member'; joinedAt: Date }[] = [];
-        const skipped: { address: string; reason: 'already-member' | 'address-in-group' | 'invalid-address' | 'duplicate-in-batch' }[] = [];
-        const seen = new Set<string>();
-        let anyAdded = false;
-
-        for (const raw of addresses) {
-            const address = (raw ?? '').trim();
-            if (!address) {
-                skipped.push({ address: raw, reason: 'invalid-address' });
-                continue;
-            }
-            if (seen.has(address)) {
-                skipped.push({ address, reason: 'duplicate-in-batch' });
-                continue;
-            }
-            seen.add(address);
-
-            const existing = await this.memberRepo.findOneBy({ address });
-            if (existing) {
-                skipped.push({
-                    address,
-                    reason: existing.groupId === groupId ? 'already-member' : 'address-in-group',
-                });
-                continue;
-            }
-
-            const saved = await this.memberRepo.save(this.memberRepo.create({
-                groupId,
-                address,
-                role: 'member',
-            }));
-            added.push({ address: saved.address, role: 'member', joinedAt: saved.joinedAt });
-            anyAdded = true;
-        }
-
-        if (anyAdded) {
-            await this.recomputeActive(groupId);
-            await this.rebuildCache();
-        }
-        return { added, skipped };
-    }
-
     async removeMember(groupId: string, address: string, token: string | undefined): Promise<void> {
         await this.requireAdminToken(groupId, token);
         await this.internalRemove(groupId, address, /*fromCreator*/ true);
-    }
-
-    async selfLeave(groupId: string, address: string): Promise<void> {
-        const member = await this.memberRepo.findOneBy({ groupId, address });
-        if (!member) {
-            throw new GroupServiceError('not-member', 'Address is not a member of this group');
-        }
-        if (member.role === 'creator') {
-            throw new GroupServiceError('creator-cannot-self-leave', 'Creator must transfer role or dissolve the group before leaving');
-        }
-        await this.internalRemove(groupId, address, /*fromCreator*/ false);
     }
 
     private async internalRemove(groupId: string, address: string, fromCreator: boolean): Promise<void> {
@@ -271,34 +234,24 @@ export class GroupService implements OnModuleInit {
         if (!member) {
             throw new GroupServiceError('not-member', 'Address is not a member of this group');
         }
-
         if (member.role === 'creator') {
-            // Creator removal: auto-transfer to oldest remaining member, or dissolve if none.
-            const remaining = await this.memberRepo.find({
-                where: { groupId },
-                order: { joinedAt: 'ASC' },
-            });
-            const others = remaining.filter(m => m.address !== address);
-            if (others.length === 0) {
-                await this.dissolveInternal(groupId);
-                return;
-            }
-            const newCreator = others[0];
-            newCreator.role = 'creator';
-            await this.memberRepo.save(newCreator);
-            // Rotate admin token so old one can't be used anymore.
-            const newToken = this.generateToken();
-            const group = await this.groupRepo.findOneBy({ id: groupId });
-            if (group) {
-                group.adminTokenHash = this.hashToken(newToken);
-                group.creatorAddress = newCreator.address;
-                await this.groupRepo.save(group);
-            }
-            // NOTE: The new admin token can't be returned from this path since it's
-            // triggered by a creator-leave. The new creator must call /recover if
-            // they don't have the token. (Recovery not implemented in MVP.)
+            throw new GroupServiceError(
+                'creator-cannot-be-removed',
+                'Creator must transfer the role or dissolve the group before being removed',
+            );
         }
 
+        const lastActive = await this.groupSoloService.getMemberLastActive(groupId, address);
+        const reference = lastActive ?? member.joinedAt.getTime();
+        const daysSince = (Date.now() - reference) / MS_PER_DAY;
+        if (daysSince < this.kickInactivityDays) {
+            throw new GroupServiceError(
+                'member-still-active',
+                `Member has been active within the last ${this.kickInactivityDays} days`,
+            );
+        }
+
+        await this.groupSoloService.removeMemberState(groupId, address);
         await this.memberRepo.delete({ groupId, address });
         await this.recomputeActive(groupId);
         await this.rebuildCache();
@@ -345,6 +298,12 @@ export class GroupService implements OnModuleInit {
     }
 
     private async dissolveInternal(groupId: string): Promise<void> {
+        // Clear all group-solo round state (Redis shares, rejected hash,
+        // last-seen hash, pending balance rows) before dropping the members.
+        // Without this the keys live forever in Valkey since they carry no
+        // TTL, and orphan balance rows would be stranded with a groupId
+        // that no longer resolves.
+        await this.groupSoloService.removeGroupState(groupId);
         await this.memberRepo.delete({ groupId });
         const group = await this.groupRepo.findOneBy({ id: groupId });
         if (group) {

--- a/src/services/group.service.ts
+++ b/src/services/group.service.ts
@@ -6,6 +6,7 @@ import * as crypto from 'crypto';
 import { PplnsGroupEntity } from '../ORM/pplns-group/pplns-group.entity';
 import { PplnsGroupMemberEntity } from '../ORM/pplns-group/pplns-group-member.entity';
 import { GroupSoloService } from './group-solo.service';
+import { normalizeBtcAddress } from '../utils/btc-address.utils';
 
 /**
  * Manages group lifecycle (create/transfer/dissolve), membership (add/kick/self-leave),
@@ -114,7 +115,7 @@ export class GroupService implements OnModuleInit {
     // ── Lookup ────────────────────────────────────────────────────
 
     getGroupForAddress(address: string): GroupCacheEntry | undefined {
-        return this.addressCache.get(address);
+        return this.addressCache.get(normalizeBtcAddress(address));
     }
 
     async getGroup(groupId: string): Promise<PplnsGroupEntity | null> {
@@ -142,7 +143,8 @@ export class GroupService implements OnModuleInit {
         if (/[\x00-\x1f\x7f]/.test(trimmedName)) {
             throw new GroupServiceError('invalid-name', 'Group name must not contain control characters');
         }
-        if (!creatorAddress) {
+        const normalizedAddress = normalizeBtcAddress(creatorAddress);
+        if (!normalizedAddress) {
             throw new GroupServiceError('invalid-address', 'Creator address required');
         }
 
@@ -151,7 +153,7 @@ export class GroupService implements OnModuleInit {
             throw new GroupServiceError('name-taken', 'Group name already in use');
         }
 
-        const existingMember = await this.memberRepo.findOneBy({ address: creatorAddress });
+        const existingMember = await this.memberRepo.findOneBy({ address: normalizedAddress });
         if (existingMember) {
             throw new GroupServiceError('address-in-group', 'Address is already a member of another group');
         }
@@ -160,14 +162,14 @@ export class GroupService implements OnModuleInit {
         const group = await this.groupRepo.save(this.groupRepo.create({
             id: crypto.randomUUID(),
             name: trimmedName,
-            creatorAddress,
+            creatorAddress: normalizedAddress,
             adminTokenHash: this.hashToken(adminToken),
             active: false,
         }));
 
         await this.memberRepo.save(this.memberRepo.create({
             groupId: group.id,
-            address: creatorAddress,
+            address: normalizedAddress,
             role: 'creator',
         }));
 
@@ -188,11 +190,12 @@ export class GroupService implements OnModuleInit {
      * invitee proves they own the address by clicking the email link.
      */
     async addMemberWithoutAdmin(groupId: string, address: string): Promise<PplnsGroupMemberEntity> {
-        if (!address) {
+        const normalizedAddress = normalizeBtcAddress(address);
+        if (!normalizedAddress) {
             throw new GroupServiceError('invalid-address', 'Address required');
         }
 
-        const existing = await this.memberRepo.findOneBy({ address });
+        const existing = await this.memberRepo.findOneBy({ address: normalizedAddress });
         if (existing) {
             if (existing.groupId === groupId) {
                 throw new GroupServiceError('already-member', 'Address is already in this group');
@@ -202,7 +205,7 @@ export class GroupService implements OnModuleInit {
 
         const member = await this.memberRepo.save(this.memberRepo.create({
             groupId,
-            address,
+            address: normalizedAddress,
             role: 'member',
         }));
 

--- a/src/services/group.service.ts
+++ b/src/services/group.service.ts
@@ -158,6 +158,16 @@ export class GroupService implements OnModuleInit {
 
     async addMember(groupId: string, address: string, token: string | undefined): Promise<PplnsGroupMemberEntity> {
         await this.requireAdminToken(groupId, token);
+        return this.addMemberWithoutAdmin(groupId, address);
+    }
+
+    /**
+     * Add a member bypassing the admin-token check. Intended for callers
+     * that have already verified authorization through a different
+     * mechanism — currently only the invitation-accept flow, where the
+     * invitee proves they own the address by clicking the email link.
+     */
+    async addMemberWithoutAdmin(groupId: string, address: string): Promise<PplnsGroupMemberEntity> {
         if (!address) {
             throw new GroupServiceError('invalid-address', 'Address required');
         }

--- a/src/services/group.service.ts
+++ b/src/services/group.service.ts
@@ -251,7 +251,16 @@ export class GroupService implements OnModuleInit {
             );
         }
 
-        await this.groupSoloService.removeMemberState(groupId, address);
+        // Snapshot the remaining members BEFORE we delete the target — the
+        // state-cleanup step splits the kicked miner's pending balance
+        // across these addresses, so we need the list before the member
+        // row vanishes from the DB.
+        const allMembers = await this.memberRepo.find({ where: { groupId } });
+        const remainingAddresses = allMembers
+            .filter(m => m.address !== address)
+            .map(m => m.address);
+
+        await this.groupSoloService.removeMemberState(groupId, address, remainingAddresses);
         await this.memberRepo.delete({ groupId, address });
         await this.recomputeActive(groupId);
         await this.rebuildCache();

--- a/src/services/pplns-group-invitation.service.spec.ts
+++ b/src/services/pplns-group-invitation.service.spec.ts
@@ -125,8 +125,9 @@ describe('PplnsGroupInvitationService', () => {
         const sent = (emailService.sendInvitation as jest.Mock).mock.calls[0][0];
         expect(sent.to).toBe('bob@example.com');
         expect(sent.address).toBe('bc1qbob');
-        expect(sent.acceptUrl).toContain('https://blitzpool.test/invite/');
-        expect(sent.declineUrl).toContain('/decline');
+        // Single inviteUrl pointing at the UI invite page — no automatic
+        // accept/decline URL anymore, the user confirms on the page.
+        expect(sent.inviteUrl).toContain('https://blitzpool.test/invite/');
 
         expect(invitationRepo.rows).toHaveLength(1);
         expect(invitationRepo.rows[0].status).toBe('pending');

--- a/src/services/pplns-group-invitation.service.spec.ts
+++ b/src/services/pplns-group-invitation.service.spec.ts
@@ -181,6 +181,21 @@ describe('PplnsGroupInvitationService', () => {
         await expect(service.accept(r.token)).rejects.toThrow(/declined/i);
     });
 
+    it('accept fails when the group has been dissolved between invite and accept', async () => {
+        const { service, addressEmailService, groupService, memberRepo } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r = await service.createInvitation('g1', 'bc1qbob', 'good-token');
+
+        // Admin dissolves the group after the invite but before the accept.
+        groupService.getGroup = jest.fn(async (id: string) => ({
+            id, name: 'Friends', creatorAddress: 'bc1qadmin',
+            dissolvedAt: new Date(),
+        }));
+
+        await expect(service.accept(r.token)).rejects.toMatchObject({ code: 'group-dissolved' });
+        expect(memberRepo.rows).toHaveLength(0);
+    });
+
     it('accept fails on expired invitation', async () => {
         const { service, addressEmailService, invitationRepo } = makeService();
         addressEmailService._setVerified('bc1qbob', 'bob@example.com');

--- a/src/services/pplns-group-invitation.service.spec.ts
+++ b/src/services/pplns-group-invitation.service.spec.ts
@@ -127,7 +127,8 @@ describe('PplnsGroupInvitationService', () => {
         expect(sent.address).toBe('bc1qbob');
         // Single inviteUrl pointing at the UI invite page — no automatic
         // accept/decline URL anymore, the user confirms on the page.
-        expect(sent.inviteUrl).toContain('https://blitzpool.test/invite/');
+        // Hash routing: path lives in the fragment, hence /#/invite/<token>.
+        expect(sent.inviteUrl).toContain('https://blitzpool.test/#/invite/');
 
         expect(invitationRepo.rows).toHaveLength(1);
         expect(invitationRepo.rows[0].status).toBe('pending');

--- a/src/services/pplns-group-invitation.service.spec.ts
+++ b/src/services/pplns-group-invitation.service.spec.ts
@@ -222,6 +222,12 @@ describe('PplnsGroupInvitationService', () => {
 
         const list = await service.listPendingForAddress('bc1qbob');
         expect(list).toHaveLength(1);
-        expect(list[0].token).toBe(r1.token);
+        // Sanity: the response is the non-expired one (we can tell by the groupId).
+        expect(list[0].groupId).toBe('g1');
+        // The token is deliberately NOT in the response — this endpoint serves
+        // the public dashboard banner, and leaking the token would let any
+        // visitor of /app/:address accept the invitation on the recipient's
+        // behalf. Reference r1.token to avoid an unused-binding complaint.
+        expect(r1.token).toBeTruthy();
     });
 });

--- a/src/services/pplns-group-invitation.service.spec.ts
+++ b/src/services/pplns-group-invitation.service.spec.ts
@@ -1,0 +1,225 @@
+jest.mock('node-telegram-bot-api', () => jest.fn());
+
+import { PplnsGroupInvitationService, InvitationServiceError } from './pplns-group-invitation.service';
+
+function makeRepo<T>() {
+    const rows: T[] = [];
+    return {
+        rows,
+        save: jest.fn(async (row: T) => {
+            const idx = (rows as any[]).findIndex((r: any) =>
+                ('token' in (row as any) && r.token === (row as any).token) ||
+                ('id' in (row as any) && r.id === (row as any).id),
+            );
+            if (idx >= 0) {
+                rows[idx] = { ...(rows[idx] as any), ...(row as any) };
+                return rows[idx];
+            }
+            rows.push({ ...(row as any) });
+            return row;
+        }),
+        create: jest.fn((partial: Partial<T>) => ({ ...partial }) as T),
+        find: jest.fn(async (opts?: any) => {
+            if (!opts?.where) return [...rows];
+            const where = opts.where;
+            return (rows as any[]).filter((r) =>
+                Object.entries(where).every(([k, v]) => r[k] === v),
+            );
+        }),
+        findOneBy: jest.fn(async (where: any) => {
+            return (rows as any[]).find((r) =>
+                Object.entries(where).every(([k, v]) => r[k] === v),
+            ) ?? null;
+        }),
+        findOne: jest.fn(async (opts: any) => {
+            const where = opts.where ?? {};
+            return (rows as any[]).find((r) =>
+                Object.entries(where).every(([k, v]) => r[k] === v),
+            ) ?? null;
+        }),
+        delete: jest.fn(async (where: any) => {
+            const before = rows.length;
+            const remaining = (rows as any[]).filter((r) => {
+                if (typeof where === 'string') return r.token !== where;
+                return !Object.entries(where).every(([k, v]) => r[k] === v);
+            });
+            rows.length = 0;
+            rows.push(...remaining as any);
+            return { affected: before - rows.length };
+        }),
+        update: jest.fn(async () => ({ affected: 0 })),
+    };
+}
+
+function makeService(opts: { emailEnabled?: boolean } = {}) {
+    const invitationRepo = makeRepo<any>();
+    const memberRepo = makeRepo<any>();
+    const groupService = {
+        requireAdminToken: jest.fn(async (groupId: string, token: string | undefined) => {
+            if (!token) throw new (require('./group.service').GroupServiceError)('missing-token', 'no token');
+            if (token !== 'good-token') throw new (require('./group.service').GroupServiceError)('invalid-token', 'bad');
+            return { id: groupId, name: 'Friends', creatorAddress: 'bc1qadmin' };
+        }),
+        getGroup: jest.fn(async (id: string) => ({
+            id, name: 'Friends', creatorAddress: 'bc1qadmin', dissolvedAt: null,
+        })),
+        addMemberWithoutAdmin: jest.fn(async (groupId: string, address: string) => {
+            const existing = memberRepo.rows.find((m: any) => m.address === address);
+            if (existing) throw new (require('./group.service').GroupServiceError)('address-in-group', 'already in another group');
+            const m = { groupId, address, role: 'member', joinedAt: new Date() };
+            memberRepo.rows.push(m);
+            return m;
+        }),
+    };
+    const addressEmailService = {
+        getVerified: jest.fn(async (address: string) => {
+            const verified = (addressEmailService as any)._verified.get(address);
+            return verified ?? null;
+        }),
+        _verified: new Map<string, any>(),
+        _setVerified: (address: string, email: string) => {
+            (addressEmailService as any)._verified.set(address, { address, email, verifiedAt: new Date() });
+        },
+    };
+    const emailService = {
+        isEnabled: jest.fn(() => opts.emailEnabled !== false),
+        sendInvitation: jest.fn(async () => undefined),
+        sendVerification: jest.fn(async () => undefined),
+    };
+    const config = {
+        get: jest.fn((key: string) => {
+            if (key === 'POOL_BASE_URL') return 'https://blitzpool.test';
+            return undefined;
+        }),
+    };
+    const service = new PplnsGroupInvitationService(
+        invitationRepo as any,
+        memberRepo as any,
+        groupService as any,
+        addressEmailService as any,
+        emailService as any,
+        config as any,
+    );
+    return { service, invitationRepo, memberRepo, groupService, addressEmailService, emailService };
+}
+
+describe('PplnsGroupInvitationService', () => {
+
+    it('createInvitation refuses if address has no verified email', async () => {
+        const { service } = makeService();
+        await expect(
+            service.createInvitation('g1', 'bc1qbob', 'good-token'),
+        ).rejects.toThrow(/email/i);
+    });
+
+    it('createInvitation succeeds when address has verified email + sends mail', async () => {
+        const { service, addressEmailService, emailService, invitationRepo } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+
+        const r = await service.createInvitation('g1', 'bc1qbob', 'good-token');
+        expect(r.email).toBe('bob@example.com');
+        expect(r.token).toBeTruthy();
+        expect(r.expiresAt).toBeInstanceOf(Date);
+
+        expect(emailService.sendInvitation).toHaveBeenCalledTimes(1);
+        const sent = (emailService.sendInvitation as jest.Mock).mock.calls[0][0];
+        expect(sent.to).toBe('bob@example.com');
+        expect(sent.address).toBe('bc1qbob');
+        expect(sent.acceptUrl).toContain('https://blitzpool.test/invite/');
+        expect(sent.declineUrl).toContain('/decline');
+
+        expect(invitationRepo.rows).toHaveLength(1);
+        expect(invitationRepo.rows[0].status).toBe('pending');
+    });
+
+    it('createInvitation rejects bad admin token', async () => {
+        const { service, addressEmailService } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        await expect(
+            service.createInvitation('g1', 'bc1qbob', 'wrong-token'),
+        ).rejects.toMatchObject({ code: 'invalid-token' });
+    });
+
+    it('createInvitation refuses if invitation already pending', async () => {
+        const { service, addressEmailService } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        await service.createInvitation('g1', 'bc1qbob', 'good-token');
+        await expect(
+            service.createInvitation('g1', 'bc1qbob', 'good-token'),
+        ).rejects.toThrow(/pending/i);
+    });
+
+    it('accept creates the membership', async () => {
+        const { service, addressEmailService, memberRepo } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r = await service.createInvitation('g1', 'bc1qbob', 'good-token');
+
+        const member = await service.accept(r.token);
+        expect(member.address).toBe('bc1qbob');
+        expect(member.groupId).toBe('g1');
+        expect(memberRepo.rows).toHaveLength(1);
+    });
+
+    it('accept twice is idempotent (second call returns same member)', async () => {
+        const { service, addressEmailService } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r = await service.createInvitation('g1', 'bc1qbob', 'good-token');
+
+        const m1 = await service.accept(r.token);
+        const m2 = await service.accept(r.token);
+        expect(m1.address).toBe(m2.address);
+    });
+
+    it('accept fails on declined invitation', async () => {
+        const { service, addressEmailService } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r = await service.createInvitation('g1', 'bc1qbob', 'good-token');
+
+        await service.decline(r.token);
+        await expect(service.accept(r.token)).rejects.toThrow(/declined/i);
+    });
+
+    it('accept fails on expired invitation', async () => {
+        const { service, addressEmailService, invitationRepo } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r = await service.createInvitation('g1', 'bc1qbob', 'good-token');
+
+        // Force expiry
+        const row = invitationRepo.rows[0];
+        row.expiresAt = new Date(Date.now() - 1000);
+
+        await expect(service.accept(r.token)).rejects.toThrow(/expired/i);
+        expect(invitationRepo.rows[0].status).toBe('expired');
+    });
+
+    it('decline marks invitation as declined; second accept fails', async () => {
+        const { service, addressEmailService, invitationRepo } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r = await service.createInvitation('g1', 'bc1qbob', 'good-token');
+
+        await service.decline(r.token);
+        expect(invitationRepo.rows[0].status).toBe('declined');
+        await expect(service.accept(r.token)).rejects.toThrow();
+    });
+
+    it('listPendingForAddress returns only pending non-expired invitations', async () => {
+        const { service, addressEmailService, invitationRepo } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r1 = await service.createInvitation('g1', 'bc1qbob', 'good-token');
+
+        // Make it look like a different address has been invited too, but expired
+        invitationRepo.rows.push({
+            token: 'expired-token',
+            groupId: 'g2',
+            address: 'bc1qbob',
+            email: 'bob@example.com',
+            status: 'pending',
+            createdAt: new Date(Date.now() - 100_000),
+            expiresAt: new Date(Date.now() - 1000),
+        });
+
+        const list = await service.listPendingForAddress('bc1qbob');
+        expect(list).toHaveLength(1);
+        expect(list[0].token).toBe(r1.token);
+    });
+});

--- a/src/services/pplns-group-invitation.service.ts
+++ b/src/services/pplns-group-invitation.service.ts
@@ -1,0 +1,288 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThan, Repository } from 'typeorm';
+import * as crypto from 'crypto';
+import { PplnsGroupEntity } from '../ORM/pplns-group/pplns-group.entity';
+import { PplnsGroupMemberEntity } from '../ORM/pplns-group/pplns-group-member.entity';
+import { PplnsGroupInvitationEntity } from '../ORM/pplns-group/pplns-group-invitation.entity';
+import { GroupService, GroupServiceError } from './group.service';
+import { AddressEmailService } from './address-email.service';
+import { EmailService } from './email.service';
+
+const INVITATION_TTL_DAYS = 7;
+
+export class InvitationServiceError extends Error {
+    constructor(public readonly code: string, message: string) {
+        super(message);
+    }
+}
+
+export interface CreatedInvitation {
+    token: string;
+    email: string;
+    expiresAt: Date;
+}
+
+/**
+ * Two-phase membership for payout groups: an admin creates an invitation
+ * (this service), an email is sent to the address holder, and they accept
+ * (or decline) via a tokenized link. Only on accept does the address
+ * actually become a member of the group.
+ *
+ * The trust anchor is the verified email bound to the address — without it
+ * an admin cannot create an invitation, and without the email-delivered
+ * token the invitation cannot be accepted. This blocks the silent-add
+ * attack where an admin would otherwise route an unsuspecting miner's
+ * payouts into their own group.
+ */
+@Injectable()
+export class PplnsGroupInvitationService {
+
+    constructor(
+        @InjectRepository(PplnsGroupInvitationEntity)
+        private readonly invitationRepo: Repository<PplnsGroupInvitationEntity>,
+        @InjectRepository(PplnsGroupMemberEntity)
+        private readonly memberRepo: Repository<PplnsGroupMemberEntity>,
+        private readonly groupService: GroupService,
+        private readonly addressEmailService: AddressEmailService,
+        private readonly emailService: EmailService,
+        private readonly config: ConfigService,
+    ) {}
+
+    /**
+     * Create + send a single invitation. Admin token is verified by
+     * GroupService; we then check the invited address has a verified
+     * email binding before sending.
+     */
+    async createInvitation(
+        groupId: string,
+        address: string,
+        adminToken: string | undefined,
+    ): Promise<CreatedInvitation> {
+        const group = await this.groupService.requireAdminToken(groupId, adminToken);
+
+        if (!address) throw new InvitationServiceError('invalid-address', 'Address required');
+
+        // Already a member? Skip.
+        const existingMember = await this.memberRepo.findOneBy({ address });
+        if (existingMember) {
+            if (existingMember.groupId === groupId) {
+                throw new InvitationServiceError('already-member', 'Address is already in this group');
+            }
+            throw new InvitationServiceError('address-in-group', 'Address is already a member of another group');
+        }
+
+        // Pending invitation already in flight? Skip.
+        const pending = await this.invitationRepo.findOne({
+            where: { groupId, address, status: 'pending' },
+        });
+        if (pending && pending.expiresAt.getTime() > Date.now()) {
+            throw new InvitationServiceError('invitation-pending', 'An invitation for this address is already pending');
+        }
+
+        // Email-verified address? Mandatory.
+        const binding = await this.addressEmailService.getVerified(address);
+        if (!binding) {
+            throw new InvitationServiceError(
+                'email-not-verified',
+                'Address has no verified email. Ask the recipient to bind one in their dashboard first.',
+            );
+        }
+
+        // Mark any expired pending invitation as expired (cleanup).
+        if (pending && pending.expiresAt.getTime() <= Date.now()) {
+            pending.status = 'expired';
+            await this.invitationRepo.save(pending);
+        }
+
+        const token = this.generateToken();
+        const expiresAt = new Date(Date.now() + INVITATION_TTL_DAYS * 24 * 60 * 60 * 1000);
+        const invitation = await this.invitationRepo.save(this.invitationRepo.create({
+            token,
+            groupId,
+            address,
+            email: binding.email,
+            status: 'pending',
+            expiresAt,
+        }));
+
+        const baseUrl = this.poolBaseUrl();
+        await this.emailService.sendInvitation({
+            to: binding.email,
+            address,
+            groupName: group.name,
+            inviterAddress: group.creatorAddress,
+            acceptUrl: `${baseUrl}/invite/${token}/accept`,
+            declineUrl: `${baseUrl}/invite/${token}/decline`,
+            expiresAt: invitation.expiresAt,
+        });
+
+        return { token: invitation.token, email: binding.email, expiresAt: invitation.expiresAt };
+    }
+
+    /**
+     * Look up an invitation by its public token. Used by the accept/decline
+     * UI to render the group context before the user commits.
+     */
+    async getByToken(token: string): Promise<{
+        invitation: PplnsGroupInvitationEntity;
+        group: PplnsGroupEntity;
+    } | null> {
+        const invitation = await this.invitationRepo.findOneBy({ token });
+        if (!invitation) return null;
+        const group = await this.groupService.getGroup(invitation.groupId);
+        if (!group || group.dissolvedAt) return null;
+        return { invitation, group };
+    }
+
+    /**
+     * Accept an invitation. Idempotent on the resulting membership: if the
+     * token has already been accepted, surfaces 'already-accepted' rather
+     * than creating a duplicate member.
+     */
+    async accept(token: string): Promise<PplnsGroupMemberEntity> {
+        const invitation = await this.invitationRepo.findOneBy({ token });
+        if (!invitation) {
+            throw new InvitationServiceError('not-found', 'Invitation unknown or already consumed');
+        }
+        if (invitation.status === 'accepted') {
+            const member = await this.memberRepo.findOneBy({
+                groupId: invitation.groupId,
+                address: invitation.address,
+            });
+            if (member) return member;
+            throw new InvitationServiceError('inconsistent', 'Invitation accepted but member missing — contact admin');
+        }
+        if (invitation.status === 'declined') {
+            throw new InvitationServiceError('already-declined', 'Invitation was declined');
+        }
+        if (invitation.expiresAt.getTime() < Date.now()) {
+            invitation.status = 'expired';
+            await this.invitationRepo.save(invitation);
+            throw new InvitationServiceError('expired', 'Invitation has expired');
+        }
+
+        // Make sure the address didn't join another group in the meantime.
+        const existingMember = await this.memberRepo.findOneBy({ address: invitation.address });
+        if (existingMember && existingMember.groupId !== invitation.groupId) {
+            throw new InvitationServiceError('address-in-group', 'Address is now in another group — invitation invalid');
+        }
+        if (existingMember && existingMember.groupId === invitation.groupId) {
+            // Defensive — user is already a member somehow (manual add?), just
+            // mark invitation accepted and return the existing member.
+            invitation.status = 'accepted';
+            invitation.respondedAt = new Date();
+            await this.invitationRepo.save(invitation);
+            return existingMember;
+        }
+
+        const member = await this.groupService.addMemberWithoutAdmin(
+            invitation.groupId,
+            invitation.address,
+        );
+
+        invitation.status = 'accepted';
+        invitation.respondedAt = new Date();
+        await this.invitationRepo.save(invitation);
+        return member;
+    }
+
+    /**
+     * Decline an invitation. No auth — anyone with the token can decline.
+     * That's intentional: there's no incentive for a third party to decline
+     * on someone's behalf, and it lets the recipient dispose of the
+     * invitation even if they've lost access to the email account that
+     * received it.
+     */
+    async decline(token: string): Promise<void> {
+        const invitation = await this.invitationRepo.findOneBy({ token });
+        if (!invitation) {
+            throw new InvitationServiceError('not-found', 'Invitation unknown or already consumed');
+        }
+        if (invitation.status === 'pending') {
+            invitation.status = 'declined';
+            invitation.respondedAt = new Date();
+            await this.invitationRepo.save(invitation);
+        }
+    }
+
+    /**
+     * List pending invitations for an address — drives the "you have
+     * pending invitations" banner on the dashboard.
+     */
+    async listPendingForAddress(address: string): Promise<{
+        token: string;
+        groupId: string;
+        groupName: string;
+        inviterAddress: string;
+        createdAt: Date;
+        expiresAt: Date;
+    }[]> {
+        const rows = await this.invitationRepo.find({
+            where: { address, status: 'pending' },
+            order: { createdAt: 'DESC' },
+        });
+        const now = Date.now();
+        const result: any[] = [];
+        for (const row of rows) {
+            if (row.expiresAt.getTime() < now) continue;
+            const group = await this.groupService.getGroup(row.groupId);
+            if (!group || group.dissolvedAt) continue;
+            result.push({
+                token: row.token,
+                groupId: row.groupId,
+                groupName: group.name,
+                inviterAddress: group.creatorAddress,
+                createdAt: row.createdAt,
+                expiresAt: row.expiresAt,
+            });
+        }
+        return result;
+    }
+
+    /**
+     * List pending invitations for a group — admin uses this to see who's
+     * been invited but hasn't responded yet, and to cancel if needed.
+     */
+    async listPendingForGroup(groupId: string): Promise<PplnsGroupInvitationEntity[]> {
+        const rows = await this.invitationRepo.find({
+            where: { groupId, status: 'pending' },
+            order: { createdAt: 'DESC' },
+        });
+        const now = Date.now();
+        return rows.filter(r => r.expiresAt.getTime() >= now);
+    }
+
+    async cancelInvitation(token: string, groupId: string, adminToken: string | undefined): Promise<void> {
+        await this.groupService.requireAdminToken(groupId, adminToken);
+        const invitation = await this.invitationRepo.findOneBy({ token });
+        if (!invitation || invitation.groupId !== groupId) {
+            throw new InvitationServiceError('not-found', 'Invitation not found in this group');
+        }
+        await this.invitationRepo.delete({ token });
+    }
+
+    /**
+     * Periodic cleanup — flips expired pending invitations to 'expired'.
+     */
+    async expireOld(): Promise<number> {
+        const result = await this.invitationRepo.update(
+            { status: 'pending', expiresAt: LessThan(new Date()) },
+            { status: 'expired' },
+        );
+        return result.affected ?? 0;
+    }
+
+    private generateToken(): string {
+        return crypto.randomBytes(32).toString('base64url');
+    }
+
+    private poolBaseUrl(): string {
+        const url = this.config.get<string>('POOL_BASE_URL');
+        if (!url) {
+            throw new InvitationServiceError('config-missing', 'POOL_BASE_URL is not set');
+        }
+        return url.replace(/\/+$/, '');
+    }
+}

--- a/src/services/pplns-group-invitation.service.ts
+++ b/src/services/pplns-group-invitation.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { Interval } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { LessThan, Repository } from 'typeorm';
 import * as crypto from 'crypto';
@@ -38,6 +39,8 @@ export interface CreatedInvitation {
  */
 @Injectable()
 export class PplnsGroupInvitationService {
+
+    private readonly logger = new Logger(PplnsGroupInvitationService.name);
 
     constructor(
         @InjectRepository(PplnsGroupInvitationEntity)
@@ -169,6 +172,15 @@ export class PplnsGroupInvitationService {
             throw new InvitationServiceError('expired', 'Invitation has expired');
         }
 
+        // The group may have been dissolved between invite-send and accept.
+        // addMemberWithoutAdmin would happily write a member row into a
+        // dissolved group (rebuildCache filters it out but the stale DB
+        // row remains, causing UI/stratum inconsistency). Block it here.
+        const group = await this.groupService.getGroup(invitation.groupId);
+        if (!group || group.dissolvedAt) {
+            throw new InvitationServiceError('group-dissolved', 'Group no longer exists');
+        }
+
         // Make sure the address didn't join another group in the meantime.
         const existingMember = await this.memberRepo.findOneBy({ address: invitation.address });
         if (existingMember && existingMember.groupId !== invitation.groupId) {
@@ -290,13 +302,23 @@ export class PplnsGroupInvitationService {
 
     /**
      * Periodic cleanup — flips expired pending invitations to 'expired'.
+     * Fires hourly via @Interval. The method is also safe to call directly
+     * (tests / admin endpoints).
      */
+    @Interval(60 * 60 * 1000)
     async expireOld(): Promise<number> {
-        const result = await this.invitationRepo.update(
-            { status: 'pending', expiresAt: LessThan(new Date()) },
-            { status: 'expired' },
-        );
-        return result.affected ?? 0;
+        try {
+            const result = await this.invitationRepo.update(
+                { status: 'pending', expiresAt: LessThan(new Date()) },
+                { status: 'expired' },
+            );
+            const n = result.affected ?? 0;
+            if (n > 0) this.logger.log(`Marked ${n} expired invitations`);
+            return n;
+        } catch (err) {
+            this.logger.warn(`expireOld failed: ${(err as Error).message}`);
+            return 0;
+        }
     }
 
     private generateToken(): string {

--- a/src/services/pplns-group-invitation.service.ts
+++ b/src/services/pplns-group-invitation.service.ts
@@ -268,13 +268,24 @@ export class PplnsGroupInvitationService {
         return rows.filter(r => r.expiresAt.getTime() >= now);
     }
 
-    async cancelInvitation(token: string, groupId: string, adminToken: string | undefined): Promise<void> {
+    /**
+     * Cancel the pending invitation for an address in a group. Identified
+     * by (groupId, address) rather than by token, so the admin never sees
+     * the secret token — that lives only in the email body.
+     */
+    async cancelInvitationByAddress(
+        groupId: string,
+        address: string,
+        adminToken: string | undefined,
+    ): Promise<void> {
         await this.groupService.requireAdminToken(groupId, adminToken);
-        const invitation = await this.invitationRepo.findOneBy({ token });
-        if (!invitation || invitation.groupId !== groupId) {
-            throw new InvitationServiceError('not-found', 'Invitation not found in this group');
+        const invitation = await this.invitationRepo.findOne({
+            where: { groupId, address, status: 'pending' },
+        });
+        if (!invitation) {
+            throw new InvitationServiceError('not-found', 'No pending invitation for this address in this group');
         }
-        await this.invitationRepo.delete({ token });
+        await this.invitationRepo.delete({ token: invitation.token });
     }
 
     /**

--- a/src/services/pplns-group-invitation.service.ts
+++ b/src/services/pplns-group-invitation.service.ts
@@ -118,7 +118,9 @@ export class PplnsGroupInvitationService {
             address,
             groupName: group.name,
             inviterAddress: group.creatorAddress,
-            inviteUrl: `${baseUrl}/invite/${token}`,
+            // UI uses HashLocationStrategy — path has to be in the
+            // fragment. See address-email.service.ts for the same trap.
+            inviteUrl: `${baseUrl}/#/invite/${token}`,
             expiresAt: invitation.expiresAt,
         });
 

--- a/src/services/pplns-group-invitation.service.ts
+++ b/src/services/pplns-group-invitation.service.ts
@@ -107,14 +107,18 @@ export class PplnsGroupInvitationService {
             expiresAt,
         }));
 
+        // Email link goes to the UI invitation page, not directly at the
+        // accept/decline endpoints — the recipient sees the group context
+        // and confirms there with an explicit button click. This protects
+        // against accidental accept/decline from email-preview link
+        // pre-fetchers or one-tap email-client gestures.
         const baseUrl = this.poolBaseUrl();
         await this.emailService.sendInvitation({
             to: binding.email,
             address,
             groupName: group.name,
             inviterAddress: group.creatorAddress,
-            acceptUrl: `${baseUrl}/invite/${token}/accept`,
-            declineUrl: `${baseUrl}/invite/${token}/decline`,
+            inviteUrl: `${baseUrl}/invite/${token}`,
             expiresAt: invitation.expiresAt,
         });
 

--- a/src/services/pplns-group-invitation.service.ts
+++ b/src/services/pplns-group-invitation.service.ts
@@ -216,12 +216,20 @@ export class PplnsGroupInvitationService {
     /**
      * List pending invitations for an address — drives the "you have
      * pending invitations" banner on the dashboard.
+     *
+     * Deliberately does NOT include the invitation token. /app/:address
+     * is a public URL with no authentication, so exposing the token in
+     * this response would let any visitor construct /invite/:token and
+     * accept on the address holder's behalf — defeating the whole point
+     * of the email-based trust anchor. Instead we return a masked email
+     * hint so the user knows WHICH inbox to check, and they accept by
+     * clicking the link in the email itself.
      */
     async listPendingForAddress(address: string): Promise<{
-        token: string;
         groupId: string;
         groupName: string;
         inviterAddress: string;
+        maskedEmail: string;
         createdAt: Date;
         expiresAt: Date;
     }[]> {
@@ -236,10 +244,10 @@ export class PplnsGroupInvitationService {
             const group = await this.groupService.getGroup(row.groupId);
             if (!group || group.dissolvedAt) continue;
             result.push({
-                token: row.token,
                 groupId: row.groupId,
                 groupName: group.name,
                 inviterAddress: group.creatorAddress,
+                maskedEmail: maskEmail(row.email),
                 createdAt: row.createdAt,
                 expiresAt: row.expiresAt,
             });
@@ -291,4 +299,18 @@ export class PplnsGroupInvitationService {
         }
         return url.replace(/\/+$/, '');
     }
+}
+
+/**
+ * Mask an email for public display: first char of the local part + domain.
+ * Gives the recipient enough of a hint to know which inbox to check
+ * without exposing the full address to anyone who knows their mining
+ * address.
+ */
+function maskEmail(email: string): string {
+    if (!email) return '';
+    const [local, domain] = email.split('@');
+    if (!domain) return '***';
+    const head = local.slice(0, 1);
+    return `${head}***@${domain}`;
 }

--- a/src/services/pplns-group-invitation.service.ts
+++ b/src/services/pplns-group-invitation.service.ts
@@ -10,6 +10,7 @@ import { PplnsGroupInvitationEntity } from '../ORM/pplns-group/pplns-group-invit
 import { GroupService, GroupServiceError } from './group.service';
 import { AddressEmailService } from './address-email.service';
 import { EmailService } from './email.service';
+import { normalizeBtcAddress } from '../utils/btc-address.utils';
 
 const INVITATION_TTL_DAYS = 7;
 
@@ -65,7 +66,9 @@ export class PplnsGroupInvitationService {
     ): Promise<CreatedInvitation> {
         const group = await this.groupService.requireAdminToken(groupId, adminToken);
 
-        if (!address) throw new InvitationServiceError('invalid-address', 'Address required');
+        const normalizedAddress = normalizeBtcAddress(address);
+        if (!normalizedAddress) throw new InvitationServiceError('invalid-address', 'Address required');
+        address = normalizedAddress;
 
         // Already a member? Skip.
         const existingMember = await this.memberRepo.findOneBy({ address });
@@ -181,8 +184,14 @@ export class PplnsGroupInvitationService {
             throw new InvitationServiceError('group-dissolved', 'Group no longer exists');
         }
 
+        // Invitation rows were stored with a normalized address (bech32
+        // lowercased) but older data from before this change might not
+        // be — re-normalize here for the lookup so legacy rows still
+        // resolve correctly.
+        const normalizedInvitedAddress = normalizeBtcAddress(invitation.address);
+
         // Make sure the address didn't join another group in the meantime.
-        const existingMember = await this.memberRepo.findOneBy({ address: invitation.address });
+        const existingMember = await this.memberRepo.findOneBy({ address: normalizedInvitedAddress });
         if (existingMember && existingMember.groupId !== invitation.groupId) {
             throw new InvitationServiceError('address-in-group', 'Address is now in another group — invitation invalid');
         }
@@ -197,7 +206,7 @@ export class PplnsGroupInvitationService {
 
         const member = await this.groupService.addMemberWithoutAdmin(
             invitation.groupId,
-            invitation.address,
+            normalizedInvitedAddress,
         );
 
         invitation.status = 'accepted';

--- a/src/services/pplns.service.ts
+++ b/src/services/pplns.service.ts
@@ -586,27 +586,28 @@ export class PplnsService implements OnModuleInit, OnModuleDestroy {
 
     /**
      * Get current distribution (all miners and their share).
+     * `totalShares` is diff-1-weighted real work, not raw share count.
      */
-    async getCurrentDistribution(): Promise<{ address: string; difficulty: number; percent: number }[]> {
+    async getCurrentDistribution(): Promise<{ address: string; totalShares: number; percent: number }[]> {
         if (!this.redis) return [];
 
         const entries = await this.redis.zRange(REDIS_KEY_SHARES, 0, -1);
         if (!entries || entries.length === 0) return [];
 
-        const addressDiff = new Map<string, number>();
-        let totalDiff = 0;
+        const addressShares = new Map<string, number>();
+        let totalShares = 0;
         for (const entry of entries) {
             const parts = entry.split(':');
-            const diff = parseFloat(parts[1]) || 0;
-            addressDiff.set(parts[0], (addressDiff.get(parts[0]) ?? 0) + diff);
-            totalDiff += diff;
+            const shares = parseFloat(parts[1]) || 0;
+            addressShares.set(parts[0], (addressShares.get(parts[0]) ?? 0) + shares);
+            totalShares += shares;
         }
 
-        return Array.from(addressDiff.entries())
-            .map(([address, difficulty]) => ({
+        return Array.from(addressShares.entries())
+            .map(([address, shares]) => ({
                 address,
-                difficulty,
-                percent: totalDiff > 0 ? (difficulty / totalDiff) * 100 : 0,
+                totalShares: shares,
+                percent: totalShares > 0 ? (shares / totalShares) * 100 : 0,
             }))
             .sort((a, b) => b.percent - a.percent);
     }

--- a/src/services/pplns.service.ts
+++ b/src/services/pplns.service.ts
@@ -109,6 +109,19 @@ export class PplnsService implements OnModuleInit, OnModuleDestroy {
     }
 
     /**
+     * Pool fee config exposed to the UI so the landing pages can show current
+     * fees dynamically without hard-coding them. Same config is reused by the
+     * group-solo path, so one endpoint covers both modes.
+     */
+    getFeeConfig(): { feePercent: number; feeAddress: string; coinbaseWeightBudget: number } {
+        return {
+            feePercent: this.feePercent,
+            feeAddress: this.feeAddress,
+            coinbaseWeightBudget: this.coinbaseWeightBudget,
+        };
+    }
+
+    /**
      * Update network difficulty (called when new block template arrives).
      */
     setNetworkDifficulty(difficulty: number): void {

--- a/src/utils/btc-address.utils.spec.ts
+++ b/src/utils/btc-address.utils.spec.ts
@@ -1,0 +1,41 @@
+import { normalizeBtcAddress } from './btc-address.utils';
+
+describe('normalizeBtcAddress', () => {
+    it('lowercases bech32 mainnet addresses', () => {
+        expect(normalizeBtcAddress('BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4')).toBe(
+            'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+        );
+    });
+
+    it('lowercases bech32m (taproot) mainnet addresses', () => {
+        expect(normalizeBtcAddress('BC1PXW5... mixed Case ...'.trim())).toMatch(/^bc1p/);
+    });
+
+    it('lowercases testnet tb1', () => {
+        expect(normalizeBtcAddress('TB1QSomething')).toBe('tb1qsomething');
+    });
+
+    it('lowercases regtest bcrt1', () => {
+        expect(normalizeBtcAddress('BCRT1QSomething')).toBe('bcrt1qsomething');
+    });
+
+    it('leaves legacy P2PKH case-sensitive (base58)', () => {
+        expect(normalizeBtcAddress('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'))
+            .toBe('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa');
+    });
+
+    it('leaves legacy P2SH case-sensitive', () => {
+        expect(normalizeBtcAddress('3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy'))
+            .toBe('3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy');
+    });
+
+    it('trims whitespace', () => {
+        expect(normalizeBtcAddress('  bc1qtest  ')).toBe('bc1qtest');
+    });
+
+    it('returns empty string for null/undefined/empty input', () => {
+        expect(normalizeBtcAddress(null)).toBe('');
+        expect(normalizeBtcAddress(undefined)).toBe('');
+        expect(normalizeBtcAddress('')).toBe('');
+    });
+});

--- a/src/utils/btc-address.utils.ts
+++ b/src/utils/btc-address.utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Normalize a BTC mining address for equality / storage.
+ *
+ * Bech32 and bech32m (BIP-173 / BIP-350) are protocol-specified as
+ * lowercase on the wire. Wallets / UIs may present them uppercase as a
+ * QR-code optimization, but every string comparison downstream has to
+ * treat them case-insensitively or an address invited in one case and
+ * mined in the other will silently miss the member cache lookup and
+ * shares will route to solo/PPLNS instead of the intended group.
+ *
+ * Legacy P2PKH/P2SH (base58, starting with 1/3/m/n/2) IS case-sensitive —
+ * `1A1zP...` and `1a1zp...` are different addresses with different
+ * checksums. Those we leave untouched.
+ *
+ * Accepts the common mainnet, testnet and regtest bech32 prefixes:
+ *   bc1 / tb1 / bcrt1
+ * plus signet (tb1 is shared, sb1 for Signet BIP-0350 variant — some
+ * wallets still use tb1 there).
+ */
+export function normalizeBtcAddress(address: string | undefined | null): string {
+    const trimmed = (address ?? '').trim();
+    if (!trimmed) return '';
+    const lower = trimmed.toLowerCase();
+    if (
+        lower.startsWith('bc1')
+        || lower.startsWith('tb1')
+        || lower.startsWith('bcrt1')
+        || lower.startsWith('sb1')
+    ) {
+        return lower;
+    }
+    return trimmed;
+}


### PR DESCRIPTION
> Stacks on #121. Merge order: #118 → #119 → #120 → #121 → this PR.

## Summary

Adds the group-specific counterpart to \`/api/pplns/chart\`. Was flagged as missing earlier when planning the payout-group UI — the UI in #164 doesn't currently render a chart widget, but adding this now means a future group-dashboard chart can drop in without backend work.

\`\`\`
GET /api/pplns/groups/:id/chart?range=1d|3d|7d
→ [
    { "label": "2026-04-19T09:50:00.000Z", "data":  800000000000 },
    { "label": "2026-04-19T10:00:00.000Z", "data":  830000000000 },
    ...
  ]
\`\`\`

Same \`{ label, data }\` shape as \`/api/info/chart\` and \`/api/pplns/chart\`. Same 10-minute slots. Same share-based hashrate formula (\`shares × DIFFICULTY_1 / 600\`).

## Implementation

Sums \`ClientStatisticsService.getChartDataForAddress\` across every group member, then merges data points by label. Sparse slots stay sparse (no phantom zeros) — consistent with the pool-wide PPLNS chart endpoint.

Returns 404 for unknown or dissolved groups and an empty array for member-less groups.

## Tests

7 unit tests (\`pplns-group.controller.spec.ts\`) cover:
- sum math across multiple members
- sparse per-member data
- empty-group short circuit
- 404 for not-found / dissolved
- range passthrough + unknown-range fallback to 1d

## Test plan
- [x] Full Jest suite green (517 tests, 61 suites)
- [x] Build clean