### PR TITLE
feat: public directory, open invite links, join requests

### DIFF
--- a/src/ORM/pplns-group/pplns-group-invitation.entity.ts
+++ b/src/ORM/pplns-group/pplns-group-invitation.entity.ts
@@ -1,15 +1,27 @@
 import { Column, CreateDateColumn, Entity, Index, PrimaryColumn } from 'typeorm';
 
 /**
- * Pending invitation for an address to join a payout group. Created by the
- * group admin; the address holder accepts (or declines) via a tokenized link
- * sent to the email bound to that address. Pending invitations do NOT make
- * the address a member — the address is only added to the group's
- * pplns_group_member table once the invitation is accepted.
+ * Invitation for an address to join a payout group. Two flavours:
  *
- * Status lifecycle: pending -> accepted | declined | expired.
+ *   inviteType='directed' (original, two-phase admin-driven):
+ *     Admin specifies address up front, system emails the bound address
+ *     a token, recipient accepts/declines via tokenized link. The (address,
+ *     email) columns hold the pre-bound recipient. One-shot — status
+ *     transitions to 'accepted' or 'declined' on response.
+ *
+ *   inviteType='open' (admin-shareable link):
+ *     Admin generates a TTL-limited token to share in a community channel.
+ *     The (address, email) columns are NULL until acceptance. Multi-use:
+ *     anyone with a verified email binding can claim it before the TTL
+ *     expires. Acceptance does NOT mark the row 'accepted' — the row
+ *     stays usable until TTL or manual revoke.
+ *
+ * Status lifecycle:
+ *   directed: pending -> accepted | declined | expired
+ *   open:     pending -> revoked | expired (no 'accepted' state)
  */
-export type PplnsGroupInvitationStatus = 'pending' | 'accepted' | 'declined' | 'expired';
+export type PplnsGroupInvitationStatus = 'pending' | 'accepted' | 'declined' | 'expired' | 'revoked';
+export type PplnsGroupInvitationType = 'directed' | 'open';
 
 @Entity('pplns_group_invitation')
 export class PplnsGroupInvitationEntity {
@@ -22,14 +34,23 @@ export class PplnsGroupInvitationEntity {
     groupId: string;
 
     @Index()
-    @Column({ type: 'varchar', length: 62 })
-    address: string;
+    @Column({ type: 'varchar', length: 62, nullable: true })
+    address: string | null;
 
-    @Column({ type: 'varchar', length: 320 })
-    email: string;
+    @Column({ type: 'varchar', length: 320, nullable: true })
+    email: string | null;
 
     @Column({ type: 'varchar', length: 16, default: 'pending' })
     status: PplnsGroupInvitationStatus;
+
+    /**
+     * 'directed' = pre-bound address+email, sent via email, one-shot.
+     * 'open'     = no pre-bound address, shareable link, multi-use until TTL.
+     * Default is 'directed' so existing rows (created before this column)
+     * keep their original semantics on read.
+     */
+    @Column({ type: 'varchar', length: 16, default: 'directed' })
+    inviteType: PplnsGroupInvitationType;
 
     @CreateDateColumn()
     createdAt: Date;

--- a/src/ORM/pplns-group/pplns-group-join-request.entity.ts
+++ b/src/ORM/pplns-group/pplns-group-join-request.entity.ts
@@ -1,0 +1,58 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+/**
+ * User-initiated request to join a public payout group. Created by the
+ * miner from the public directory (`/groups/public/:id`); the group admin
+ * approves or rejects from the admin dashboard.
+ *
+ * The trust anchor is the same as for invitations — the requesting
+ * address must have a verified email binding before a request is
+ * accepted server-side. The email column snapshots that binding at
+ * request time so the reject/approve notification reaches the same
+ * address even if the user later rebinds.
+ *
+ * Status lifecycle: pending → approved | rejected | expired.
+ *   approved → membership created, decidedAt + decidedByAdminTokenHash set
+ *   rejected → no membership, decidedAt + decidedByAdminTokenHash set
+ *   expired  → set by cron after a long staleness window
+ */
+export type PplnsGroupJoinRequestStatus = 'pending' | 'approved' | 'rejected' | 'expired';
+
+@Entity('pplns_group_join_request')
+export class PplnsGroupJoinRequestEntity {
+
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Index()
+    @Column({ type: 'uuid' })
+    groupId: string;
+
+    @Index()
+    @Column({ type: 'varchar', length: 62 })
+    address: string;
+
+    /** Email at time of request (snapshot of the verified binding). */
+    @Column({ type: 'varchar', length: 320 })
+    email: string;
+
+    /** Optional message to the admin (max 500 chars enforced in service). */
+    @Column({ type: 'text', nullable: true })
+    message: string | null;
+
+    @Column({ type: 'varchar', length: 16, default: 'pending' })
+    status: PplnsGroupJoinRequestStatus;
+
+    @CreateDateColumn({ type: 'timestamptz' })
+    createdAt: Date;
+
+    @Column({ type: 'timestamptz', nullable: true })
+    decidedAt: Date | null;
+
+    /**
+     * SHA-256 of the admin token that decided this request. Audit trail —
+     * never the raw token, so a DB dump can't be used to act on the group.
+     */
+    @Column({ type: 'varchar', length: 255, nullable: true })
+    decidedByAdminTokenHash: string | null;
+}

--- a/src/ORM/pplns-group/pplns-group.entity.ts
+++ b/src/ORM/pplns-group/pplns-group.entity.ts
@@ -19,6 +19,16 @@ export class PplnsGroupEntity {
     @Column({ type: 'boolean', default: false })
     active: boolean;
 
+    /**
+     * When true, the group is listed in the public directory at
+     * `/pplns/groups/public` and accepts unsolicited join-requests. The
+     * admin opts into this — default is false, so pre-existing groups
+     * (created before this column was added) stay private until they
+     * explicitly enable visibility.
+     */
+    @Column({ type: 'boolean', default: false })
+    isPublic: boolean;
+
     @CreateDateColumn()
     createdAt: Date;
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -63,6 +63,7 @@ import { EmailService } from './services/email.service';
 import { AddressEmailService } from './services/address-email.service';
 import { CoinbaseCapacityMonitorService } from './services/coinbase-capacity-monitor.service';
 import { PplnsGroupInvitationService } from './services/pplns-group-invitation.service';
+import { PplnsGroupJoinRequestService } from './services/pplns-group-join-request.service';
 import { MiningModeService } from './services/mining-mode.service';
 import { MinerActiveModeService } from './services/miner-active-mode.service';
 import { DustSweepService } from './services/dust-sweep.service';
@@ -71,6 +72,7 @@ import { PplnsGroupMemberEntity } from './ORM/pplns-group/pplns-group-member.ent
 import { PplnsGroupBlockHistoryEntity } from './ORM/pplns-group/pplns-group-block-history.entity';
 import { PplnsGroupBalanceEntity } from './ORM/pplns-group/pplns-group-balance.entity';
 import { PplnsGroupInvitationEntity } from './ORM/pplns-group/pplns-group-invitation.entity';
+import { PplnsGroupJoinRequestEntity } from './ORM/pplns-group/pplns-group-join-request.entity';
 import { AddressEmailEntity } from './ORM/address-email/address-email.entity';
 import { EmailVerificationEntity } from './ORM/address-email/email-verification.entity';
 import { PplnsGroupController } from './controllers/pplns-group/pplns-group.controller';
@@ -168,6 +170,7 @@ const ORMModules = [
             PplnsGroupBlockHistoryEntity,
             PplnsGroupBalanceEntity,
             PplnsGroupInvitationEntity,
+            PplnsGroupJoinRequestEntity,
             AddressEmailEntity,
             EmailVerificationEntity,
         ]),
@@ -226,6 +229,7 @@ const ORMModules = [
         EmailService,
         AddressEmailService,
         PplnsGroupInvitationService,
+        PplnsGroupJoinRequestService,
         CoinbaseCapacityMonitorService,
     ],
 })

--- a/src/controllers/pplns-group/pplns-group.controller.spec.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.spec.ts
@@ -24,6 +24,8 @@ describe('PplnsGroupController.chart', () => {
             ),
         };
         const clientRejectedStatisticsService = {} as any;
+        const configService = { get: jest.fn(() => undefined) } as any;
+        const joinRequestService = {} as any;
         const controller = new PplnsGroupController(
             groupService as any,
             groupSoloService,
@@ -32,6 +34,8 @@ describe('PplnsGroupController.chart', () => {
             clientService,
             clientStatisticsService as any,
             clientRejectedStatisticsService,
+            configService,
+            joinRequestService,
         );
         return { controller, groupService, clientStatisticsService };
     }

--- a/src/controllers/pplns-group/pplns-group.controller.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.ts
@@ -8,6 +8,7 @@ import { PplnsGroupEntity } from '../../ORM/pplns-group/pplns-group.entity';
 import { InvitationServiceError, PplnsGroupInvitationService, OPEN_INVITE_TTL_PRESETS, OpenInviteTtl } from '../../services/pplns-group-invitation.service';
 import { JoinRequestServiceError, PplnsGroupJoinRequestService } from '../../services/pplns-group-join-request.service';
 import { ConfigService } from '@nestjs/config';
+import { maskEmail } from '../../utils/email-mask.utils';
 import { AddressEmailService } from '../../services/address-email.service';
 import { ClientService } from '../../ORM/client/client.service';
 import { ClientStatisticsService } from '../../ORM/client-statistics/client-statistics.service';
@@ -236,8 +237,13 @@ export class PplnsGroupController {
                 lastAcceptedShareAt,
             };
             if (isAdmin) {
+                // Privacy: even the admin only sees a masked email so a
+                // leaked admin token can't be used to build a BTC↔email
+                // mapping for members. The mask still lets the admin
+                // distinguish "verified email present" from "no email"
+                // (null → no binding, masked string → bound + verified).
                 const binding = await this.addressEmailService.getVerified(m.address);
-                row.email = binding?.email ?? null;
+                row.email = binding ? maskEmail(binding.email) : null;
             }
             return row;
         }));
@@ -451,7 +457,9 @@ export class PplnsGroupController {
     ) {
         try {
             const result = await this.invitationService.createInvitation(id, body.address ?? '', token);
-            return { invited: true, email: result.email, expiresAt: result.expiresAt };
+            // Privacy: return the masked email so the success toast confirms
+            // "invite went out" without revealing the BTC↔email mapping.
+            return { invited: true, email: maskEmail(result.email), expiresAt: result.expiresAt };
         } catch (e) {
             throw this.toHttpError(e);
         }
@@ -493,7 +501,7 @@ export class PplnsGroupController {
             seen.add(dedupKey);
             try {
                 const r = await this.invitationService.createInvitation(id, addr, token);
-                invited.push({ address: addr, email: r.email, expiresAt: r.expiresAt });
+                invited.push({ address: addr, email: maskEmail(r.email), expiresAt: r.expiresAt });
             } catch (e) {
                 if (e instanceof GroupServiceError && e.code === 'invalid-token') {
                     throw this.toHttpError(e);
@@ -533,7 +541,8 @@ export class PplnsGroupController {
             const rows = await this.invitationService.listPendingForGroup(id);
             return rows.map(r => ({
                 address: r.address,
-                email: r.email,
+                // Privacy: masked even for the admin — see detailsForGroupId.
+                email: r.email ? maskEmail(r.email) : null,
                 createdAt: r.createdAt,
                 expiresAt: r.expiresAt,
                 status: r.status,
@@ -652,7 +661,8 @@ export class PplnsGroupController {
             return rows.map(r => ({
                 id: r.id,
                 address: r.address,
-                email: r.email,
+                // Privacy: masked even for the admin — see detailsForGroupId.
+                email: maskEmail(r.email),
                 message: r.message,
                 status: r.status,
                 createdAt: r.createdAt,

--- a/src/controllers/pplns-group/pplns-group.controller.ts
+++ b/src/controllers/pplns-group/pplns-group.controller.ts
@@ -5,7 +5,9 @@ import { normalizeBtcAddress } from '../../utils/btc-address.utils';
 import { GroupSoloService } from '../../services/group-solo.service';
 import { computeNextResetAt } from '../../services/group-round-reset.service';
 import { PplnsGroupEntity } from '../../ORM/pplns-group/pplns-group.entity';
-import { InvitationServiceError, PplnsGroupInvitationService } from '../../services/pplns-group-invitation.service';
+import { InvitationServiceError, PplnsGroupInvitationService, OPEN_INVITE_TTL_PRESETS, OpenInviteTtl } from '../../services/pplns-group-invitation.service';
+import { JoinRequestServiceError, PplnsGroupJoinRequestService } from '../../services/pplns-group-join-request.service';
+import { ConfigService } from '@nestjs/config';
 import { AddressEmailService } from '../../services/address-email.service';
 import { ClientService } from '../../ORM/client/client.service';
 import { ClientStatisticsService } from '../../ORM/client-statistics/client-statistics.service';
@@ -41,6 +43,8 @@ export class PplnsGroupController {
         private readonly clientService: ClientService,
         private readonly clientStatisticsService: ClientStatisticsService,
         private readonly clientRejectedStatisticsService: ClientRejectedStatisticsService,
+        private readonly configService: ConfigService,
+        private readonly joinRequestService: PplnsGroupJoinRequestService,
     ) {}
 
     /** Sum of live hashrates across all workers of an address. Matches /api/client/:address. */
@@ -55,6 +59,126 @@ export class PplnsGroupController {
     async list() {
         const groups = await this.groupService.listGroups();
         return groups.map(g => this.publicGroupView(g));
+    }
+
+    /**
+     * GET /pplns/groups/public?page=1&pageSize=50
+     *
+     * Public directory of opt-in groups. Sorted by total hashrate desc so
+     * the most active groups surface first. Each row is enriched with
+     * member count + summed live hashrate so the directory card has all
+     * the data it needs without a follow-up call per group.
+     *
+     * Pagination is server-side because a popular pool could have many
+     * public groups; the UI infinite-scrolls or paginates client-side.
+     */
+    @Get('public')
+    async listPublic(
+        @Query('page') pageStr?: string,
+        @Query('pageSize') pageSizeStr?: string,
+    ) {
+        const page = Math.max(1, parseInt(pageStr ?? '1', 10) || 1);
+        const pageSize = Math.min(100, Math.max(1, parseInt(pageSizeStr ?? '50', 10) || 50));
+
+        const all = await this.groupService.listGroups();
+        const publicGroups = all.filter(g => g.isPublic);
+
+        // Compute member counts + hashrates in parallel; the listing is
+        // cheap-ish (filtered to public groups) so this scales fine for
+        // realistic pool sizes.
+        const enriched = await Promise.all(publicGroups.map(async g => {
+            const members = await this.groupService.listMembers(g.id);
+            const memberCount = members.length;
+            const totalHashrate = (await Promise.all(members.map(m => this.addressHashrate(m.address))))
+                .reduce((sum, h) => sum + h, 0);
+            return {
+                ...this.publicGroupView(g),
+                memberCount,
+                totalHashrate,
+            };
+        }));
+
+        enriched.sort((a, b) => b.totalHashrate - a.totalHashrate);
+
+        const total = enriched.length;
+        const start = (page - 1) * pageSize;
+        const items = enriched.slice(start, start + pageSize);
+        return {
+            page,
+            pageSize,
+            total,
+            items,
+        };
+    }
+
+    /**
+     * GET /pplns/groups/join-requests/by-address/:address
+     *
+     * Pending join requests submitted by this address — used by the
+     * directory page to show "Pending review" instead of the request
+     * form on groups the user has already pinged. Public, no auth: no
+     * sensitive data is exposed (just group ids the user already knows
+     * they applied to).
+     *
+     * MUST be declared before `@Get(':id')` so 'join-requests' isn't
+     * captured as a group id.
+     */
+    @Get('join-requests/by-address/:address')
+    async listJoinRequestsForAddress(@Param('address') address: string) {
+        return this.joinRequestService.listForAddress(address);
+    }
+
+    /**
+     * GET /pplns/groups/public/:id
+     *
+     * Public detail page for a directory group. Returns a directory row
+     * plus the recent block-history (capped) so the user can see if the
+     * group has ever found anything. Member list is intentionally NOT
+     * exposed — that's a privacy boundary; non-members shouldn't see who
+     * else is mining there.
+     */
+    @Get('public/:id')
+    async detailsPublic(@Param('id') id: string) {
+        const group = await this.groupService.getGroup(id);
+        if (!group || group.dissolvedAt || !group.isPublic) {
+            throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
+        }
+        const members = await this.groupService.listMembers(id);
+        const memberCount = members.length;
+        const totalHashrate = (await Promise.all(members.map(m => this.addressHashrate(m.address))))
+            .reduce((sum, h) => sum + h, 0);
+        const history = await this.groupSoloService.getBlockHistory(id, 20);
+        return {
+            ...this.publicGroupView(group),
+            memberCount,
+            totalHashrate,
+            recentBlocks: history,
+        };
+    }
+
+    /**
+     * POST /pplns/groups/public/:id/join-request
+     * Body: { address: string, message?: string }
+     *
+     * User-submitted request to join a public group. Public — the trust
+     * anchor is the verified email binding for the supplied address.
+     * Rate-limited per-IP (preventing spam from a single source) and
+     * per-address (multi-layer in service: DB unique partial index +
+     * service-level pending cap + reject cooldown).
+     */
+    @UseGuards(ThrottlerGuard)
+    @Throttle(5, 60)
+    @Post('public/:id/join-request')
+    async createJoinRequest(
+        @Param('id') id: string,
+        @Body() body: { address?: string; message?: string },
+    ) {
+        try {
+            const r = await this.joinRequestService.createJoinRequest(id, body?.address ?? '', body?.message);
+            return { id: r.id, groupId: r.groupId, status: r.status, createdAt: r.createdAt };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
     }
 
     @Get(':id')
@@ -420,6 +544,76 @@ export class PplnsGroupController {
     }
 
     /**
+     * POST /pplns/groups/:id/invitations/open
+     * Generate (or replace) the active open-invite link for the group.
+     * Body: { ttl: '1h' | '24h' | '7d' | '30d' }
+     * Response: { token, expiresAt, link } where link is the public URL
+     * the admin can share. Atomic-replaces any existing active open link.
+     */
+    @UseGuards(ThrottlerGuard)
+    @Throttle(10, 60)
+    @Post(':id/invitations/open')
+    async createOpenInvitation(
+        @Param('id') id: string,
+        @Body() body: { ttl?: string },
+        @Headers('x-admin-token') token?: string,
+    ) {
+        try {
+            const ttl = body?.ttl as OpenInviteTtl;
+            const result = await this.invitationService.createOpenInvite(id, ttl, token);
+            const baseUrl = (this.configService.get<string>('POOL_BASE_URL') ?? '').replace(/\/+$/, '');
+            const link = baseUrl ? `${baseUrl}/#/invite/open/${result.token}` : `/#/invite/open/${result.token}`;
+            return { token: result.token, expiresAt: result.expiresAt, link };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    /**
+     * GET /pplns/groups/:id/invitations/open/active
+     * Returns the currently active open-invite link (or null). Admin-token
+     * gated — the token is the live secret, never exposed publicly.
+     */
+    @Get(':id/invitations/open/active')
+    async getActiveOpenInvitation(
+        @Param('id') id: string,
+        @Headers('x-admin-token') token?: string,
+    ) {
+        try {
+            const result = await this.invitationService.getActiveOpenInvite(id, token);
+            if (!result) return { active: false };
+            const baseUrl = (this.configService.get<string>('POOL_BASE_URL') ?? '').replace(/\/+$/, '');
+            const link = baseUrl ? `${baseUrl}/#/invite/open/${result.token}` : `/#/invite/open/${result.token}`;
+            return {
+                active: true,
+                token: result.token,
+                expiresAt: result.expiresAt,
+                createdAt: result.createdAt,
+                link,
+            };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    /**
+     * DELETE /pplns/groups/:id/invitations/open
+     * Manually revoke the active open-invite link. Idempotent.
+     */
+    @Delete(':id/invitations/open')
+    async revokeOpenInvitation(
+        @Param('id') id: string,
+        @Headers('x-admin-token') token?: string,
+    ) {
+        try {
+            await this.invitationService.revokeOpenInvite(id, token);
+            return { revoked: true };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    /**
      * DELETE /pplns/groups/:id/invitations/by-address/:address
      * Cancel a pending invitation before the recipient responds.
      * Admin-token-auth. Addressed by (groupId, address) instead of token
@@ -434,6 +628,74 @@ export class PplnsGroupController {
         try {
             await this.invitationService.cancelInvitationByAddress(id, address, token);
             return { cancelled: true };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    /**
+     * GET /pplns/groups/:id/join-requests?includeDecided=1
+     * List user-initiated join requests. Admin-token gated. Default returns
+     * only pending; pass `includeDecided=1` to also see recent approvals
+     * and rejections (useful for audit / undo-ish flows).
+     */
+    @Get(':id/join-requests')
+    async listJoinRequests(
+        @Param('id') id: string,
+        @Query('includeDecided') includeDecided?: string,
+        @Headers('x-admin-token') token?: string,
+    ) {
+        try {
+            const rows = await this.joinRequestService.listForGroup(id, token, {
+                includeDecided: includeDecided === '1' || includeDecided === 'true',
+            });
+            return rows.map(r => ({
+                id: r.id,
+                address: r.address,
+                email: r.email,
+                message: r.message,
+                status: r.status,
+                createdAt: r.createdAt,
+                decidedAt: r.decidedAt,
+            }));
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    /**
+     * POST /pplns/groups/:id/join-requests/:reqId/approve
+     * Approve a pending join request — adds the address as a member and
+     * notifies them by email. Admin-token gated.
+     */
+    @Post(':id/join-requests/:reqId/approve')
+    async approveJoinRequest(
+        @Param('id') id: string,
+        @Param('reqId') reqId: string,
+        @Headers('x-admin-token') token?: string,
+    ) {
+        try {
+            await this.joinRequestService.approveRequest(id, reqId, token);
+            return { approved: true };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    /**
+     * POST /pplns/groups/:id/join-requests/:reqId/reject
+     * Reject a pending join request and notify the requester by email.
+     * Admin-token gated.
+     */
+    @Post(':id/join-requests/:reqId/reject')
+    async rejectJoinRequest(
+        @Param('id') id: string,
+        @Param('reqId') reqId: string,
+        @Headers('x-admin-token') token?: string,
+    ) {
+        try {
+            await this.joinRequestService.rejectRequest(id, reqId, token);
+            return { rejected: true };
         } catch (e) {
             throw this.toHttpError(e);
         }
@@ -491,6 +753,7 @@ export class PplnsGroupController {
                 finderBonusSats: updated.finderBonusSats ?? 0,
                 lastRoundResetAt: updated.lastRoundResetAt,
                 nextResetAt: computeNextResetAt(updated as PplnsGroupEntity),
+                isPublic: updated.isPublic ?? false,
             };
         } catch (e) {
             throw this.toHttpError(e);
@@ -535,6 +798,7 @@ export class PplnsGroupController {
         finderBonusSats?: number | null;
         lastRoundResetAt?: Date | null;
         dissolvedAt?: Date | null;
+        isPublic?: boolean;
     }) {
         // Round-reset config + finder bonus are intentionally exposed on the
         // public view — every member needs them to render the "next reset in
@@ -553,6 +817,7 @@ export class PplnsGroupController {
             finderBonusSats: group.finderBonusSats ?? 0,
             lastRoundResetAt: group.lastRoundResetAt ?? null,
             nextResetAt: computeNextResetAt(group as PplnsGroupEntity),
+            isPublic: group.isPublic ?? false,
         };
     }
 
@@ -590,6 +855,20 @@ export class PplnsGroupController {
                 'group-dissolved': HttpStatus.GONE,
                 'invalid-address': HttpStatus.BAD_REQUEST,
                 'config-missing': HttpStatus.SERVICE_UNAVAILABLE,
+            }[e.code] ?? HttpStatus.BAD_REQUEST;
+            return new HttpException({ code: e.code, message: e.message }, status);
+        }
+        if (e instanceof JoinRequestServiceError) {
+            const status = {
+                'not-found': HttpStatus.NOT_FOUND,
+                'invalid-address': HttpStatus.BAD_REQUEST,
+                'email-not-verified': HttpStatus.FAILED_DEPENDENCY,
+                'already-member': HttpStatus.CONFLICT,
+                'address-in-group': HttpStatus.CONFLICT,
+                'request-pending': HttpStatus.CONFLICT,
+                'too-many-pending': HttpStatus.TOO_MANY_REQUESTS,
+                'reject-cooldown': HttpStatus.TOO_MANY_REQUESTS,
+                'group-dissolved': HttpStatus.GONE,
             }[e.code] ?? HttpStatus.BAD_REQUEST;
             return new HttpException({ code: e.code, message: e.message }, status);
         }

--- a/src/controllers/pplns-invitation/pplns-invitation.controller.ts
+++ b/src/controllers/pplns-invitation/pplns-invitation.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpException, HttpStatus, Param, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpException, HttpStatus, Param, Post, UseGuards } from '@nestjs/common';
 import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import { InvitationServiceError, PplnsGroupInvitationService } from '../../services/pplns-group-invitation.service';
 
@@ -76,6 +76,50 @@ export class PplnsInvitationController {
         try {
             await this.invitationService.decline(token);
             return { ok: true };
+        } catch (e) {
+            throw this.toHttp(e);
+        }
+    }
+
+    /**
+     * GET /api/pplns/invitations/open/:token
+     * Public landing-page lookup for an open invite. Returns just enough
+     * to render the join form: group name + expiry. No member list, no
+     * admin secrets. 404 if the token is unknown, expired, revoked, or
+     * for a dissolved group.
+     */
+    @Get('open/:token')
+    async openInviteByToken(@Param('token') token: string) {
+        const result = await this.invitationService.getOpenInvitePublic(token);
+        if (!result) {
+            throw new HttpException({ code: 'not-found', message: 'Open invitation not found or no longer valid' }, HttpStatus.NOT_FOUND);
+        }
+        return {
+            token: result.token,
+            groupId: result.groupId,
+            groupName: result.groupName,
+            expiresAt: result.expiresAt,
+        };
+    }
+
+    /**
+     * POST /api/pplns/invitations/open/:token/accept
+     * Accept an open invite by binding it to a specific address. The
+     * address must have a verified email binding (same trust anchor as
+     * directed invites). Multi-use: the link stays valid until TTL.
+     */
+    // 10 req/min per IP. Open links can be claimed by anyone, so this is
+    // the realistic abuse vector — limit harder than the directed flow.
+    @UseGuards(ThrottlerGuard)
+    @Throttle(10, 60)
+    @Post('open/:token/accept')
+    async acceptOpen(
+        @Param('token') token: string,
+        @Body() body: { address?: string },
+    ) {
+        try {
+            const member = await this.invitationService.acceptOpenInvite(token, body?.address ?? '');
+            return { address: member.address, role: member.role, joinedAt: member.joinedAt, groupId: member.groupId };
         } catch (e) {
             throw this.toHttp(e);
         }

--- a/src/migrations/1779400000000-AddGroupIsPublic.ts
+++ b/src/migrations/1779400000000-AddGroupIsPublic.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Adds `isPublic` to `pplns_group`. When true, the group surfaces in the
+ * public group directory (`GET /pplns/groups/public`) and accepts
+ * unsolicited join-requests via the public-listing flow. Default false
+ * for backward compatibility — existing groups stay private until the
+ * admin opts in.
+ */
+export class AddGroupIsPublic1779400000000 implements MigrationInterface {
+    name = 'AddGroupIsPublic1779400000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            'pplns_group',
+            new TableColumn({
+                name: 'isPublic',
+                type: 'boolean',
+                default: false,
+                isNullable: false,
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn('pplns_group', 'isPublic');
+    }
+}

--- a/src/migrations/1779600000000-AddOpenInvitationSupport.ts
+++ b/src/migrations/1779600000000-AddOpenInvitationSupport.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Adds open-invitation support to `pplns_group_invitation`:
+ *   - `address` becomes nullable (open invites have no pre-bound address)
+ *   - `email` becomes nullable (open invites have no pre-bound email)
+ *   - `inviteType` enum-string column, default 'directed'
+ *
+ * Existing rows are unaffected — they keep their (address, email) values
+ * and get `inviteType='directed'` from the column default. Open invites
+ * (inviteType='open') store nothing about the invitee at create time;
+ * they get bound to a specific address only at accept time, and the
+ * single row stays usable until TTL expires (or until manually revoked).
+ *
+ * Status semantics now also recognise 'revoked' for open invites that
+ * were superseded by a new open-invite or explicitly revoked by the
+ * admin. The varchar column doesn't enforce the enum so this is a
+ * pure code-level change.
+ */
+export class AddOpenInvitationSupport1779600000000 implements MigrationInterface {
+    name = 'AddOpenInvitationSupport1779600000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "pplns_group_invitation" ALTER COLUMN "address" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "pplns_group_invitation" ALTER COLUMN "email" DROP NOT NULL`);
+        await queryRunner.addColumn(
+            'pplns_group_invitation',
+            new TableColumn({
+                name: 'inviteType',
+                type: 'varchar',
+                length: '16',
+                default: `'directed'`,
+                isNullable: false,
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn('pplns_group_invitation', 'inviteType');
+        // Note: the down does NOT re-add NOT NULL constraints. Doing so
+        // would fail if any open-invitation rows exist (they have NULL
+        // address/email). Manual cleanup required if you need to revert
+        // the nullability change.
+    }
+}

--- a/src/migrations/1779800000000-AddPublicDirectoryAndJoinRequests.ts
+++ b/src/migrations/1779800000000-AddPublicDirectoryAndJoinRequests.ts
@@ -1,0 +1,59 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+/**
+ * Adds the `pplns_group_join_request` table — user-initiated requests to
+ * join a public group. Lifecycle: pending → approved | rejected | expired.
+ *
+ * The unique partial index `(groupId, address)` WHERE status='pending'
+ * enforces the "1 pending per (address, group)" rate limit at DB level so
+ * concurrent requests can't slip through. Other rate limits (max-pending
+ * per address globally, post-reject cooldown) are enforced in the service.
+ */
+export class AddPublicDirectoryAndJoinRequests1779800000000 implements MigrationInterface {
+    name = 'AddPublicDirectoryAndJoinRequests1779800000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(new Table({
+            name: 'pplns_group_join_request',
+            columns: [
+                { name: 'id', type: 'uuid', isPrimary: true, default: 'gen_random_uuid()' },
+                { name: 'groupId', type: 'uuid', isNullable: false },
+                { name: 'address', type: 'varchar', length: '62', isNullable: false },
+                { name: 'email', type: 'varchar', length: '320', isNullable: false },
+                { name: 'message', type: 'text', isNullable: true },
+                { name: 'status', type: 'varchar', length: '16', default: `'pending'`, isNullable: false },
+                { name: 'createdAt', type: 'timestamptz', default: 'now()', isNullable: false },
+                { name: 'decidedAt', type: 'timestamptz', isNullable: true },
+                // Audit trail for admin decisions. Stored as the SHA-256 hash
+                // (already how admin tokens are stored on the group) so a DB
+                // dump never reveals raw tokens.
+                { name: 'decidedByAdminTokenHash', type: 'varchar', length: '255', isNullable: true },
+            ],
+        }), true);
+
+        await queryRunner.createIndex('pplns_group_join_request', new TableIndex({
+            name: 'IDX_pplns_join_request_group_status',
+            columnNames: ['groupId', 'status'],
+        }));
+
+        await queryRunner.createIndex('pplns_group_join_request', new TableIndex({
+            name: 'IDX_pplns_join_request_address_status',
+            columnNames: ['address', 'status'],
+        }));
+
+        // Unique partial index: at most one pending request per (group, address).
+        // TypeORM doesn't directly model partial indexes — go via raw SQL.
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "UQ_pplns_join_request_group_address_pending"
+            ON "pplns_group_join_request" ("groupId", "address")
+            WHERE "status" = 'pending'
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX IF EXISTS "UQ_pplns_join_request_group_address_pending"`);
+        await queryRunner.dropIndex('pplns_group_join_request', 'IDX_pplns_join_request_address_status');
+        await queryRunner.dropIndex('pplns_group_join_request', 'IDX_pplns_join_request_group_status');
+        await queryRunner.dropTable('pplns_group_join_request', true);
+    }
+}

--- a/src/services/address-email.service.spec.ts
+++ b/src/services/address-email.service.spec.ts
@@ -90,7 +90,7 @@ describe('AddressEmailService — K1-minimal FCFS-lock + binding-change notifica
         const arg = (emailService.sendBindingChangeAttempt as jest.Mock).mock.calls[0][0];
         expect(arg.to).toBe('bob@example.com');
         expect(arg.address).toBe('bc1qbob');
-        expect(arg.attemptedEmailMasked).toBe('e***@evil.com');
+        expect(arg.attemptedEmailMasked).toBe('e***@e***.com');
         // No verification email sent to attacker
         expect(emailService.sendVerification).not.toHaveBeenCalled();
     });

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -71,6 +71,8 @@ export class EmailService implements OnModuleInit {
     private readonly logger = new Logger(EmailService.name);
     private transport: Transporter | null = null;
     private fromAddress: string;
+    private replyToAddress: string;
+    private unsubscribeMailto: string;
     private enabled = false;
 
     constructor(private readonly config: ConfigService) {}
@@ -82,6 +84,12 @@ export class EmailService implements OnModuleInit {
         const user = this.config.get<string>('SMTP_USER');
         const pass = this.config.get<string>('SMTP_PASS');
         const from = this.config.get<string>('SMTP_FROM');
+        // Optional. Both fall back to SMTP_FROM if unset; the goal is just
+        // to ensure every outgoing message carries a Reply-To and a
+        // List-Unsubscribe target so receivers (Gmail/MS/Apple) don't
+        // treat the mail as unsolicited bulk by header heuristic alone.
+        const replyTo = this.config.get<string>('SMTP_REPLY_TO');
+        const unsub = this.config.get<string>('SMTP_UNSUBSCRIBE_MAILTO');
 
         if (!host || !user || !pass || !from) {
             this.logger.warn('EmailService disabled: SMTP_HOST/USER/PASS/FROM not all set. Invitation + verification emails will fail until configured.');
@@ -95,8 +103,28 @@ export class EmailService implements OnModuleInit {
             auth: { user, pass },
         });
         this.fromAddress = from;
+        this.replyToAddress = replyTo || from;
+        this.unsubscribeMailto = unsub || from;
         this.enabled = true;
         this.logger.log(`EmailService configured (host=${host}:${port}, secure=${secure}, from=${from})`);
+    }
+
+    /**
+     * Headers attached to every outgoing message. Gmail (since Feb 2024)
+     * and MS Outlook strongly favour transactional senders that signal
+     * "I am bulk-but-legitimate" via List-Unsubscribe + Auto-Submitted +
+     * Precedence. List-Unsubscribe is a pure mailto target — we don't
+     * actually have a per-user unsubscribe URL because these are all
+     * transactional flows, but the header presence alone meaningfully
+     * lifts inbox placement.
+     */
+    private commonHeaders(): Record<string, string> {
+        return {
+            'List-Unsubscribe': `<mailto:${this.unsubscribeMailto}>`,
+            'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+            'Auto-Submitted': 'auto-generated',
+            'Precedence': 'list',
+        };
     }
 
     isEnabled(): boolean {
@@ -112,10 +140,12 @@ export class EmailService implements OnModuleInit {
         const text = renderVerificationText(ctx);
         await this.transport.sendMail({
             from: this.fromAddress,
+            replyTo: this.replyToAddress,
             to: ctx.to,
             subject,
             html,
             text,
+            headers: this.commonHeaders(),
         });
     }
 
@@ -135,10 +165,12 @@ export class EmailService implements OnModuleInit {
         const text = renderBindingChangeAttemptText(ctx);
         await this.transport.sendMail({
             from: this.fromAddress,
+            replyTo: this.replyToAddress,
             to: ctx.to,
             subject,
             html,
             text,
+            headers: this.commonHeaders(),
         });
     }
 
@@ -151,10 +183,12 @@ export class EmailService implements OnModuleInit {
         const text = renderInvitationText(ctx);
         await this.transport.sendMail({
             from: this.fromAddress,
+            replyTo: this.replyToAddress,
             to: ctx.to,
             subject,
             html,
             text,
+            headers: this.commonHeaders(),
         });
     }
 
@@ -172,10 +206,12 @@ export class EmailService implements OnModuleInit {
         try {
             await this.transport.sendMail({
                 from: this.fromAddress,
+                replyTo: this.replyToAddress,
                 to: ctx.to,
                 subject,
                 html,
                 text,
+                headers: this.commonHeaders(),
             });
         } catch (e) {
             this.logger.warn(`sendJoinRequestApproved failed: ${(e as Error).message}`);
@@ -195,10 +231,12 @@ export class EmailService implements OnModuleInit {
         try {
             await this.transport.sendMail({
                 from: this.fromAddress,
+                replyTo: this.replyToAddress,
                 to: ctx.to,
                 subject,
                 html,
                 text,
+                headers: this.commonHeaders(),
             });
         } catch (e) {
             this.logger.warn(`sendJoinRequestRejected failed: ${(e as Error).message}`);
@@ -221,10 +259,12 @@ export class EmailService implements OnModuleInit {
         const text = renderCapacityAlertText(ctx);
         await this.transport.sendMail({
             from: this.fromAddress,
+            replyTo: this.replyToAddress,
             to: ctx.to,
             subject,
             html,
             text,
+            headers: this.commonHeaders(),
         });
     }
 }
@@ -232,14 +272,22 @@ export class EmailService implements OnModuleInit {
 // ── Theme ────────────────────────────────────────────────────────────
 //
 // Inline-styled HTML — email clients strip <style> tags, so colours/fonts
-// have to live on each element. Palette mirrors the dashboard's
-// mdc-dark-indigo theme:
-//   surface: #1e1e1e (page bg)
+// have to live on each element. Card stays on the dashboard's
+// mdc-dark-indigo palette so the email feels like part of the app; only
+// the page background AROUND the card is light grey, mirroring how
+// Gmail/Outlook themselves render a light page with the card as
+// content. ML-based spam classifiers (Gmail in particular) treat a
+// fully dark <body> as a mild risk signal, but a light page with a
+// dark card reads as "themed UI", not as "phishing template".
+//
+//   page:    #f5f5f7 (outer body / wrapper bg only)
+//   surface: #1e1e1e (in-card insets, e.g. code blocks)
 //   card:    #2a2a2a
 //   border:  #3a3a3a
 //   primary: #9FA8DA
 //   text:    #ffffff / #cfd8dc / #888
 
+const COLOR_PAGE = '#f5f5f7';
 const COLOR_BG = '#1e1e1e';
 const COLOR_CARD = '#2a2a2a';
 const COLOR_BORDER = '#3a3a3a';
@@ -256,8 +304,8 @@ function shellHtml(title: string, bodyHtml: string): string {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${escapeHtml(title)}</title>
 </head>
-<body style="margin:0;padding:0;background:${COLOR_BG};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:${COLOR_TEXT};">
-<table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background:${COLOR_BG};padding:32px 16px;">
+<body style="margin:0;padding:0;background:${COLOR_PAGE};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:${COLOR_TEXT};">
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background:${COLOR_PAGE};padding:32px 16px;">
   <tr><td align="center">
     <table role="presentation" width="600" cellspacing="0" cellpadding="0" border="0" style="max-width:600px;width:100%;background:${COLOR_CARD};border:1px solid ${COLOR_BORDER};border-radius:8px;overflow:hidden;">
       <tr><td style="padding:24px 32px;border-bottom:1px solid ${COLOR_BORDER};">

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -29,6 +29,14 @@ interface BindingChangeAttemptContext {
     attemptedEmailMasked: string;
 }
 
+interface JoinRequestDecisionContext {
+    to: string;
+    address: string;
+    groupName: string;
+    /** Public group dashboard URL — recipient lands on the joined group on approve. */
+    groupUrl: string;
+}
+
 export type CapacityAlertLevel = 'warning' | 'urgent' | 'recovery';
 
 export interface CapacityAlertContext {
@@ -148,6 +156,53 @@ export class EmailService implements OnModuleInit {
             html,
             text,
         });
+    }
+
+    /**
+     * Notify a miner that their public-directory join request was approved
+     * and they're now a member of the group. Best-effort — we log and
+     * swallow on failure so the approval flow doesn't fail the admin's
+     * request just because SMTP is down.
+     */
+    async sendJoinRequestApproved(ctx: JoinRequestDecisionContext): Promise<void> {
+        if (!this.enabled || !this.transport) return;
+        const subject = `Welcome to ${sanitizeHeader(ctx.groupName)} — Blitz Pool`;
+        const html = renderJoinDecisionHtml(ctx, 'approved');
+        const text = renderJoinDecisionText(ctx, 'approved');
+        try {
+            await this.transport.sendMail({
+                from: this.fromAddress,
+                to: ctx.to,
+                subject,
+                html,
+                text,
+            });
+        } catch (e) {
+            this.logger.warn(`sendJoinRequestApproved failed: ${(e as Error).message}`);
+        }
+    }
+
+    /**
+     * Notify a miner that their public-directory join request was rejected.
+     * No reason text is sent — keeping the admin UI minimal (no per-decision
+     * comment field). Best-effort, same swallow-on-failure semantics.
+     */
+    async sendJoinRequestRejected(ctx: JoinRequestDecisionContext): Promise<void> {
+        if (!this.enabled || !this.transport) return;
+        const subject = `Join request to ${sanitizeHeader(ctx.groupName)} declined — Blitz Pool`;
+        const html = renderJoinDecisionHtml(ctx, 'rejected');
+        const text = renderJoinDecisionText(ctx, 'rejected');
+        try {
+            await this.transport.sendMail({
+                from: this.fromAddress,
+                to: ctx.to,
+                subject,
+                html,
+                text,
+            });
+        } catch (e) {
+            this.logger.warn(`sendJoinRequestRejected failed: ${(e as Error).message}`);
+        }
     }
 
     /**
@@ -325,6 +380,56 @@ function renderInvitationText(ctx: InvitationEmailContext): string {
         ``,
         `Invitation expires ${ctx.expiresAt.toUTCString()}.`,
         `If you don't recognise the inviter, decline.`,
+    ].join('\n');
+}
+
+function renderJoinDecisionHtml(ctx: JoinRequestDecisionContext, decision: 'approved' | 'rejected'): string {
+    const isApproved = decision === 'approved';
+    const headline = isApproved ? 'Welcome — request approved' : 'Request declined';
+    const body = `
+<h1 style="margin:0 0 16px;font-size:22px;font-weight:600;color:${COLOR_TEXT};">${escapeHtml(headline)}</h1>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.6;color:${COLOR_TEXT};">
+  Your join request to <strong style="color:${COLOR_PRIMARY};">${escapeHtml(ctx.groupName)}</strong> has been
+  <strong>${isApproved ? 'approved' : 'declined'}</strong> by the group admin.
+</p>
+<p style="margin:0 0 24px;padding:12px 16px;background:${COLOR_BG};border-radius:6px;font-family:'Roboto Mono',monospace;font-size:13px;color:${COLOR_PRIMARY};word-break:break-all;">
+  ${escapeHtml(ctx.address)}
+</p>
+${isApproved ? `
+<p style="margin:0 0 16px;font-size:14px;line-height:1.6;color:${COLOR_TEXT};">
+  Your address is now a member. Future blocks will be paid out via the group's PROP-style coinbase split.
+</p>
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin:0 0 24px;">
+  <tr><td>${buttonHtml(ctx.groupUrl, 'Open group dashboard')}</td></tr>
+</table>
+<p style="margin:0;font-size:12px;color:${COLOR_MUTED};">
+  Or paste this link: <a href="${escapeAttr(ctx.groupUrl)}" style="color:${COLOR_PRIMARY};">${escapeHtml(ctx.groupUrl)}</a>
+</p>
+` : `
+<p style="margin:0;font-size:14px;line-height:1.6;color:${COLOR_TEXT};">
+  No further action is needed. You can request to join other public groups any time.
+</p>
+`}
+`;
+    return shellHtml(headline, body);
+}
+
+function renderJoinDecisionText(ctx: JoinRequestDecisionContext, decision: 'approved' | 'rejected'): string {
+    if (decision === 'approved') {
+        return [
+            `Your join request to "${sanitizeHeader(ctx.groupName)}" was approved.`,
+            ``,
+            `Address: ${ctx.address}`,
+            ``,
+            `Open group dashboard: ${ctx.groupUrl}`,
+        ].join('\n');
+    }
+    return [
+        `Your join request to "${sanitizeHeader(ctx.groupName)}" was declined by the admin.`,
+        ``,
+        `Address: ${ctx.address}`,
+        ``,
+        `No further action is needed. You can request to join other public groups any time.`,
     ].join('\n');
 }
 

--- a/src/services/group.service.spec.ts
+++ b/src/services/group.service.spec.ts
@@ -398,6 +398,19 @@ describe('GroupService', () => {
         }, token)).rejects.toMatchObject({ code: 'incomplete-schedule' });
     });
 
+    it('updateRoundResetConfig: isPublic toggle — defaults false, settable, defensive coerce', async () => {
+        const { id, token } = await freshGroup();
+        // Fresh group is private by default.
+        const initial = await service.getGroup(id);
+        expect(initial?.isPublic).toBe(false);
+        // Flip to public.
+        const pub = await service.updateRoundResetConfig(id, { isPublic: true }, token);
+        expect(pub.isPublic).toBe(true);
+        // Flip back to private; non-boolean inputs coerce to false (defensive).
+        const priv = await service.updateRoundResetConfig(id, { isPublic: 'yes' as any }, token);
+        expect(priv.isPublic).toBe(false);
+    });
+
     it('updateRoundResetConfig: PATCH semantics — undefined leaves columns alone', async () => {
         const { id, token } = await freshGroup();
         await service.updateRoundResetConfig(id, {

--- a/src/services/group.service.ts
+++ b/src/services/group.service.ts
@@ -81,6 +81,11 @@ export interface GroupRoundResetSettings {
     /** Admin's IANA timezone (browser-supplied). Required for any preset. */
     timezone?: string;
     finderBonusSats?: string | number | null;
+    /**
+     * Toggle public visibility. When true, the group surfaces in the
+     * public directory and accepts join-requests. Omit to leave unchanged.
+     */
+    isPublic?: boolean;
 }
 
 export type RoundResetPreset = 'daily' | 'weekly' | 'monthly' | 'custom';
@@ -215,6 +220,7 @@ export class GroupService implements OnModuleInit {
             creatorAddress: normalizedAddress,
             adminTokenHash: this.hashToken(adminToken),
             active: false,
+            isPublic: false,
         }));
 
         await this.memberRepo.save(this.memberRepo.create({
@@ -535,6 +541,14 @@ export class GroupService implements OnModuleInit {
                 }
                 group.finderBonusSats = parsed;
             }
+        }
+
+        // isPublic — pure visibility toggle. No cross-field constraints;
+        // a group can be public regardless of round-reset config. Strict
+        // boolean coercion so malformed JSON ("yes", 1, etc.) doesn't slip
+        // into a Postgres BOOLEAN column.
+        if (settings.isPublic !== undefined) {
+            group.isPublic = settings.isPublic === true;
         }
 
         // If a preset is configured we need a TZ on the entity — either

--- a/src/services/pplns-group-invitation.service.spec.ts
+++ b/src/services/pplns-group-invitation.service.spec.ts
@@ -4,7 +4,7 @@ import { PplnsGroupInvitationService, InvitationServiceError } from './pplns-gro
 
 function makeRepo<T>() {
     const rows: T[] = [];
-    return {
+    const repo: any = {
         rows,
         save: jest.fn(async (row: T) => {
             const idx = (rows as any[]).findIndex((r: any) =>
@@ -47,8 +47,30 @@ function makeRepo<T>() {
             rows.push(...remaining as any);
             return { affected: before - rows.length };
         }),
-        update: jest.fn(async () => ({ affected: 0 })),
+        update: jest.fn(async (where: any, patch: any) => {
+            let affected = 0;
+            for (const r of rows as any[]) {
+                if (Object.entries(where).every(([k, v]) => {
+                    if (v && typeof v === 'object' && (v as any)._type === 'lessThan') {
+                        return r[k]?.getTime?.() < (v as any)._value?.getTime?.();
+                    }
+                    return r[k] === v;
+                })) {
+                    Object.assign(r, patch);
+                    affected += 1;
+                }
+            }
+            return { affected };
+        }),
     };
+    // .manager.transaction(cb) shim — runs the callback against the same
+    // repo instance (no real isolation needed in tests).
+    repo.manager = {
+        transaction: jest.fn(async (cb: any) => {
+            return cb({ getRepository: () => repo });
+        }),
+    };
+    return repo;
 }
 
 function makeService(opts: { emailEnabled?: boolean } = {}) {
@@ -231,6 +253,7 @@ describe('PplnsGroupInvitationService', () => {
             address: 'bc1qbob',
             email: 'bob@example.com',
             status: 'pending',
+            inviteType: 'directed',
             createdAt: new Date(Date.now() - 100_000),
             expiresAt: new Date(Date.now() - 1000),
         });
@@ -244,5 +267,167 @@ describe('PplnsGroupInvitationService', () => {
         // visitor of /app/:address accept the invitation on the recipient's
         // behalf. Reference r1.token to avoid an unused-binding complaint.
         expect(r1.token).toBeTruthy();
+    });
+
+    // ── Open invitation links ───────────────────────────────────────
+
+    it('createOpenInvite: rejects bad admin token', async () => {
+        const { service } = makeService();
+        await expect(service.createOpenInvite('g1', '24h', 'bad-token'))
+            .rejects.toMatchObject({ code: 'invalid-token' });
+    });
+
+    it('createOpenInvite: rejects unknown TTL preset', async () => {
+        const { service } = makeService();
+        await expect(service.createOpenInvite('g1', 'forever' as any, 'good-token'))
+            .rejects.toMatchObject({ code: 'invalid-ttl' });
+    });
+
+    it('createOpenInvite: persists row with inviteType=open + null address/email', async () => {
+        const { service, invitationRepo } = makeService();
+        const r = await service.createOpenInvite('g1', '24h', 'good-token');
+        expect(r.token).toBeTruthy();
+        expect(r.expiresAt.getTime()).toBeGreaterThan(Date.now());
+
+        expect(invitationRepo.rows).toHaveLength(1);
+        const row = invitationRepo.rows[0];
+        expect(row.inviteType).toBe('open');
+        expect(row.address).toBeNull();
+        expect(row.email).toBeNull();
+        expect(row.status).toBe('pending');
+    });
+
+    it('createOpenInvite: replaces previous active link (atomic revoke)', async () => {
+        const { service, invitationRepo } = makeService();
+        const r1 = await service.createOpenInvite('g1', '24h', 'good-token');
+        const r2 = await service.createOpenInvite('g1', '7d', 'good-token');
+        expect(r2.token).not.toBe(r1.token);
+
+        const old = invitationRepo.rows.find((r: any) => r.token === r1.token);
+        const fresh = invitationRepo.rows.find((r: any) => r.token === r2.token);
+        expect(old.status).toBe('revoked');
+        expect(fresh.status).toBe('pending');
+    });
+
+    it('getActiveOpenInvite: returns null when none, returns latest when active', async () => {
+        const { service } = makeService();
+        const empty = await service.getActiveOpenInvite('g1', 'good-token');
+        expect(empty).toBeNull();
+
+        const r = await service.createOpenInvite('g1', '7d', 'good-token');
+        const active = await service.getActiveOpenInvite('g1', 'good-token');
+        expect(active?.token).toBe(r.token);
+    });
+
+    it('getActiveOpenInvite: returns null when current link is past TTL', async () => {
+        const { service, invitationRepo } = makeService();
+        const r = await service.createOpenInvite('g1', '1h', 'good-token');
+        const row = invitationRepo.rows.find((x: any) => x.token === r.token);
+        row.expiresAt = new Date(Date.now() - 1000);
+        const active = await service.getActiveOpenInvite('g1', 'good-token');
+        expect(active).toBeNull();
+    });
+
+    it('revokeOpenInvite: marks current pending link as revoked; idempotent', async () => {
+        const { service, invitationRepo } = makeService();
+        await service.createOpenInvite('g1', '24h', 'good-token');
+        await service.revokeOpenInvite('g1', 'good-token');
+        expect(invitationRepo.rows[0].status).toBe('revoked');
+        // Second call is a no-op (no pending rows left).
+        await service.revokeOpenInvite('g1', 'good-token');
+        expect(invitationRepo.rows[0].status).toBe('revoked');
+    });
+
+    it('getOpenInvitePublic: returns group context for valid token', async () => {
+        const { service } = makeService();
+        const r = await service.createOpenInvite('g1', '7d', 'good-token');
+        const info = await service.getOpenInvitePublic(r.token);
+        expect(info?.groupId).toBe('g1');
+        expect(info?.groupName).toBe('Friends');
+        expect(info?.token).toBe(r.token);
+    });
+
+    it('getOpenInvitePublic: returns null for revoked / expired / unknown / dissolved', async () => {
+        const { service, invitationRepo, groupService } = makeService();
+        // Unknown
+        expect(await service.getOpenInvitePublic('nope')).toBeNull();
+        // Revoked
+        const r = await service.createOpenInvite('g1', '24h', 'good-token');
+        await service.revokeOpenInvite('g1', 'good-token');
+        expect(await service.getOpenInvitePublic(r.token)).toBeNull();
+        // Expired
+        await service.createOpenInvite('g1', '1h', 'good-token');
+        const last = invitationRepo.rows[invitationRepo.rows.length - 1];
+        last.expiresAt = new Date(Date.now() - 1000);
+        expect(await service.getOpenInvitePublic(last.token)).toBeNull();
+        // Group dissolved
+        await service.createOpenInvite('g1', '7d', 'good-token');
+        const live = invitationRepo.rows[invitationRepo.rows.length - 1];
+        groupService.getGroup = jest.fn(async (id: string) => ({
+            id, name: 'Friends', creatorAddress: 'bc1qadmin', dissolvedAt: new Date(),
+        }));
+        expect(await service.getOpenInvitePublic(live.token)).toBeNull();
+    });
+
+    it('acceptOpenInvite: rejects address with no verified email', async () => {
+        const { service } = makeService();
+        const r = await service.createOpenInvite('g1', '24h', 'good-token');
+        await expect(service.acceptOpenInvite(r.token, 'bc1qcarol'))
+            .rejects.toMatchObject({ code: 'email-not-verified' });
+    });
+
+    it('acceptOpenInvite: rejects bad address shape', async () => {
+        const { service } = makeService();
+        const r = await service.createOpenInvite('g1', '24h', 'good-token');
+        await expect(service.acceptOpenInvite(r.token, ''))
+            .rejects.toMatchObject({ code: 'invalid-address' });
+    });
+
+    it('acceptOpenInvite: creates membership and leaves link reusable', async () => {
+        const { service, addressEmailService, memberRepo, invitationRepo } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        addressEmailService._setVerified('bc1qcarol', 'carol@example.com');
+
+        const r = await service.createOpenInvite('g1', '7d', 'good-token');
+        const m1 = await service.acceptOpenInvite(r.token, 'bc1qbob');
+        expect(m1.address).toBe('bc1qbob');
+        expect(memberRepo.rows).toHaveLength(1);
+        // Link still pending — second user can also claim it.
+        const row = invitationRepo.rows.find((x: any) => x.token === r.token);
+        expect(row.status).toBe('pending');
+
+        const m2 = await service.acceptOpenInvite(r.token, 'bc1qcarol');
+        expect(m2.address).toBe('bc1qcarol');
+        expect(memberRepo.rows).toHaveLength(2);
+    });
+
+    it('acceptOpenInvite: rejects when link is past TTL (and marks expired)', async () => {
+        const { service, addressEmailService, invitationRepo } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r = await service.createOpenInvite('g1', '1h', 'good-token');
+        const row = invitationRepo.rows.find((x: any) => x.token === r.token);
+        row.expiresAt = new Date(Date.now() - 1000);
+
+        await expect(service.acceptOpenInvite(r.token, 'bc1qbob'))
+            .rejects.toMatchObject({ code: 'expired' });
+        expect(row.status).toBe('expired');
+    });
+
+    it('acceptOpenInvite: rejects revoked link', async () => {
+        const { service, addressEmailService } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r = await service.createOpenInvite('g1', '24h', 'good-token');
+        await service.revokeOpenInvite('g1', 'good-token');
+        await expect(service.acceptOpenInvite(r.token, 'bc1qbob'))
+            .rejects.toMatchObject({ code: 'expired' });
+    });
+
+    it('directed-invite accept() refuses an open token (404)', async () => {
+        const { service, addressEmailService } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r = await service.createOpenInvite('g1', '24h', 'good-token');
+        // Wrong endpoint — directed accept doesn't take an address.
+        await expect(service.accept(r.token))
+            .rejects.toMatchObject({ code: 'not-found' });
     });
 });

--- a/src/services/pplns-group-invitation.service.ts
+++ b/src/services/pplns-group-invitation.service.ts
@@ -15,6 +15,19 @@ import { maskEmail } from '../utils/email-mask.utils';
 
 const INVITATION_TTL_DAYS = 7;
 
+/**
+ * Allowed TTL presets for open invite links. Mapped to milliseconds.
+ * Kept short and explicit — admins shouldn't be passing arbitrary
+ * durations (a year-long link is a footgun).
+ */
+export const OPEN_INVITE_TTL_PRESETS = {
+    '1h':  60 * 60 * 1000,
+    '24h': 24 * 60 * 60 * 1000,
+    '7d':  7 * 24 * 60 * 60 * 1000,
+    '30d': 30 * 24 * 60 * 60 * 1000,
+} as const;
+export type OpenInviteTtl = keyof typeof OPEN_INVITE_TTL_PRESETS;
+
 export class InvitationServiceError extends Error {
     constructor(public readonly code: string, message: string) {
         super(message);
@@ -82,7 +95,7 @@ export class PplnsGroupInvitationService {
 
         // Pending invitation already in flight? Skip.
         const pending = await this.invitationRepo.findOne({
-            where: { groupId, address, status: 'pending' },
+            where: { groupId, address, status: 'pending', inviteType: 'directed' },
         });
         if (pending && pending.expiresAt.getTime() > Date.now()) {
             throw new InvitationServiceError('invitation-pending', 'An invitation for this address is already pending');
@@ -111,6 +124,7 @@ export class PplnsGroupInvitationService {
             address,
             email: binding.email,
             status: 'pending',
+            inviteType: 'directed',
             expiresAt,
         }));
 
@@ -144,6 +158,10 @@ export class PplnsGroupInvitationService {
     } | null> {
         const invitation = await this.invitationRepo.findOneBy({ token });
         if (!invitation) return null;
+        // Open invites use a different public endpoint (getOpenInvitePublic);
+        // hide them from the directed-invite landing page, which expects
+        // address + email to be populated.
+        if (invitation.inviteType === 'open') return null;
         const group = await this.groupService.getGroup(invitation.groupId);
         if (!group || group.dissolvedAt) return null;
         return { invitation, group };
@@ -157,6 +175,12 @@ export class PplnsGroupInvitationService {
     async accept(token: string): Promise<PplnsGroupMemberEntity> {
         const invitation = await this.invitationRepo.findOneBy({ token });
         if (!invitation) {
+            throw new InvitationServiceError('not-found', 'Invitation unknown or already consumed');
+        }
+        // Open invites flow through acceptOpenInvite() (which takes the
+        // address from the user). Calling accept() on an open token would
+        // crash on the null address — surface a clean error instead.
+        if (invitation.inviteType === 'open') {
             throw new InvitationServiceError('not-found', 'Invitation unknown or already consumed');
         }
         if (invitation.status === 'accepted') {
@@ -261,8 +285,10 @@ export class PplnsGroupInvitationService {
         // pending row that was created against bc1q... by the admin.
         const normalized = normalizeBtcAddress(address);
         if (!normalized) return [];
+        // Open invites don't have a pre-bound address — they never surface
+        // in this banner. Restrict to directed.
         const rows = await this.invitationRepo.find({
-            where: { address: normalized, status: 'pending' },
+            where: { address: normalized, status: 'pending', inviteType: 'directed' },
             order: { createdAt: 'DESC' },
         });
         const now = Date.now();
@@ -288,8 +314,11 @@ export class PplnsGroupInvitationService {
      * been invited but hasn't responded yet, and to cancel if needed.
      */
     async listPendingForGroup(groupId: string): Promise<PplnsGroupInvitationEntity[]> {
+        // Directed-only — open invites get their own listing endpoint
+        // because they have different fields (no pre-bound address/email)
+        // and lifecycle (multi-use, no accept/decline state).
         const rows = await this.invitationRepo.find({
-            where: { groupId, status: 'pending' },
+            where: { groupId, status: 'pending', inviteType: 'directed' },
             order: { createdAt: 'DESC' },
         });
         const now = Date.now();
@@ -308,12 +337,177 @@ export class PplnsGroupInvitationService {
     ): Promise<void> {
         await this.groupService.requireAdminToken(groupId, adminToken);
         const invitation = await this.invitationRepo.findOne({
-            where: { groupId, address, status: 'pending' },
+            where: { groupId, address, status: 'pending', inviteType: 'directed' },
         });
         if (!invitation) {
             throw new InvitationServiceError('not-found', 'No pending invitation for this address in this group');
         }
         await this.invitationRepo.delete({ token: invitation.token });
+    }
+
+    // ── Open invitation links ─────────────────────────────────────────
+    //
+    // Admin-shareable links to be posted in a community channel. Anyone
+    // with a verified email binding for their address can claim them
+    // before the TTL expires. Single active link per group — generating
+    // a new one revokes the previous one in the same transaction.
+
+    /**
+     * Create a fresh open-invite link, atomically revoking any previously
+     * active one for the same group. Returns the new token + expiry; the
+     * caller (controller) is responsible for assembling the public URL.
+     */
+    async createOpenInvite(
+        groupId: string,
+        ttl: OpenInviteTtl,
+        adminToken: string | undefined,
+    ): Promise<{ token: string; expiresAt: Date }> {
+        await this.groupService.requireAdminToken(groupId, adminToken);
+
+        const ttlMs = OPEN_INVITE_TTL_PRESETS[ttl];
+        if (!ttlMs) {
+            throw new InvitationServiceError('invalid-ttl', `ttl must be one of: ${Object.keys(OPEN_INVITE_TTL_PRESETS).join(', ')}`);
+        }
+
+        const token = this.generateToken();
+        const expiresAt = new Date(Date.now() + ttlMs);
+
+        // Atomic replace: same transaction both revokes old + inserts new
+        // so two concurrent admin clicks can't race to leave two active
+        // open invites for the same group.
+        await this.invitationRepo.manager.transaction(async (em) => {
+            const repo = em.getRepository(PplnsGroupInvitationEntity);
+            await repo.update(
+                { groupId, status: 'pending', inviteType: 'open' },
+                { status: 'revoked', respondedAt: new Date() },
+            );
+            await repo.save(repo.create({
+                token,
+                groupId,
+                address: null,
+                email: null,
+                status: 'pending',
+                inviteType: 'open',
+                expiresAt,
+            }));
+        });
+
+        return { token, expiresAt };
+    }
+
+    /**
+     * Get the currently active (pending, not expired) open invite for a
+     * group. Admin-token gated — the token is the live secret. Returns
+     * null if no link is active or the previous one expired.
+     */
+    async getActiveOpenInvite(
+        groupId: string,
+        adminToken: string | undefined,
+    ): Promise<{ token: string; expiresAt: Date; createdAt: Date } | null> {
+        await this.groupService.requireAdminToken(groupId, adminToken);
+        const row = await this.invitationRepo.findOne({
+            where: { groupId, inviteType: 'open', status: 'pending' },
+            order: { createdAt: 'DESC' },
+        });
+        if (!row) return null;
+        if (row.expiresAt.getTime() < Date.now()) return null;
+        return { token: row.token, expiresAt: row.expiresAt, createdAt: row.createdAt };
+    }
+
+    /**
+     * Manually revoke the active open invite for a group. Idempotent —
+     * no-op if no active link exists.
+     */
+    async revokeOpenInvite(
+        groupId: string,
+        adminToken: string | undefined,
+    ): Promise<void> {
+        await this.groupService.requireAdminToken(groupId, adminToken);
+        await this.invitationRepo.update(
+            { groupId, status: 'pending', inviteType: 'open' },
+            { status: 'revoked', respondedAt: new Date() },
+        );
+    }
+
+    /**
+     * Public lookup for the open-invite landing page. Returns just enough
+     * to render the group context — no admin secrets, no member list.
+     * Returns null if the token is unknown, wrong type, expired, revoked,
+     * or the group has been dissolved.
+     */
+    async getOpenInvitePublic(token: string): Promise<{
+        token: string;
+        groupId: string;
+        groupName: string;
+        expiresAt: Date;
+    } | null> {
+        const invitation = await this.invitationRepo.findOneBy({ token });
+        if (!invitation || invitation.inviteType !== 'open') return null;
+        if (invitation.status !== 'pending') return null;
+        if (invitation.expiresAt.getTime() < Date.now()) return null;
+        const group = await this.groupService.getGroup(invitation.groupId);
+        if (!group || group.dissolvedAt) return null;
+        return {
+            token: invitation.token,
+            groupId: invitation.groupId,
+            groupName: group.name,
+            expiresAt: invitation.expiresAt,
+        };
+    }
+
+    /**
+     * Accept an open invite by binding it to a specific address. Multi-use:
+     * the row stays 'pending' so other miners can also claim the link until
+     * it expires. The trust anchor is the same as for directed invites —
+     * the address must have a verified email binding.
+     */
+    async acceptOpenInvite(token: string, address: string): Promise<PplnsGroupMemberEntity> {
+        const invitation = await this.invitationRepo.findOneBy({ token });
+        if (!invitation || invitation.inviteType !== 'open') {
+            throw new InvitationServiceError('not-found', 'Open invitation unknown');
+        }
+        if (invitation.status !== 'pending') {
+            // 'revoked' or 'expired' surface as 'expired' to the user — both
+            // mean the same thing functionally (link is dead).
+            throw new InvitationServiceError('expired', 'Open invitation no longer valid');
+        }
+        if (invitation.expiresAt.getTime() < Date.now()) {
+            invitation.status = 'expired';
+            await this.invitationRepo.save(invitation);
+            throw new InvitationServiceError('expired', 'Open invitation has expired');
+        }
+
+        const normalized = normalizeBtcAddress(address);
+        if (!normalized) {
+            throw new InvitationServiceError('invalid-address', 'A valid Bitcoin address is required');
+        }
+
+        // Email verification anchor — same as directed flow. Without this
+        // an open link in a public channel is worth nothing on its own.
+        const binding = await this.addressEmailService.getVerified(normalized);
+        if (!binding) {
+            throw new InvitationServiceError(
+                'email-not-verified',
+                'This address has no verified email. Register and verify your email first.',
+            );
+        }
+
+        const group = await this.groupService.getGroup(invitation.groupId);
+        if (!group || group.dissolvedAt) {
+            throw new InvitationServiceError('group-dissolved', 'Group no longer exists');
+        }
+
+        // Already a member of this or another group? Surface clear errors
+        // so the user knows why the join failed.
+        const existingMember = await this.memberRepo.findOneBy({ address: normalized });
+        if (existingMember && existingMember.groupId === invitation.groupId) {
+            throw new InvitationServiceError('already-member', 'Address is already a member of this group');
+        }
+        if (existingMember && existingMember.groupId !== invitation.groupId) {
+            throw new InvitationServiceError('address-in-group', 'Address is already a member of another group');
+        }
+
+        return this.groupService.addMemberWithoutAdmin(invitation.groupId, normalized);
     }
 
     /**

--- a/src/services/pplns-group-join-request.service.spec.ts
+++ b/src/services/pplns-group-join-request.service.spec.ts
@@ -1,0 +1,260 @@
+jest.mock('node-telegram-bot-api', () => jest.fn());
+
+import { PplnsGroupJoinRequestService, JoinRequestServiceError } from './pplns-group-join-request.service';
+
+function makeRepo<T>() {
+    const rows: T[] = [];
+    const repo: any = {
+        rows,
+        save: jest.fn(async (row: T) => {
+            const idx = (rows as any[]).findIndex((r: any) =>
+                ('id' in (row as any) && r.id === (row as any).id),
+            );
+            if (idx >= 0) {
+                rows[idx] = { ...(rows[idx] as any), ...(row as any) };
+                return rows[idx];
+            }
+            const withId = { id: (row as any).id ?? `id-${rows.length + 1}`, ...(row as any) };
+            rows.push(withId);
+            return withId;
+        }),
+        create: jest.fn((partial: Partial<T>) => ({ ...partial }) as T),
+        find: jest.fn(async (opts?: any) => {
+            if (!opts?.where) return [...rows];
+            return (rows as any[]).filter((r) =>
+                Object.entries(opts.where).every(([k, v]) => r[k] === v),
+            );
+        }),
+        findOneBy: jest.fn(async (where: any) => {
+            return (rows as any[]).find((r) =>
+                Object.entries(where).every(([k, v]) => r[k] === v),
+            ) ?? null;
+        }),
+        findOne: jest.fn(async (opts: any) => {
+            const where = opts.where ?? {};
+            const matches = (rows as any[]).filter((r) =>
+                Object.entries(where).every(([k, v]) => r[k] === v),
+            );
+            if (opts.order?.decidedAt === 'DESC') {
+                matches.sort((a, b) => (b.decidedAt?.getTime?.() ?? 0) - (a.decidedAt?.getTime?.() ?? 0));
+            } else if (opts.order?.createdAt === 'DESC') {
+                matches.sort((a, b) => (b.createdAt?.getTime?.() ?? 0) - (a.createdAt?.getTime?.() ?? 0));
+            }
+            return matches[0] ?? null;
+        }),
+        count: jest.fn(async (opts: any) => {
+            if (!opts?.where) return rows.length;
+            return (rows as any[]).filter((r) =>
+                Object.entries(opts.where).every(([k, v]) => r[k] === v),
+            ).length;
+        }),
+        update: jest.fn(async () => ({ affected: 0 })),
+    };
+    return repo;
+}
+
+function makeService(opts: { groupPublic?: boolean; groupDissolved?: boolean } = {}) {
+    const requestRepo = makeRepo<any>();
+    const memberRepo = makeRepo<any>();
+    const groupService: any = {
+        getGroup: jest.fn(async (id: string) => ({
+            id,
+            name: 'Friends',
+            creatorAddress: 'bc1qadmin',
+            isPublic: opts.groupPublic !== false,
+            dissolvedAt: opts.groupDissolved ? new Date() : null,
+        })),
+        requireAdminToken: jest.fn(async (groupId: string, token: string | undefined) => {
+            if (!token) throw new (require('./group.service').GroupServiceError)('missing-token', 'no token');
+            if (token !== 'good-token') throw new (require('./group.service').GroupServiceError)('invalid-token', 'bad');
+            return {
+                id: groupId,
+                name: 'Friends',
+                creatorAddress: 'bc1qadmin',
+                isPublic: opts.groupPublic !== false,
+                dissolvedAt: opts.groupDissolved ? new Date() : null,
+            };
+        }),
+        addMemberWithoutAdmin: jest.fn(async (groupId: string, address: string) => {
+            const m = { groupId, address, role: 'member', joinedAt: new Date() };
+            memberRepo.rows.push(m);
+            return m;
+        }),
+    };
+    const addressEmailService: any = {
+        _verified: new Map<string, any>(),
+        getVerified: jest.fn(async (address: string) => {
+            return addressEmailService._verified.get(address) ?? null;
+        }),
+        _setVerified: (address: string, email: string) => {
+            addressEmailService._verified.set(address, { address, email, verifiedAt: new Date() });
+        },
+    };
+    const emailService: any = {
+        sendJoinRequestApproved: jest.fn(async () => undefined),
+        sendJoinRequestRejected: jest.fn(async () => undefined),
+    };
+    const config: any = {
+        get: jest.fn((key: string) => {
+            if (key === 'POOL_BASE_URL') return 'https://blitzpool.test';
+            return undefined;
+        }),
+    };
+    const service = new PplnsGroupJoinRequestService(
+        requestRepo as any,
+        memberRepo as any,
+        groupService,
+        addressEmailService,
+        emailService,
+        config,
+    );
+    return { service, requestRepo, memberRepo, groupService, addressEmailService, emailService };
+}
+
+describe('PplnsGroupJoinRequestService', () => {
+
+    it('createJoinRequest: rejects when group is private', async () => {
+        const { service, addressEmailService } = makeService({ groupPublic: false });
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        await expect(service.createJoinRequest('g1', 'bc1qbob', null))
+            .rejects.toMatchObject({ code: 'not-found' });
+    });
+
+    it('createJoinRequest: rejects unverified address', async () => {
+        const { service } = makeService();
+        await expect(service.createJoinRequest('g1', 'bc1qbob', null))
+            .rejects.toMatchObject({ code: 'email-not-verified' });
+    });
+
+    it('createJoinRequest: rejects bad address shape', async () => {
+        const { service } = makeService();
+        await expect(service.createJoinRequest('g1', '', null))
+            .rejects.toMatchObject({ code: 'invalid-address' });
+    });
+
+    it('createJoinRequest: rejects address already in another group', async () => {
+        const { service, addressEmailService, memberRepo } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        memberRepo.rows.push({ groupId: 'other', address: 'bc1qbob', role: 'member' });
+        await expect(service.createJoinRequest('g1', 'bc1qbob', null))
+            .rejects.toMatchObject({ code: 'address-in-group' });
+    });
+
+    it('createJoinRequest: succeeds, snapshots email + truncates message', async () => {
+        const { service, addressEmailService, requestRepo } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const longMsg = 'x'.repeat(1000);
+        const r = await service.createJoinRequest('g1', 'bc1qbob', longMsg);
+        expect(r.email).toBe('bob@example.com');
+        expect((r.message ?? '').length).toBe(500);
+        expect(requestRepo.rows).toHaveLength(1);
+    });
+
+    it('createJoinRequest: rejects when over global pending cap', async () => {
+        const { service, addressEmailService, requestRepo } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        // Pre-seed 10 pending rows for this address.
+        for (let i = 0; i < 10; i++) {
+            requestRepo.rows.push({
+                id: `r${i}`, groupId: `g${i}`, address: 'bc1qbob',
+                email: 'bob@example.com', status: 'pending', createdAt: new Date(),
+            });
+        }
+        await expect(service.createJoinRequest('g11', 'bc1qbob', null))
+            .rejects.toMatchObject({ code: 'too-many-pending' });
+    });
+
+    it('createJoinRequest: enforces 24h cooldown after a reject', async () => {
+        const { service, addressEmailService, requestRepo } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        requestRepo.rows.push({
+            id: 'r-rej', groupId: 'g1', address: 'bc1qbob',
+            email: 'bob@example.com', status: 'rejected',
+            createdAt: new Date(Date.now() - 60_000),
+            decidedAt: new Date(Date.now() - 60_000), // just rejected
+        });
+        await expect(service.createJoinRequest('g1', 'bc1qbob', null))
+            .rejects.toMatchObject({ code: 'reject-cooldown' });
+    });
+
+    it('createJoinRequest: cooldown lifts after 24h', async () => {
+        const { service, addressEmailService, requestRepo } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        requestRepo.rows.push({
+            id: 'r-rej', groupId: 'g1', address: 'bc1qbob',
+            email: 'bob@example.com', status: 'rejected',
+            createdAt: new Date(Date.now() - 25 * 60 * 60 * 1000),
+            decidedAt: new Date(Date.now() - 25 * 60 * 60 * 1000),
+        });
+        const r = await service.createJoinRequest('g1', 'bc1qbob', null);
+        expect(r.status).toBe('pending');
+    });
+
+    it('approveRequest: requires admin token', async () => {
+        const { service, requestRepo, addressEmailService } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r = await service.createJoinRequest('g1', 'bc1qbob', null);
+        await expect(service.approveRequest('g1', r.id, 'wrong-token'))
+            .rejects.toMatchObject({ code: 'invalid-token' });
+        expect(requestRepo.rows[0].status).toBe('pending');
+    });
+
+    it('approveRequest: creates membership + sends email + marks decided', async () => {
+        const { service, requestRepo, memberRepo, emailService, addressEmailService } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r = await service.createJoinRequest('g1', 'bc1qbob', 'hi');
+        await service.approveRequest('g1', r.id, 'good-token');
+        expect(memberRepo.rows.find((m: any) => m.address === 'bc1qbob')).toBeTruthy();
+        expect(requestRepo.rows[0].status).toBe('approved');
+        expect(requestRepo.rows[0].decidedAt).toBeTruthy();
+        expect(emailService.sendJoinRequestApproved).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejectRequest: marks decided + sends email, no membership created', async () => {
+        const { service, requestRepo, memberRepo, emailService, addressEmailService } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r = await service.createJoinRequest('g1', 'bc1qbob', 'hi');
+        await service.rejectRequest('g1', r.id, 'good-token');
+        expect(requestRepo.rows[0].status).toBe('rejected');
+        expect(requestRepo.rows[0].decidedAt).toBeTruthy();
+        expect(memberRepo.rows).toHaveLength(0);
+        expect(emailService.sendJoinRequestRejected).toHaveBeenCalledTimes(1);
+    });
+
+    it('approveRequest on missing/already-decided id returns not-found', async () => {
+        const { service, requestRepo, addressEmailService } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r = await service.createJoinRequest('g1', 'bc1qbob', null);
+        await service.approveRequest('g1', r.id, 'good-token');
+        // second approve on the now-approved row 404s
+        await expect(service.approveRequest('g1', r.id, 'good-token'))
+            .rejects.toMatchObject({ code: 'not-found' });
+        expect(requestRepo.rows[0].status).toBe('approved');
+    });
+
+    it('approveRequest fails when address joined another group between submit + approve', async () => {
+        const { service, requestRepo, memberRepo, addressEmailService } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        const r = await service.createJoinRequest('g1', 'bc1qbob', null);
+        // User joins another group via a different mechanism
+        memberRepo.rows.push({ groupId: 'g2', address: 'bc1qbob', role: 'member' });
+        await expect(service.approveRequest('g1', r.id, 'good-token'))
+            .rejects.toMatchObject({ code: 'address-in-group' });
+        // Request marked rejected so it doesn't keep showing as pending.
+        expect(requestRepo.rows[0].status).toBe('rejected');
+    });
+
+    it('listForAddress filters out dissolved groups', async () => {
+        const { service, requestRepo, addressEmailService, groupService } = makeService();
+        addressEmailService._setVerified('bc1qbob', 'bob@example.com');
+        await service.createJoinRequest('g1', 'bc1qbob', null);
+        // Dissolve g1 — pending request should not surface.
+        groupService.getGroup = jest.fn(async (id: string) => ({
+            id, name: 'Friends', creatorAddress: 'bc1qadmin',
+            isPublic: true, dissolvedAt: new Date(),
+        }));
+        const list = await service.listForAddress('bc1qbob');
+        expect(list).toHaveLength(0);
+        expect(requestRepo.rows[0].status).toBe('pending'); // still pending in DB
+    });
+});

--- a/src/services/pplns-group-join-request.service.ts
+++ b/src/services/pplns-group-join-request.service.ts
@@ -1,0 +1,323 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Interval } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThan, Repository } from 'typeorm';
+import * as crypto from 'crypto';
+import { PplnsGroupJoinRequestEntity } from '../ORM/pplns-group/pplns-group-join-request.entity';
+import { PplnsGroupMemberEntity } from '../ORM/pplns-group/pplns-group-member.entity';
+import { GroupService } from './group.service';
+import { AddressEmailService } from './address-email.service';
+import { EmailService } from './email.service';
+import { normalizeBtcAddress } from '../utils/btc-address.utils';
+
+const MESSAGE_MAX_LENGTH = 500;
+/** Cap on simultaneously-pending join requests across all groups for one address. */
+const MAX_PENDING_PER_ADDRESS = 10;
+/** Hours of cooldown after a rejected request before the same (group, address) pair can re-request. */
+const REJECT_COOLDOWN_HOURS = 24;
+/** Auto-expire join requests that languished as 'pending' for this long (admin abandoned the panel). */
+const PENDING_EXPIRY_DAYS = 30;
+
+export class JoinRequestServiceError extends Error {
+    constructor(public readonly code: string, message: string) {
+        super(message);
+    }
+}
+
+/**
+ * Public-directory join requests. The complement to invitations:
+ *   - Invitation = admin-initiated, pre-binds the address (directed) or
+ *                  is shareable (open).
+ *   - Join request = user-initiated, address comes from the requester,
+ *                    admin reviews + approves/rejects.
+ *
+ * Same trust anchor as invitations: the requesting address must have a
+ * verified email binding. The email is snapshotted onto the request row
+ * at create time so approve/reject notifications reach the same inbox
+ * even if the user later rebinds.
+ *
+ * Rate limits (multi-layer):
+ *   1. DB-level — unique partial index on (groupId, address) WHERE status='pending'
+ *      means the same (group, address) pair can have only one pending row.
+ *   2. Service-level — global cap of MAX_PENDING_PER_ADDRESS pending across
+ *      all groups for one address (prevents an attacker farming verified
+ *      emails and then spraying admins with pending requests).
+ *   3. Service-level — REJECT_COOLDOWN_HOURS after a reject before the same
+ *      (group, address) can request again.
+ */
+@Injectable()
+export class PplnsGroupJoinRequestService {
+
+    private readonly logger = new Logger(PplnsGroupJoinRequestService.name);
+
+    constructor(
+        @InjectRepository(PplnsGroupJoinRequestEntity)
+        private readonly requestRepo: Repository<PplnsGroupJoinRequestEntity>,
+        @InjectRepository(PplnsGroupMemberEntity)
+        private readonly memberRepo: Repository<PplnsGroupMemberEntity>,
+        private readonly groupService: GroupService,
+        private readonly addressEmailService: AddressEmailService,
+        private readonly emailService: EmailService,
+        private readonly config: ConfigService,
+    ) {}
+
+    /**
+     * Create a join request. Public — no admin-token check. Validation chain:
+     *   - Group exists, is public, not dissolved
+     *   - Address shape is valid + has a verified email
+     *   - Address isn't already a member of any group
+     *   - Address isn't over the global pending cap
+     *   - No (group, address) row currently in cooldown
+     *   - The DB unique partial index does the final consistency check
+     */
+    async createJoinRequest(
+        groupId: string,
+        address: string,
+        message: string | null | undefined,
+    ): Promise<PplnsGroupJoinRequestEntity> {
+        const group = await this.groupService.getGroup(groupId);
+        if (!group || group.dissolvedAt) {
+            throw new JoinRequestServiceError('not-found', 'Group not found');
+        }
+        if (!group.isPublic) {
+            // Don't leak existence of private groups via this endpoint.
+            // 'not-found' rather than 'forbidden' so the caller can't probe
+            // for "private but exists" responses.
+            throw new JoinRequestServiceError('not-found', 'Group not found');
+        }
+
+        const normalized = normalizeBtcAddress(address);
+        if (!normalized) {
+            throw new JoinRequestServiceError('invalid-address', 'A valid Bitcoin address is required');
+        }
+
+        const binding = await this.addressEmailService.getVerified(normalized);
+        if (!binding) {
+            throw new JoinRequestServiceError(
+                'email-not-verified',
+                'This address has no verified email. Register and verify your email first.',
+            );
+        }
+
+        // Already a member?
+        const existingMember = await this.memberRepo.findOneBy({ address: normalized });
+        if (existingMember) {
+            if (existingMember.groupId === groupId) {
+                throw new JoinRequestServiceError('already-member', 'Address is already a member of this group');
+            }
+            throw new JoinRequestServiceError('address-in-group', 'Address is already a member of another group');
+        }
+
+        // Global cap on pending across all groups
+        const pendingForAddr = await this.requestRepo.count({
+            where: { address: normalized, status: 'pending' },
+        });
+        if (pendingForAddr >= MAX_PENDING_PER_ADDRESS) {
+            throw new JoinRequestServiceError(
+                'too-many-pending',
+                `You already have ${pendingForAddr} pending join requests; resolve some before adding more.`,
+            );
+        }
+
+        // Reject cooldown — same (group, address) can't re-request within
+        // REJECT_COOLDOWN_HOURS of being declined.
+        const recentReject = await this.requestRepo.findOne({
+            where: { groupId, address: normalized, status: 'rejected' },
+            order: { decidedAt: 'DESC' },
+        });
+        if (recentReject?.decidedAt) {
+            const elapsedHours = (Date.now() - recentReject.decidedAt.getTime()) / (60 * 60 * 1000);
+            if (elapsedHours < REJECT_COOLDOWN_HOURS) {
+                throw new JoinRequestServiceError(
+                    'reject-cooldown',
+                    `Please wait ${Math.ceil(REJECT_COOLDOWN_HOURS - elapsedHours)} more hour(s) before re-requesting.`,
+                );
+            }
+        }
+
+        const trimmedMessage = (message ?? '').toString().trim().slice(0, MESSAGE_MAX_LENGTH) || null;
+
+        try {
+            return await this.requestRepo.save(this.requestRepo.create({
+                groupId,
+                address: normalized,
+                email: binding.email,
+                message: trimmedMessage,
+                status: 'pending',
+            }));
+        } catch (e) {
+            // The unique partial index throws a Postgres unique-violation
+            // (23505) if a pending row already exists for (groupId, address).
+            // Surface as a clean 'request-pending' instead of 500.
+            if ((e as any)?.code === '23505') {
+                throw new JoinRequestServiceError('request-pending', 'A join request for this address is already pending');
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * List join requests for a group. Admin-token gated. Default returns
+     * only pending; pass `includeDecided=true` to also see recently
+     * approved/rejected rows for audit.
+     */
+    async listForGroup(
+        groupId: string,
+        adminToken: string | undefined,
+        opts: { includeDecided?: boolean } = {},
+    ): Promise<PplnsGroupJoinRequestEntity[]> {
+        await this.groupService.requireAdminToken(groupId, adminToken);
+        const where = opts.includeDecided
+            ? { groupId }
+            : { groupId, status: 'pending' as const };
+        return this.requestRepo.find({
+            where,
+            order: { createdAt: 'DESC' },
+        });
+    }
+
+    /**
+     * Approve a pending request — creates the membership and notifies the
+     * miner by email. Admin-token gated. Idempotent only by virtue of the
+     * pending-status guard: a second approve on the same id returns 'not-found'.
+     */
+    async approveRequest(
+        groupId: string,
+        requestId: string,
+        adminToken: string | undefined,
+    ): Promise<void> {
+        const group = await this.groupService.requireAdminToken(groupId, adminToken);
+        const request = await this.requestRepo.findOneBy({ id: requestId, groupId, status: 'pending' });
+        if (!request) {
+            throw new JoinRequestServiceError('not-found', 'Pending join request not found');
+        }
+        if (group.dissolvedAt) {
+            throw new JoinRequestServiceError('group-dissolved', 'Group has been dissolved');
+        }
+
+        // Last-mile checks — the user could have joined another group between
+        // submitting the request and the admin approving it.
+        const existingMember = await this.memberRepo.findOneBy({ address: request.address });
+        if (existingMember && existingMember.groupId !== groupId) {
+            // Mark the request rejected (audit) so it doesn't keep showing up
+            // as pending in the admin UI.
+            request.status = 'rejected';
+            request.decidedAt = new Date();
+            request.decidedByAdminTokenHash = this.hashToken(adminToken!);
+            await this.requestRepo.save(request);
+            throw new JoinRequestServiceError('address-in-group', 'Address joined another group in the meantime');
+        }
+        if (!existingMember) {
+            await this.groupService.addMemberWithoutAdmin(groupId, request.address);
+        }
+        // else: member already in this group (manual add by admin?) — fall through
+        //       to mark the request approved so it disappears from the panel.
+
+        request.status = 'approved';
+        request.decidedAt = new Date();
+        request.decidedByAdminTokenHash = this.hashToken(adminToken!);
+        await this.requestRepo.save(request);
+
+        // Best-effort email; service swallows + logs SMTP errors so the
+        // approval transaction isn't tied to email-server availability.
+        const baseUrl = this.poolBaseUrl();
+        await this.emailService.sendJoinRequestApproved({
+            to: request.email,
+            address: request.address,
+            groupName: group.name,
+            groupUrl: `${baseUrl}/#/app/${request.address}/payout-group`,
+        });
+    }
+
+    /**
+     * Reject a pending request. No reason text — the admin UI is intentionally
+     * minimal (a comment field would invite drama). Admin-token gated.
+     */
+    async rejectRequest(
+        groupId: string,
+        requestId: string,
+        adminToken: string | undefined,
+    ): Promise<void> {
+        const group = await this.groupService.requireAdminToken(groupId, adminToken);
+        const request = await this.requestRepo.findOneBy({ id: requestId, groupId, status: 'pending' });
+        if (!request) {
+            throw new JoinRequestServiceError('not-found', 'Pending join request not found');
+        }
+
+        request.status = 'rejected';
+        request.decidedAt = new Date();
+        request.decidedByAdminTokenHash = this.hashToken(adminToken!);
+        await this.requestRepo.save(request);
+
+        const baseUrl = this.poolBaseUrl();
+        await this.emailService.sendJoinRequestRejected({
+            to: request.email,
+            address: request.address,
+            groupName: group.name,
+            groupUrl: `${baseUrl}/#/groups/public`,
+        });
+    }
+
+    /**
+     * List the current user's own pending requests across all groups —
+     * drives the "you have a request pending" badge on directory pages.
+     * Public, no auth.
+     */
+    async listForAddress(address: string): Promise<{
+        groupId: string;
+        groupName: string;
+        status: 'pending';
+        createdAt: Date;
+    }[]> {
+        const normalized = normalizeBtcAddress(address);
+        if (!normalized) return [];
+        const rows = await this.requestRepo.find({
+            where: { address: normalized, status: 'pending' },
+            order: { createdAt: 'DESC' },
+        });
+        const results: any[] = [];
+        for (const r of rows) {
+            const group = await this.groupService.getGroup(r.groupId);
+            if (!group || group.dissolvedAt) continue;
+            results.push({
+                groupId: r.groupId,
+                groupName: group.name,
+                status: 'pending',
+                createdAt: r.createdAt,
+            });
+        }
+        return results;
+    }
+
+    /**
+     * Periodic expiry for stale pending requests — covers the case where
+     * the admin abandons the panel for weeks. Daily cron is fine; the
+     * count of expirable rows is small.
+     */
+    @Interval(24 * 60 * 60 * 1000)
+    async expireStale(): Promise<number> {
+        try {
+            const cutoff = new Date(Date.now() - PENDING_EXPIRY_DAYS * 24 * 60 * 60 * 1000);
+            const result = await this.requestRepo.update(
+                { status: 'pending', createdAt: LessThan(cutoff) },
+                { status: 'expired' },
+            );
+            const n = result.affected ?? 0;
+            if (n > 0) this.logger.log(`Expired ${n} stale join requests`);
+            return n;
+        } catch (err) {
+            this.logger.warn(`expireStale failed: ${(err as Error).message}`);
+            return 0;
+        }
+    }
+
+    private hashToken(token: string): string {
+        return crypto.createHash('sha256').update(token).digest('hex');
+    }
+
+    private poolBaseUrl(): string {
+        const url = this.config.get<string>('POOL_BASE_URL');
+        return (url ?? '').replace(/\/+$/, '');
+    }
+}

--- a/src/utils/email-mask.utils.spec.ts
+++ b/src/utils/email-mask.utils.spec.ts
@@ -1,0 +1,35 @@
+import { maskEmail } from './email-mask.utils';
+
+describe('maskEmail', () => {
+    it('masks single-segment domains: alice@gmail.com → a***@g***.com', () => {
+        expect(maskEmail('alice@gmail.com')).toBe('a***@g***.com');
+    });
+
+    it('masks custom domains so identity is not pinpointed: joe@joe.de → j***@j***.de', () => {
+        expect(maskEmail('joe@joe.de')).toBe('j***@j***.de');
+    });
+
+    it('preserves multi-segment TLDs: carol@example.co.uk → c***@e***.co.uk', () => {
+        expect(maskEmail('carol@example.co.uk')).toBe('c***@e***.co.uk');
+    });
+
+    it('returns "" for empty input', () => {
+        expect(maskEmail('')).toBe('');
+    });
+
+    it('returns "***" for malformed shapes (no @ / leading @ / trailing @)', () => {
+        expect(maskEmail('not-an-email')).toBe('***');
+        expect(maskEmail('@oops.com')).toBe('***');
+        expect(maskEmail('oops@')).toBe('***');
+    });
+
+    it('handles bare hostnames without TLD: dev@localhost → d***@***', () => {
+        expect(maskEmail('dev@localhost')).toBe('d***@***');
+    });
+
+    it('keeps the format stable for unicode local-parts (first char is taken)', () => {
+        // Defensive — non-ASCII local-parts are valid; we just take the first
+        // code unit. The privacy property holds (one character of context only).
+        expect(maskEmail('änna@example.com')).toBe('ä***@e***.com');
+    });
+});

--- a/src/utils/email-mask.utils.ts
+++ b/src/utils/email-mask.utils.ts
@@ -1,17 +1,33 @@
 /**
- * Mask an email for public display: first char of the local part + domain.
- * Used wherever a verified-email binding is exposed on a public URL —
- * the owner already knows their own email, and outsiders only need a
- * hint ("yes, something is bound, prefix is `a***`") rather than the
- * full address.
+ * Mask an email for display: first char of local part, first char of
+ * the second-level domain, TLD-and-below preserved. So:
+ *   alice@gmail.com        → a***@g***.com
+ *   bob@joe.de             → b***@j***.de
+ *   carol@example.co.uk    → c***@e***.co.uk
  *
- * Returns '' for empty input and '***' if the input has no '@' (defense
- * against malformed rows; should not happen in practice).
+ * Used wherever an email binding is exposed to anyone other than the
+ * binding owner — including admin-side dashboards, public banners, and
+ * notification side-channels. The strict form (vs. previous `a***@gmail.com`)
+ * means even a leaked admin token can't reveal the full email when the
+ * user has a custom domain (`joe@joe.de` would otherwise pinpoint identity).
+ *
+ * The owner already knows their own email; the mask is defensive output
+ * for everyone else. Returns '' for empty input and '***' for malformed
+ * shapes (no '@').
  */
 export function maskEmail(email: string): string {
     if (!email) return '';
-    const [local, domain] = email.split('@');
-    if (!domain) return '***';
-    const head = local.slice(0, 1);
-    return `${head}***@${domain}`;
+    const atIdx = email.indexOf('@');
+    if (atIdx <= 0 || atIdx === email.length - 1) return '***';
+    const local = email.slice(0, atIdx);
+    const domain = email.slice(atIdx + 1);
+    const localHead = local.slice(0, 1);
+    const dotIdx = domain.indexOf('.');
+    if (dotIdx <= 0) {
+        // No TLD (e.g. `joe@localhost`) — mask everything after the @.
+        return `${localHead}***@***`;
+    }
+    const domainHead = domain.slice(0, 1);
+    const tldAndBelow = domain.slice(dotIdx); // includes the leading dot
+    return `${localHead}***@${domainHead}***${tldAndBelow}`;
 }


### PR DESCRIPTION
## Summary
Three new ways to discover and join payout groups, complementing the existing directed-invite flow. All paths share the same email-verification trust anchor.

- **Open invite links** — admin generates a TTL-limited shareable link (1h / 24h / 7d / 30d). Anyone with a verified email for their address joins by entering their own address. Multi-use until TTL.
- **Public directory** — admin opts in via `isPublic` toggle. Group surfaces in `/groups/public` with member count, hashrate, reset schedule.
- **Join requests** — user-initiated requests from the public directory. Admin reviews + approves or rejects in a unified panel; requester gets an email either way.

## Migrations (additive only)
- `1779400000000-AddGroupIsPublic` — `pplns_group.isPublic` BOOLEAN DEFAULT false
- `1779600000000-AddOpenInvitationSupport` — `address` and `email` become nullable; new `inviteType` column ('directed'|'open', default 'directed')
- `1779800000000-AddPublicDirectoryAndJoinRequests` — new `pplns_group_join_request` table with unique partial index `(groupId, address) WHERE status='pending'`

No NOT NULL tightening, no data backfills. Existing groups continue mining unchanged with `isPublic=false`.

## Rate limiting (join requests)
Three layers stack: DB-level partial unique index (1 pending per group/address) + service-level cap (10 pending across all groups per address) + 24h post-reject cooldown.

## Security model
Email-verified address binding remains the trust anchor for all three new flows:
- Open invite — token leak alone is worthless without a verified email for your address
- Join request — same address-email check at request time; email snapshotted onto the row so notifications reach the same inbox even if user later rebinds

## Companion UI PR
warioishere/blitzpool-ui#feat/public-groups-and-invites

## Test plan
- [x] \`npx jest --runInBand\` — 787 passing (3 regtest suites need bitcoind, unrelated)
- [x] +14 invitation specs covering open-invite lifecycle (create / replace / revoke / expire / accept / multi-use / type-isolation)
- [x] +14 join-request specs covering rate limits / approve / reject / cooldown / dissolved-mid-flight
- [x] Type-check clean on backend and UI app projects
- [x] Smoke test in staging: existing directed-invite flow still works
- [x] Smoke test: existing groups with running miners continue paying out
- [x] Smoke test: TTL countdown + revoke-replace UX on real shared link