### PR TITLE
feat(blockparty): fixed-% loot-split mining mode (v2.1.7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blitzpool",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "",
   "author": "",
   "private": true,

--- a/src/ORM/blockparty/blockparty-block-history.entity.ts
+++ b/src/ORM/blockparty/blockparty-block-history.entity.ts
@@ -1,0 +1,59 @@
+import { BeforeInsert, Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+import { epochMsTransformer } from '../utils/epoch-ms-transformer';
+
+export interface BlockpartySplitSnapshot {
+    address: string;
+    percentBp: number;
+    sats: number;
+    /** True if this member's payout was rolled into the pool-fee output because of dust or weight-budget trim. */
+    trimmed?: boolean;
+}
+
+/**
+ * Found-block history for a Blockparty group. One row per block —
+ * the per-member breakdown is captured atomically in `splits` (jsonb)
+ * because Blockparty has no balance/pending ledger: payouts go straight
+ * into the coinbase, history is read-only audit trail.
+ *
+ * Idempotency: unique on (groupId, blockHash). onBlockFound upserts with
+ * ON CONFLICT DO NOTHING so a crash-restart can't double-write.
+ */
+@Index('UQ_blockparty_block_history_group_hash', ['groupId', 'blockHash'], { unique: true })
+@Entity('blockparty_block_history')
+export class BlockpartyBlockHistoryEntity {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Index()
+    @Column({ type: 'uuid' })
+    groupId: string;
+
+    @Index()
+    @Column({ type: 'int' })
+    blockHeight: number;
+
+    @Column({ type: 'varchar', length: 64 })
+    blockHash: string;
+
+    @Column({ type: 'bigint', transformer: epochMsTransformer })
+    foundAt: number;
+
+    @Column({ type: 'bigint', transformer: { from: (v: string) => Number(v), to: (v: number) => v } })
+    coinbaseValueSats: number;
+
+    @Column({ type: 'bigint', transformer: { from: (v: string) => Number(v), to: (v: number) => v } })
+    poolFeeSats: number;
+
+    @Column({ type: 'jsonb' })
+    splits: BlockpartySplitSnapshot[];
+
+    @Column({ type: 'bigint', transformer: epochMsTransformer })
+    createdAt: number;
+
+    @BeforeInsert()
+    private fillCreatedAt(): void {
+        if (this.createdAt == null) this.createdAt = Date.now();
+    }
+}

--- a/src/ORM/blockparty/blockparty-group.entity.ts
+++ b/src/ORM/blockparty/blockparty-group.entity.ts
@@ -1,0 +1,79 @@
+import { BeforeInsert, BeforeUpdate, Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+import { epochMsTransformer } from '../utils/epoch-ms-transformer';
+
+export type BlockpartyStatus = 'draft' | 'confirming' | 'ready' | 'active' | 'dissolved';
+
+/**
+ * Blockparty group: loot-split mechanism for pooled hashpower rentals.
+ * Coinbase splits per admin-set fixed percentages (basis points),
+ * independent of who contributed how much hashpower.
+ *
+ * Lifecycle is share-driven (READY → ACTIVE on first share to
+ * adminAddress) and admin-driven (DISSOLVED via Dissolve button,
+ * gated by 24h hashrate-silence cooldown).
+ */
+@Entity('blockparty_group')
+export class BlockpartyGroupEntity {
+
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Index({ unique: true })
+    @Column({ type: 'varchar', length: 64 })
+    name: string;
+
+    /**
+     * Treasury BTC address — the mining target. Hashrate routed to this
+     * address triggers Blockparty mode (address-driven mode-detect on
+     * solo port 3333). One blockparty per admin address (active or
+     * dissolved is fine, but a second active one with the same admin
+     * address would collide on mode-detect).
+     */
+    @Index({ unique: true })
+    @Column({ type: 'varchar', length: 62 })
+    adminAddress: string;
+
+    /** SHA-256 of the admin token — shown once on create, never stored raw. */
+    @Column({ type: 'varchar', length: 64 })
+    adminTokenHash: string;
+
+    @Column({ type: 'varchar', length: 16, default: 'draft' })
+    status: BlockpartyStatus;
+
+    /**
+     * Updated on every accepted share whose miner address equals
+     * adminAddress. Drives the 24h dissolve cooldown.
+     */
+    @Column({ type: 'bigint', nullable: true, transformer: epochMsTransformer })
+    lastShareAt: number | null;
+
+    /**
+     * Optional admin-set rental-provider hint shown on the public detail
+     * page (e.g. "MRR", "Braiins Hashrate", "Nicehash"). Pure UI metadata —
+     * no backend semantics.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    rentalProviderHint: string | null;
+
+    @Column({ type: 'bigint', transformer: epochMsTransformer })
+    createdAt: number;
+
+    @Column({ type: 'bigint', transformer: epochMsTransformer })
+    updatedAt: number;
+
+    @Column({ type: 'bigint', nullable: true, transformer: epochMsTransformer })
+    dissolvedAt: number | null;
+
+    @BeforeInsert()
+    private fillTimestamps(): void {
+        const now = Date.now();
+        if (this.createdAt == null) this.createdAt = now;
+        if (this.updatedAt == null) this.updatedAt = now;
+    }
+
+    @BeforeUpdate()
+    private touchUpdatedAt(): void {
+        this.updatedAt = Date.now();
+    }
+}

--- a/src/ORM/blockparty/blockparty-invitation.entity.ts
+++ b/src/ORM/blockparty/blockparty-invitation.entity.ts
@@ -1,0 +1,52 @@
+import { BeforeInsert, Column, Entity, Index, PrimaryColumn } from 'typeorm';
+
+import { epochMsTransformer } from '../utils/epoch-ms-transformer';
+
+/**
+ * Invitation for an address to join a Blockparty group. Directed-only
+ * for v1: the admin specifies the prospective member's BTC address and
+ * email up front. The system mints a one-shot bearer token that the
+ * member presents at /api/blockparty/invite/:token to accept or decline.
+ *
+ * Status lifecycle: pending → accepted | declined | expired.
+ *
+ * Token is the primary key: knowledge of the token is the only
+ * authentication an accepting member needs (out-of-band-delivered
+ * secret), same as the existing PPLNS-group invitation flow.
+ */
+export type BlockpartyInvitationStatus = 'pending' | 'accepted' | 'declined' | 'expired';
+
+@Entity('blockparty_invitation')
+export class BlockpartyInvitationEntity {
+
+    @PrimaryColumn({ type: 'varchar', length: 64 })
+    token: string;
+
+    @Index()
+    @Column({ type: 'uuid' })
+    groupId: string;
+
+    @Index()
+    @Column({ type: 'varchar', length: 62 })
+    address: string;
+
+    @Column({ type: 'varchar', length: 320 })
+    email: string;
+
+    @Column({ type: 'varchar', length: 16, default: 'pending' })
+    status: BlockpartyInvitationStatus;
+
+    @Column({ type: 'bigint', transformer: epochMsTransformer })
+    createdAt: number;
+
+    @Column({ type: 'bigint', transformer: epochMsTransformer })
+    expiresAt: number;
+
+    @Column({ type: 'bigint', nullable: true, transformer: epochMsTransformer })
+    respondedAt: number | null;
+
+    @BeforeInsert()
+    private fillCreatedAt(): void {
+        if (this.createdAt == null) this.createdAt = Date.now();
+    }
+}

--- a/src/ORM/blockparty/blockparty-member.entity.ts
+++ b/src/ORM/blockparty/blockparty-member.entity.ts
@@ -1,0 +1,66 @@
+import { BeforeInsert, Column, Entity, Index, PrimaryGeneratedColumn, Unique } from 'typeorm';
+
+import { epochMsTransformer } from '../utils/epoch-ms-transformer';
+
+/**
+ * Member of a Blockparty group. The admin is also a member (with
+ * role='admin'); regular members have role='member'.
+ *
+ * `percentBp` is the basis-points share of the *miner cut*
+ * (= coinbase value minus pool fee). Sum of all members' percentBp
+ * MUST equal 10000 (= 100% of the miner cut).
+ *
+ * `address` is globally unique — an address can only be in one
+ * blockparty group at a time. Mode-collision against PPLNS /
+ * Group-Solo is enforced at the service layer.
+ */
+@Entity('blockparty_member')
+@Unique('UQ_blockparty_member_group_address', ['groupId', 'address'])
+export class BlockpartyMemberEntity {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Index()
+    @Column({ type: 'uuid' })
+    groupId: string;
+
+    @Index({ unique: true })
+    @Column({ type: 'varchar', length: 62 })
+    address: string;
+
+    @Column({ type: 'varchar', length: 320 })
+    email: string;
+
+    /** Basis points: 100 = 1%, 10000 = 100%. Min 100 enforced in service. */
+    @Column({ type: 'int' })
+    percentBp: number;
+
+    @Column({ type: 'varchar', length: 16, default: 'member' })
+    role: 'admin' | 'member';
+
+    /** Null until member accepts the invitation. Reset to null when admin edits splits. */
+    @Column({ type: 'bigint', nullable: true, transformer: epochMsTransformer })
+    confirmedAt: number | null;
+
+    /**
+     * SHA-256 of the member's persistent token, minted on first invitation
+     * accept. Required for re-confirmations after admin %-edits and for
+     * gated read access on the admin/detail page. Null until first accept.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    memberTokenHash: string | null;
+
+    @Column({ type: 'bigint', transformer: epochMsTransformer })
+    createdAt: number;
+
+    @Column({ type: 'bigint', transformer: epochMsTransformer })
+    updatedAt: number;
+
+    @BeforeInsert()
+    private fillTimestamps(): void {
+        const now = Date.now();
+        if (this.createdAt == null) this.createdAt = now;
+        if (this.updatedAt == null) this.updatedAt = now;
+    }
+}

--- a/src/ORM/pool-mode-hashrate/pool-mode-hashrate.entity.ts
+++ b/src/ORM/pool-mode-hashrate/pool-mode-hashrate.entity.ts
@@ -23,7 +23,7 @@ export class PoolModeHashrateEntity {
 
     @Index()
     @Column({ length: 16, type: 'varchar' })
-    mode: 'solo' | 'pplns' | 'group-solo';
+    mode: 'solo' | 'pplns' | 'group-solo' | 'blockparty';
 
     /** 10-min bucket start, epoch-ms. */
     @Index()

--- a/src/app.controller.block-template.spec.ts
+++ b/src/app.controller.block-template.spec.ts
@@ -20,6 +20,7 @@ import { MetricsService } from './services/metrics.service';
 import { MiningModeService } from './services/mining-mode.service';
 import { PplnsService } from './services/pplns.service';
 import { GroupSoloService } from './services/group-solo.service';
+import { BlockpartyService } from './services/blockparty.service';
 import { PoolModeHashrateService } from './ORM/pool-mode-hashrate/pool-mode-hashrate.service';
 
 describe('AppController /api/info/block-template', () => {
@@ -48,6 +49,7 @@ describe('AppController /api/info/block-template', () => {
         { provide: MiningModeService, useValue: { getMode: jest.fn().mockResolvedValue({ mode: 'solo' }) } },
         { provide: PplnsService, useValue: { isEnabled: () => false, getPayoutDistribution: jest.fn() } },
         { provide: GroupSoloService, useValue: { isEnabled: () => false, getPayoutDistribution: jest.fn() } },
+        { provide: BlockpartyService, useValue: { getPayoutDistribution: jest.fn().mockResolvedValue({ payouts: [], poolFeeSats: 0, splits: [] }) } },
         { provide: PoolModeHashrateService, useValue: { getChart: jest.fn().mockResolvedValue([]), incrementAccepted: jest.fn() } },
       ],
     }).compile();

--- a/src/app.controller.client-block-template.spec.ts
+++ b/src/app.controller.client-block-template.spec.ts
@@ -21,6 +21,7 @@ import { MetricsService } from './services/metrics.service';
 import { MiningModeService } from './services/mining-mode.service';
 import { PplnsService } from './services/pplns.service';
 import { GroupSoloService } from './services/group-solo.service';
+import { BlockpartyService } from './services/blockparty.service';
 import { PoolModeHashrateService } from './ORM/pool-mode-hashrate/pool-mode-hashrate.service';
 
 describe('AppController /api/client/:address/block-template', () => {
@@ -98,6 +99,7 @@ describe('AppController /api/client/:address/block-template', () => {
         { provide: MiningModeService, useValue: { getMode: jest.fn().mockResolvedValue({ mode: 'solo' }) } },
         { provide: PplnsService, useValue: { isEnabled: () => false, getPayoutDistribution: jest.fn() } },
         { provide: GroupSoloService, useValue: { isEnabled: () => false, getPayoutDistribution: jest.fn() } },
+        { provide: BlockpartyService, useValue: { getPayoutDistribution: jest.fn().mockResolvedValue({ payouts: [], poolFeeSats: 0, splits: [] }) } },
         { provide: PoolModeHashrateService, useValue: { getChart: jest.fn().mockResolvedValue([]), incrementAccepted: jest.fn() } },
       ],
     }).compile();

--- a/src/app.controller.core-info.spec.ts
+++ b/src/app.controller.core-info.spec.ts
@@ -20,6 +20,7 @@ import { MetricsService } from './services/metrics.service';
 import { MiningModeService } from './services/mining-mode.service';
 import { PplnsService } from './services/pplns.service';
 import { GroupSoloService } from './services/group-solo.service';
+import { BlockpartyService } from './services/blockparty.service';
 import { PoolModeHashrateService } from './ORM/pool-mode-hashrate/pool-mode-hashrate.service';
 
 describe('AppController /api/info/core', () => {
@@ -48,6 +49,7 @@ describe('AppController /api/info/core', () => {
         { provide: MiningModeService, useValue: { getMode: jest.fn().mockResolvedValue({ mode: 'solo' }) } },
         { provide: PplnsService, useValue: { isEnabled: () => false, getPayoutDistribution: jest.fn() } },
         { provide: GroupSoloService, useValue: { isEnabled: () => false, getPayoutDistribution: jest.fn() } },
+        { provide: BlockpartyService, useValue: { getPayoutDistribution: jest.fn().mockResolvedValue({ payouts: [], poolFeeSats: 0, splits: [] }) } },
         { provide: PoolModeHashrateService, useValue: { getChart: jest.fn().mockResolvedValue([]), incrementAccepted: jest.fn() } },
       ],
     }).compile();

--- a/src/app.controller.peerinfo.spec.ts
+++ b/src/app.controller.peerinfo.spec.ts
@@ -18,6 +18,7 @@ import { MetricsService } from './services/metrics.service';
 import { MiningModeService } from './services/mining-mode.service';
 import { PplnsService } from './services/pplns.service';
 import { GroupSoloService } from './services/group-solo.service';
+import { BlockpartyService } from './services/blockparty.service';
 import { PoolModeHashrateService } from './ORM/pool-mode-hashrate/pool-mode-hashrate.service';
 import { of } from 'rxjs';
 
@@ -50,6 +51,7 @@ describe('AppController info/peers', () => {
         { provide: MiningModeService, useValue: { getMode: jest.fn().mockResolvedValue({ mode: 'solo' }) } },
         { provide: PplnsService, useValue: { isEnabled: () => false, getPayoutDistribution: jest.fn() } },
         { provide: GroupSoloService, useValue: { isEnabled: () => false, getPayoutDistribution: jest.fn() } },
+        { provide: BlockpartyService, useValue: { getPayoutDistribution: jest.fn().mockResolvedValue({ payouts: [], poolFeeSats: 0, splits: [] }) } },
         { provide: PoolModeHashrateService, useValue: { getChart: jest.fn().mockResolvedValue([]), incrementAccepted: jest.fn() } },
       ],
     }).compile();

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -25,6 +25,7 @@ import { generateFormattedTimeSlots } from './utils/timeslot.utils';
 import { MiningModeService } from './services/mining-mode.service';
 import { PplnsService } from './services/pplns.service';
 import { GroupSoloService } from './services/group-solo.service';
+import { BlockpartyService } from './services/blockparty.service';
 import { PoolModeHashrateService } from './ORM/pool-mode-hashrate/pool-mode-hashrate.service';
 import type { MiningMode } from './services/mining-mode.service';
 
@@ -92,6 +93,7 @@ export class AppController {
     private readonly miningModeService: MiningModeService,
     private readonly pplnsService: PplnsService,
     private readonly groupSoloService: GroupSoloService,
+    private readonly blockpartyService: BlockpartyService,
     private readonly poolModeHashrateService: PoolModeHashrateService,
   ) {
     const packagePath = join(__dirname, '..', 'package.json');
@@ -167,9 +169,17 @@ export class AppController {
     // would mislead the miner.
     const modeResult = await this.miningModeService.getMode(address);
     let payoutInformation;
-    let mode: 'solo' | 'pplns' | 'group-solo' = modeResult.mode;
+    let mode: 'solo' | 'pplns' | 'group-solo' | 'blockparty' = modeResult.mode;
 
-    if (modeResult.mode === 'group-solo' && modeResult.groupId && this.groupSoloService.isEnabled()) {
+    if (modeResult.mode === 'blockparty' && modeResult.groupId) {
+      const distribution = await this.blockpartyService.getPayoutDistribution(
+        modeResult.groupId,
+        tpl.blockData.coinbasevalue,
+      );
+      if (distribution.payouts.length > 0) {
+        payoutInformation = distribution.payouts.map(p => ({ address: p.address, percent: p.percent }));
+      }
+    } else if (modeResult.mode === 'group-solo' && modeResult.groupId && this.groupSoloService.isEnabled()) {
       // Pass the requesting address as finderAddress so the UI's block-template
       // preview shows THIS miner's coinbase (with their bonus output), matching
       // the per-miner template the stratum layer would actually send them.
@@ -248,7 +258,7 @@ export class AppController {
       coinbaseTxHex: job.getCoinbaseTxHex(),
       mode,
       payoutInformation,
-      ...(modeResult.mode === 'group-solo' && modeResult.groupId
+      ...((modeResult.mode === 'group-solo' || modeResult.mode === 'blockparty') && modeResult.groupId
         ? { groupId: modeResult.groupId }
         : {}),
     };
@@ -373,7 +383,7 @@ export class AppController {
     @Param('mode') mode: string,
     @Query('range') range: '1d' | '3d' | '7d' = '7d',
   ) {
-    const validModes: MiningMode[] = ['solo', 'pplns', 'group-solo'];
+    const validModes: MiningMode[] = ['solo', 'pplns', 'group-solo', 'blockparty'];
     if (!validModes.includes(mode as MiningMode)) {
       return [];
     }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -61,6 +61,7 @@ import { EmailService } from './services/email.service';
 import { AddressEmailService } from './services/address-email.service';
 import { CoinbaseCapacityMonitorService } from './services/coinbase-capacity-monitor.service';
 import { PplnsGroupInvitationService } from './services/pplns-group-invitation.service';
+import { BlockpartyService } from './services/blockparty.service';
 import { PplnsGroupJoinRequestService } from './services/pplns-group-join-request.service';
 import { MiningModeService } from './services/mining-mode.service';
 import { MinerActiveModeService } from './services/miner-active-mode.service';
@@ -73,6 +74,12 @@ import { PplnsGroupInvitationEntity } from './ORM/pplns-group/pplns-group-invita
 import { PplnsGroupJoinRequestEntity } from './ORM/pplns-group/pplns-group-join-request.entity';
 import { AddressEmailEntity } from './ORM/address-email/address-email.entity';
 import { EmailVerificationEntity } from './ORM/address-email/email-verification.entity';
+import { BlockpartyGroupEntity } from './ORM/blockparty/blockparty-group.entity';
+import { BlockpartyMemberEntity } from './ORM/blockparty/blockparty-member.entity';
+import { BlockpartyBlockHistoryEntity } from './ORM/blockparty/blockparty-block-history.entity';
+import { BlockpartyInvitationEntity } from './ORM/blockparty/blockparty-invitation.entity';
+import { BlockpartyController } from './controllers/blockparty/blockparty.controller';
+import { BlockpartyInvitationService } from './services/blockparty-invitation.service';
 import { PplnsGroupController } from './controllers/pplns-group/pplns-group.controller';
 import { PplnsInvitationController } from './controllers/pplns-invitation/pplns-invitation.controller';
 import { EmailController } from './controllers/email/email.controller';
@@ -171,6 +178,10 @@ const ORMModules = [
             PplnsGroupJoinRequestEntity,
             AddressEmailEntity,
             EmailVerificationEntity,
+            BlockpartyGroupEntity,
+            BlockpartyMemberEntity,
+            BlockpartyBlockHistoryEntity,
+            BlockpartyInvitationEntity,
         ]),
         ...ORMModules
     ],
@@ -186,6 +197,7 @@ const ORMModules = [
         PplnsGroupController,
         PplnsInvitationController,
         EmailController,
+        BlockpartyController,
     ],
     providers: [
         // TimeslotMigrationService, // Disabled - migration incomplete, leaving data in mixed state
@@ -227,6 +239,8 @@ const ORMModules = [
         PplnsGroupInvitationService,
         PplnsGroupJoinRequestService,
         CoinbaseCapacityMonitorService,
+        BlockpartyService,
+        BlockpartyInvitationService,
     ],
 })
 export class AppModule {

--- a/src/controllers/blockparty/blockparty.controller.spec.ts
+++ b/src/controllers/blockparty/blockparty.controller.spec.ts
@@ -1,0 +1,517 @@
+import { HttpException } from '@nestjs/common';
+
+import { BlockpartyController } from './blockparty.controller';
+import { BlockpartyService } from '../../services/blockparty.service';
+import { BlockpartyInvitationService } from '../../services/blockparty-invitation.service';
+
+// ── Shared mock-repo factory ────────────────────────────────────
+// Mirrors the pattern used in blockparty.service.spec.ts so the controller
+// exercises real service code paths against in-memory storage. Integration-
+// style: error mapping, response shapes, header parsing all under test.
+
+function createMockRepo<T extends { id?: any }>(target: string = 'unknown') {
+    const rows = new Map<any, T>();
+    let nextNumeric = 1;
+    let nextUuid = 1;
+
+    function matchesWhere(row: any, where: any): boolean {
+        return Object.entries(where).every(([k, v]) => {
+            if (v && typeof v === 'object' && '_type' in (v as any)) {
+                if ((v as any)._type === 'isNull') return row[k] == null;
+            }
+            return row[k] === v;
+        });
+    }
+
+    return {
+        _rows: rows,
+        target,
+        save: jest.fn(async (row: T) => {
+            // Token-keyed table (invitations): use the token as the implicit primary key.
+            const isTokenKeyed = target === 'invitation';
+            if (isTokenKeyed) {
+                rows.set((row as any).token, { ...(row as any) });
+                return { ...(row as any) };
+            }
+            if (!(row as any).id) {
+                (row as any).id = target === 'history' || target === 'member'
+                    ? nextNumeric++
+                    : 'uuid-' + (nextUuid++);
+            }
+            rows.set((row as any).id, { ...(row as any) });
+            return { ...(row as any) };
+        }),
+        create: jest.fn((partial: Partial<T>) => ({ ...partial }) as T),
+        find: jest.fn(async (query?: any) => {
+            const all = Array.from(rows.values());
+            let out = all;
+            if (query?.where) {
+                const where = Array.isArray(query.where) ? query.where : [query.where];
+                out = all.filter((row: any) => where.some((w: any) => matchesWhere(row, w)));
+            }
+            if (query?.order) {
+                const [[k, dir]] = Object.entries(query.order);
+                out = [...out].sort((a: any, b: any) => {
+                    if (a[k] === b[k]) return 0;
+                    const cmp = a[k] < b[k] ? -1 : 1;
+                    return dir === 'DESC' ? -cmp : cmp;
+                });
+            }
+            return out;
+        }),
+        findOne: jest.fn(async (query: any) => {
+            const all = Array.from(rows.values());
+            if (!query?.where) return null;
+            return all.find((row: any) => matchesWhere(row, query.where)) ?? null;
+        }),
+        findOneBy: jest.fn(async (where: any) => {
+            const all = Array.from(rows.values());
+            return all.find((row: any) => matchesWhere(row, where)) ?? null;
+        }),
+        delete: jest.fn(async (where: any) => {
+            for (const [id, row] of Array.from(rows.entries())) {
+                if (matchesWhere(row, where)) rows.delete(id);
+            }
+        }),
+        update: jest.fn(async (where: any, patch: any) => {
+            let affected = 0;
+            for (const row of Array.from(rows.values()) as any[]) {
+                if (matchesWhere(row, where)) {
+                    Object.assign(row, patch);
+                    affected++;
+                }
+            }
+            return { affected };
+        }),
+    };
+}
+
+function createMockConfig(overrides: Record<string, string | undefined> = {}) {
+    return {
+        get: jest.fn((key: string) => overrides[key]),
+    };
+}
+
+async function build() {
+    const groupRepo = createMockRepo('group');
+    const memberRepo = createMockRepo('member');
+    const historyRepo = createMockRepo('history');
+    const invitationRepo = createMockRepo('invitation');
+
+    const repoByTarget: Record<string, any> = {
+        group: groupRepo,
+        member: memberRepo,
+        history: historyRepo,
+        invitation: invitationRepo,
+    };
+    const manager = {
+        transaction: jest.fn(async (cb: (em: any) => Promise<any>) => {
+            const em = {
+                getRepository: (target: string) => repoByTarget[target] ?? createMockRepo(target),
+            };
+            return cb(em);
+        }),
+    };
+    (groupRepo as any).manager = manager;
+    (memberRepo as any).manager = manager;
+    (historyRepo as any).manager = manager;
+    (invitationRepo as any).manager = manager;
+
+    const config = createMockConfig({
+        PPLNS_FEE_ADDRESS: 'bc1qfeeaddress',
+        PPLNS_FEE_PERCENT: '2',
+        PPLNS_MIN_PAYOUT_SATS: '5000',
+    });
+
+    const groupService = { getGroupForAddress: jest.fn(() => undefined) };
+    const addressEmailService = {
+        getVerified: jest.fn(async (address: string) => ({
+            address, email: `${address}@verified.local`, verifiedAt: Date.now(),
+            createdAt: Date.now(), updatedAt: Date.now(),
+        })),
+    };
+    const blockpartyService = new BlockpartyService(
+        groupRepo as any,
+        memberRepo as any,
+        historyRepo as any,
+        config as any,
+        groupService as any,
+        addressEmailService as any,
+    );
+    await blockpartyService.onModuleInit();
+
+    const emailService = {
+        sendInvitation: jest.fn(async () => undefined),
+    };
+    const invitationConfig = createMockConfig({
+        POOL_BASE_URL: 'https://pool.example',
+    });
+    const invitationService = new BlockpartyInvitationService(
+        invitationRepo as any,
+        blockpartyService,
+        emailService as any,
+        invitationConfig as any,
+    );
+
+    const controller = new BlockpartyController(blockpartyService, invitationService);
+    return { controller, blockpartyService, invitationService, groupRepo, memberRepo, invitationRepo, groupService };
+}
+
+async function expectHttp(promise: Promise<any>, status: number, code?: string): Promise<HttpException> {
+    let err: any;
+    try {
+        await promise;
+    } catch (e) {
+        err = e;
+    }
+    expect(err).toBeInstanceOf(HttpException);
+    expect((err as HttpException).getStatus()).toBe(status);
+    if (code !== undefined) {
+        expect((err as HttpException).getResponse()).toMatchObject({ code });
+    }
+    return err as HttpException;
+}
+
+describe('BlockpartyController', () => {
+
+    // ── Create ─────────────────────────────────────────────────────
+
+    it('POST / creates a draft and returns one-shot adminToken + poolFeePercent', async () => {
+        const { controller } = await build();
+        const res = await controller.create({
+            name: 'rental', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        expect(res.adminToken).toMatch(/^BP-/);
+        expect(res.poolFeePercent).toBe(2);
+        expect(res.group.status).toBe('draft');
+        expect(res.group.adminAddress).toBe('bc1qadmin');
+    });
+
+    it('POST / returns 400 for invalid percentBp', async () => {
+        const { controller } = await build();
+        await expectHttp(controller.create({
+            name: 'rental', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 50,
+        }), 400, 'invalid-percent');
+    });
+
+    it('POST / returns 409 when admin address already runs a Blockparty', async () => {
+        const { controller } = await build();
+        await controller.create({ name: 'first', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000 });
+        await expectHttp(controller.create({
+            name: 'second', adminAddress: 'bc1qadmin', adminEmail: 'x@y.z', adminPercentBp: 5000,
+        }), 409, 'admin-address-taken');
+    });
+
+    // ── Member management ──────────────────────────────────────────
+
+    it('POST /:id/members 401s on missing admin token', async () => {
+        const { controller } = await build();
+        const { group: { id } } = (await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        })) as any;
+        await expectHttp(controller.addMember(id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, undefined), 401, 'missing-token');
+    });
+
+    it('POST /:id/members mints an invitation token and surfaces it once', async () => {
+        const { controller } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        const res = await controller.addMember(created.group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, created.adminToken);
+        expect(res.inviteToken).toBeDefined();
+        expect(res.inviteToken.length).toBeGreaterThan(20);
+        expect(res.member.confirmed).toBe(false);
+        expect(res.member.email).toMatch(/^b\*+@/); // masked
+    });
+
+    it('POST /:id/members 409s when address is in PPLNS group', async () => {
+        const { controller, groupService } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        (groupService.getGroupForAddress as jest.Mock).mockImplementation(
+            (addr: string) => addr === 'bc1qbob' ? { groupId: 'pp-1', active: true } : undefined,
+        );
+        await expectHttp(controller.addMember(created.group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, created.adminToken), 409, 'address-in-pplns-group');
+    });
+
+    // ── State machine + splits ────────────────────────────────────
+
+    it('POST /:id/transition-confirming 400s on bad splits sum and 200s when fixed', async () => {
+        const { controller } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await controller.addMember(created.group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 4000, // 5000+4000=9000, need 10000
+        }, created.adminToken);
+        await expectHttp(
+            controller.transitionToConfirming(created.group.id, created.adminToken),
+            400, 'invalid-splits-sum',
+        );
+
+        // Fix the split via PATCH
+        await controller.updateSplits(created.group.id, {
+            splits: [
+                { address: 'bc1qadmin', percentBp: 5000 },
+                { address: 'bc1qbob', percentBp: 5000 },
+            ],
+        }, created.adminToken);
+
+        const res = await controller.transitionToConfirming(created.group.id, created.adminToken);
+        expect(res.status).toBe('confirming');
+    });
+
+    // ── Invitation flow ───────────────────────────────────────────
+
+    it('full happy-path: create → addMember → invite-view → accept → READY', async () => {
+        const { controller } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        const added = await controller.addMember(created.group.id, {
+            address: 'bc1qbob', email: 'bob@example.com', percentBp: 5000,
+        }, created.adminToken);
+
+        await controller.transitionToConfirming(created.group.id, created.adminToken);
+
+        // Recipient hits the public invite endpoint — sees the full splits
+        // with bob's email un-masked (he's the recipient) and the others masked.
+        const view = await controller.getInvitation(added.inviteToken);
+        expect(view.status).toBe('pending');
+        expect(view.members).toHaveLength(2);
+        expect(view.members.find((m: any) => m.address === 'bc1qbob')?.percentBp).toBe(5000);
+
+        await controller.acceptInvitation(added.inviteToken);
+
+        const detail = await controller.getDetail(created.group.id);
+        expect(detail.status).toBe('ready');
+        expect(detail.members.find((m: any) => m.address === 'bc1qbob')?.confirmed).toBe(true);
+    });
+
+    it('POST /invite/:token/accept 404s for unknown token', async () => {
+        const { controller } = await build();
+        await expectHttp(
+            controller.acceptInvitation('does-not-exist-token'),
+            404, 'invitation-not-found',
+        );
+    });
+
+    it('POST /invite/:token/decline transitions the invitation and 409s on second call', async () => {
+        const { controller } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        const added = await controller.addMember(created.group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, created.adminToken);
+
+        await controller.declineInvitation(added.inviteToken);
+        await expectHttp(
+            controller.acceptInvitation(added.inviteToken),
+            409, 'invitation-not-pending',
+        );
+    });
+
+    it('GET /invite/:token marks expired invitations as expired in the view', async () => {
+        const { controller, invitationRepo } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        const added = await controller.addMember(created.group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, created.adminToken);
+
+        // Backdate expiresAt by mutating the in-memory row.
+        const invitation = Array.from((invitationRepo as any)._rows.values())[0] as any;
+        invitation.expiresAt = Date.now() - 1000;
+
+        const view = await controller.getInvitation(added.inviteToken);
+        expect(view.status).toBe('expired');
+    });
+
+    // ── Dissolve ──────────────────────────────────────────────────
+
+    it('POST /:id/dissolve from DRAFT succeeds without cooldown', async () => {
+        const { controller } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        const res = await controller.dissolve(created.group.id, created.adminToken);
+        expect(res).toEqual({ ok: true });
+
+        const detail = await controller.getDetail(created.group.id);
+        expect(detail.status).toBe('dissolved');
+    });
+
+    it('POST /:id/dissolve 403s when called during the 24h post-share cooldown', async () => {
+        const { controller, blockpartyService } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        const added = await controller.addMember(created.group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, created.adminToken);
+        await controller.transitionToConfirming(created.group.id, created.adminToken);
+        await controller.acceptInvitation(added.inviteToken);
+        await blockpartyService.onShareAccepted('bc1qadmin');
+
+        await expectHttp(
+            controller.dissolve(created.group.id, created.adminToken),
+            403, 'dissolve-cooldown',
+        );
+    });
+
+    // ── by-address lookup ────────────────────────────────────────
+
+    // ── Member-token + re-confirm + member-view ─────────────────────
+
+    it('POST /invite/:token/accept returns a one-shot memberToken on first accept', async () => {
+        const { controller } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        const added = await controller.addMember(created.group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, created.adminToken);
+
+        const res: any = await controller.acceptInvitation(added.inviteToken);
+        expect(res.memberToken).toBeDefined();
+        expect(res.memberToken).toMatch(/^BPM-/);
+
+        // Re-accepting the same invitation is now blocked (status='accepted'),
+        // but the token is persistent — verified via reconfirm below.
+        await expect(controller.acceptInvitation(added.inviteToken))
+            .rejects.toMatchObject({ getStatus: expect.any(Function) });
+    });
+
+    it('reconfirm uses persistent memberToken after admin %-edit resets confirmedAt', async () => {
+        const { controller, memberRepo } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        const added = await controller.addMember(created.group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, created.adminToken);
+        const acc: any = await controller.acceptInvitation(added.inviteToken);
+        const bobMemberToken = acc.memberToken;
+
+        // Admin edits splits → all confirmations reset.
+        await controller.updateSplits(created.group.id, {
+            splits: [
+                { address: 'bc1qadmin', percentBp: 5000 },
+                { address: 'bc1qbob', percentBp: 4800 },
+            ],
+        }, created.adminToken);
+
+        // Bob's confirmedAt now null.
+        let bob = Array.from((memberRepo as any)._rows.values()).find((m: any) => m.address === 'bc1qbob') as any;
+        expect(bob.confirmedAt).toBeNull();
+
+        // Bob re-confirms with his persistent token — no fresh invite cycle.
+        await controller.reconfirmMember(created.group.id, 'bc1qbob', bobMemberToken);
+        bob = Array.from((memberRepo as any)._rows.values()).find((m: any) => m.address === 'bc1qbob') as any;
+        expect(bob.confirmedAt).toBeGreaterThan(0);
+    });
+
+    it('reconfirm 401s on missing or wrong memberToken', async () => {
+        const { controller } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        const added = await controller.addMember(created.group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, created.adminToken);
+        await controller.acceptInvitation(added.inviteToken);
+
+        await expectHttp(controller.reconfirmMember(created.group.id, 'bc1qbob', undefined), 401, 'missing-member-token');
+        await expectHttp(controller.reconfirmMember(created.group.id, 'bc1qbob', 'BPM-totally-wrong-token-xx-padding-1234567890'), 401, 'invalid-member-token');
+    });
+
+    it('memberView returns un-masked email for the requesting member and masked for others', async () => {
+        const { controller } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'admin@host.tld', adminPercentBp: 5000,
+        });
+        // Email field on the body is now ignored by the service — the
+        // binding email always wins (mock returns `${address}@verified.local`).
+        const added = await controller.addMember(created.group.id, {
+            address: 'bc1qbob', percentBp: 5000,
+        }, created.adminToken);
+        const acc: any = await controller.acceptInvitation(added.inviteToken);
+
+        const view: any = await controller.memberView(created.group.id, 'bc1qbob', acc.memberToken);
+        const bobRow = view.members.find((m: any) => m.address === 'bc1qbob');
+        const adminRow = view.members.find((m: any) => m.address === 'bc1qadmin');
+        expect(bobRow.email).toBe('bc1qbob@verified.local');
+        expect(adminRow.email).not.toBe('admin@host.tld');
+        expect(adminRow.email).toMatch(/\*/);
+    });
+
+    // ── Batch invitations ────────────────────────────────────────────
+
+    it('POST /:id/members/batch processes multiple invites and surfaces per-row errors', async () => {
+        const { controller, groupService } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 4000,
+        });
+        // bc1qbad is "in a PPLNS group" — must fail with address-in-pplns-group.
+        (groupService.getGroupForAddress as jest.Mock).mockImplementation(
+            (addr: string) => addr === 'bc1qbad' ? { groupId: 'pp-1', active: true } : undefined,
+        );
+
+        const res: any = await controller.addMembersBatch(created.group.id, {
+            members: [
+                { address: 'bc1qbob', email: 'bob@b.c', percentBp: 3000 },
+                { address: 'bc1qcarol', email: 'c@d.e', percentBp: 2800 },
+                { address: 'bc1qbad', email: 'x@y.z', percentBp: 0 }, // collision
+            ],
+        }, created.adminToken);
+
+        expect(res.results).toHaveLength(3);
+        expect(res.results[0]).toMatchObject({ address: 'bc1qbob', ok: true });
+        expect(res.results[1]).toMatchObject({ address: 'bc1qcarol', ok: true });
+        expect(res.results[2]).toMatchObject({ address: 'bc1qbad', ok: false });
+        expect((res.results[2] as any).code).toBeDefined();
+    });
+
+    // ── Rental-provider hint ─────────────────────────────────────────
+
+    it('PATCH /:id/rental-hint persists trimmed value, exposed in public view', async () => {
+        const { controller } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+
+        const res: any = await controller.updateRentalHint(created.group.id, { hint: '  MRR  ' }, created.adminToken);
+        expect(res.rentalProviderHint).toBe('MRR');
+
+        const detail: any = await controller.getDetail(created.group.id);
+        expect(detail.rentalProviderHint).toBe('MRR');
+
+        // Clearing via null
+        await controller.updateRentalHint(created.group.id, { hint: null }, created.adminToken);
+        const cleared: any = await controller.getDetail(created.group.id);
+        expect(cleared.rentalProviderHint).toBeNull();
+    });
+
+    // ── by-address ───────────────────────────────────────────────────
+
+    it('GET /by-address/:address surfaces role + status for a member', async () => {
+        const { controller } = await build();
+        const created = await controller.create({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        const adminRes = await controller.getByAddress('bc1qadmin');
+        expect(adminRes).toMatchObject({ groupId: created.group.id, role: 'admin', status: 'draft' });
+
+        const nobodyRes = await controller.getByAddress('bc1qnobody');
+        expect(nobodyRes).toEqual({ groupId: null });
+    });
+});

--- a/src/controllers/blockparty/blockparty.controller.ts
+++ b/src/controllers/blockparty/blockparty.controller.ts
@@ -1,0 +1,510 @@
+import {
+    Body, Controller, Delete, Get, Headers, HttpException, HttpStatus,
+    Param, Patch, Post, Query,
+} from '@nestjs/common';
+
+import { BlockpartyService, BlockpartyServiceError } from '../../services/blockparty.service';
+import {
+    BlockpartyInvitationService,
+    InvitationServiceError,
+} from '../../services/blockparty-invitation.service';
+import { normalizeBtcAddress } from '../../utils/btc-address.utils';
+import { maskEmail } from '../../utils/email-mask.utils';
+
+interface CreateBlockpartyDto {
+    name?: string;
+    adminAddress?: string;
+    adminEmail?: string;
+    adminPercentBp?: number;
+}
+
+interface AddMemberDto {
+    address?: string;
+    email?: string;
+    percentBp?: number;
+    ttlDays?: number;
+}
+
+interface UpdateSplitsDto {
+    splits?: Array<{ address: string; percentBp: number }>;
+}
+
+interface BatchMembersDto {
+    members?: Array<{ address: string; percentBp: number; email?: string }>;
+    ttlDays?: number;
+}
+
+interface UpdateRentalHintDto {
+    hint?: string | null;
+}
+
+const ADMIN_TOKEN_HEADER = 'x-blockparty-admin-token';
+const MEMBER_TOKEN_HEADER = 'x-blockparty-member-token';
+
+@Controller('blockparty')
+export class BlockpartyController {
+
+    constructor(
+        private readonly blockpartyService: BlockpartyService,
+        private readonly invitationService: BlockpartyInvitationService,
+    ) {}
+
+    // ── Discovery ───────────────────────────────────────────────
+
+    @Get()
+    async list() {
+        const groups = await this.blockpartyService.listGroups();
+        return groups.map(g => this.publicView(g));
+    }
+
+    @Get('public')
+    async listPublic() {
+        // For v1 every non-dissolved party is publicly discoverable —
+        // there's no isPublic flag (parties are short-lived rental
+        // arrangements, not long-lived clubs). Sort by createdAt desc.
+        const all = await this.blockpartyService.listGroups();
+        return all.filter(g => g.status !== 'dissolved').map(g => this.publicView(g));
+    }
+
+    @Get('by-address/:address')
+    async getByAddress(@Param('address') address: string) {
+        const normalized = normalizeBtcAddress(address);
+        if (!normalized) {
+            throw new HttpException({ code: 'invalid-address' }, HttpStatus.BAD_REQUEST);
+        }
+        const groupId = this.blockpartyService.getGroupIdForAddress(normalized);
+        if (!groupId) {
+            return { groupId: null };
+        }
+        const group = await this.blockpartyService.getGroup(groupId);
+        if (!group) {
+            return { groupId: null };
+        }
+        // Admin role gets surfaced so the UI can pick the right route
+        // (admin dashboard vs. read-only detail).
+        const members = await this.blockpartyService.listMembers(groupId);
+        const me = members.find(m => m.address === normalized);
+        return {
+            groupId,
+            groupName: group.name,
+            status: group.status,
+            role: me?.role ?? null,
+        };
+    }
+
+    @Get(':id')
+    async getDetail(@Param('id') groupId: string) {
+        const group = await this.blockpartyService.getGroup(groupId);
+        if (!group) {
+            throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
+        }
+        const members = await this.blockpartyService.listMembers(groupId);
+        return {
+            ...this.publicView(group),
+            members: members.map(m => ({
+                address: m.address,
+                email: maskEmail(m.email),
+                percentBp: m.percentBp,
+                role: m.role,
+                confirmed: m.confirmedAt != null,
+            })),
+        };
+    }
+
+    @Get(':id/history')
+    async getHistory(@Param('id') groupId: string) {
+        const group = await this.blockpartyService.getGroup(groupId);
+        if (!group) {
+            throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
+        }
+        const rows = await this.blockpartyService.getHistory(groupId);
+        return rows.map(r => ({
+            blockHeight: r.blockHeight,
+            blockHash: r.blockHash,
+            foundAt: r.foundAt,
+            coinbaseValueSats: r.coinbaseValueSats,
+            poolFeeSats: r.poolFeeSats,
+            splits: r.splits,
+        }));
+    }
+
+    // ── Admin lifecycle ──────────────────────────────────────────
+
+    @Post()
+    async create(@Body() body: CreateBlockpartyDto) {
+        try {
+            const { group, adminToken } = await this.blockpartyService.createGroup({
+                name: body.name ?? '',
+                adminAddress: body.adminAddress ?? '',
+                adminEmail: body.adminEmail ?? '',
+                adminPercentBp: body.adminPercentBp ?? 0,
+            });
+            return {
+                group: this.publicView(group),
+                adminToken, // one-shot — admin must store this client-side
+                poolFeePercent: this.blockpartyService.getPoolFeePercent(),
+            };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Post(':id/members')
+    async addMember(
+        @Param('id') groupId: string,
+        @Body() body: AddMemberDto,
+        @Headers(ADMIN_TOKEN_HEADER) token: string | undefined,
+    ) {
+        try {
+            const member = await this.blockpartyService.addMember(groupId, {
+                address: body.address ?? '',
+                percentBp: body.percentBp ?? 0,
+                // Only pass email through if the caller explicitly supplied
+                // one — otherwise let the service resolve it from the
+                // verified binding (mirror of the Group-Solo invite flow).
+                ...(body.email ? { email: body.email } : {}),
+            }, token);
+            const { token: inviteToken } = await this.invitationService.createInvitation({
+                groupId,
+                address: member.address,
+                email: member.email,
+                ttlDays: body.ttlDays,
+            });
+            return {
+                member: {
+                    address: member.address,
+                    email: maskEmail(member.email),
+                    percentBp: member.percentBp,
+                    role: member.role,
+                    confirmed: false,
+                },
+                inviteToken, // one-shot — admin shares this with the member out-of-band
+            };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Delete(':id/members/:address')
+    async removeMember(
+        @Param('id') groupId: string,
+        @Param('address') address: string,
+        @Headers(ADMIN_TOKEN_HEADER) token: string | undefined,
+    ) {
+        try {
+            await this.blockpartyService.removeMember(groupId, address, token);
+            return { ok: true };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Patch(':id/splits')
+    async updateSplits(
+        @Param('id') groupId: string,
+        @Body() body: UpdateSplitsDto,
+        @Headers(ADMIN_TOKEN_HEADER) token: string | undefined,
+    ) {
+        try {
+            await this.blockpartyService.updateSplits(groupId, body.splits ?? [], token);
+            return { ok: true };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Post(':id/members/:address/resend-invitation')
+    async resendInvitation(
+        @Param('id') groupId: string,
+        @Param('address') address: string,
+        @Headers(ADMIN_TOKEN_HEADER) token: string | undefined,
+    ) {
+        try {
+            await this.blockpartyService.requireAdminToken(groupId, token);
+            const { resent } = await this.invitationService.resendInvitation(groupId, address);
+            return { ok: true, resent };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Post(':id/transition-confirming')
+    async transitionToConfirming(
+        @Param('id') groupId: string,
+        @Headers(ADMIN_TOKEN_HEADER) token: string | undefined,
+    ) {
+        try {
+            await this.blockpartyService.transitionToConfirming(groupId, token);
+            const group = await this.blockpartyService.getGroup(groupId);
+            return { status: group?.status };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Post(':id/dissolve')
+    async dissolve(
+        @Param('id') groupId: string,
+        @Headers(ADMIN_TOKEN_HEADER) token: string | undefined,
+    ) {
+        try {
+            await this.blockpartyService.dissolveGroup(groupId, token);
+            return { ok: true };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Get(':id/invitations')
+    async listInvitations(
+        @Param('id') groupId: string,
+        @Headers(ADMIN_TOKEN_HEADER) token: string | undefined,
+    ) {
+        try {
+            // Admin-token-gated. Don't return the raw token in the list —
+            // that would let anyone with admin access claim invites on
+            // behalf of pending members. Admin can re-issue if a token
+            // is genuinely lost.
+            await this.blockpartyService.requireAdminToken(groupId, token);
+            const invitations = await this.invitationService.listForGroup(groupId);
+            // Token IS exposed here — this endpoint is admin-token-gated, and
+            // the admin needs the raw token to call /invitations/:token for
+            // revoke. Anyone with the admin token can already mint a fresh
+            // invitation, so exposing existing pending ones is no extra risk.
+            return invitations.map(i => ({
+                token: i.token,
+                address: i.address,
+                email: maskEmail(i.email),
+                status: i.status,
+                createdAt: i.createdAt,
+                expiresAt: i.expiresAt,
+                respondedAt: i.respondedAt,
+            }));
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    // ── Invitation (recipient side) ──────────────────────────────
+
+    @Get('invite/:token')
+    async getInvitation(@Param('token') token: string) {
+        const view = await this.invitationService.getInvitationView(token);
+        if (!view) {
+            throw new HttpException({ code: 'invitation-not-found' }, HttpStatus.NOT_FOUND);
+        }
+        return view;
+    }
+
+    @Post('invite/:token/accept')
+    async acceptInvitation(@Param('token') token: string) {
+        try {
+            const { memberToken } = await this.invitationService.accept(token);
+            // memberToken is one-shot — surfaces in the response exactly
+            // here. Member must persist it (localStorage); needed for
+            // re-confirmations after admin %-edits and for member-view
+            // read access.
+            return { ok: true, memberToken };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Post(':id/members/:address/reconfirm')
+    async reconfirmMember(
+        @Param('id') groupId: string,
+        @Param('address') address: string,
+        @Headers(MEMBER_TOKEN_HEADER) memberToken: string | undefined,
+    ) {
+        try {
+            await this.blockpartyService.confirmAsMember(groupId, address, memberToken);
+            return { ok: true };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Get(':id/member-view/:address')
+    async memberView(
+        @Param('id') groupId: string,
+        @Param('address') address: string,
+        @Headers(MEMBER_TOKEN_HEADER) memberToken: string | undefined,
+    ) {
+        try {
+            // Token gates this read so members get full splits + emails
+            // visible to them, the public detail endpoint stays masked.
+            await this.blockpartyService.requireMemberToken(groupId, address, memberToken);
+            const group = await this.blockpartyService.getGroup(groupId);
+            if (!group) {
+                throw new HttpException({ code: 'not-found' }, HttpStatus.NOT_FOUND);
+            }
+            const members = await this.blockpartyService.listMembers(groupId);
+            return {
+                ...this.publicView(group),
+                rentalProviderHint: group.rentalProviderHint,
+                members: members.map(m => ({
+                    address: m.address,
+                    // Members see masked emails of OTHER members but their own un-masked
+                    // so they can verify the binding.
+                    email: m.address === address ? m.email : maskEmail(m.email),
+                    percentBp: m.percentBp,
+                    role: m.role,
+                    confirmed: m.confirmedAt != null,
+                })),
+            };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Post(':id/members/batch')
+    async addMembersBatch(
+        @Param('id') groupId: string,
+        @Body() body: BatchMembersDto,
+        @Headers(ADMIN_TOKEN_HEADER) token: string | undefined,
+    ) {
+        try {
+            const inputs = body.members ?? [];
+            if (inputs.length === 0) {
+                throw new HttpException({ code: 'no-members' }, HttpStatus.BAD_REQUEST);
+            }
+            // Process one-by-one so a single bad input returns a structured
+            // partial result rather than rolling back valid invites. Mirrors
+            // PPLNS /invitations/batch.
+            const results: Array<{ address: string; ok: true; inviteToken: string } | { address: string; ok: false; code: string; message: string }> = [];
+            for (const input of inputs) {
+                try {
+                    const member = await this.blockpartyService.addMember(groupId, {
+                        address: input.address ?? '',
+                        percentBp: input.percentBp ?? 0,
+                        ...(input.email ? { email: input.email } : {}),
+                    }, token);
+                    const { token: inviteToken } = await this.invitationService.createInvitation({
+                        groupId,
+                        address: member.address,
+                        email: member.email,
+                        ttlDays: body.ttlDays,
+                    });
+                    results.push({ address: member.address, ok: true, inviteToken });
+                } catch (e) {
+                    const code = (e as BlockpartyServiceError)?.code ?? 'unknown';
+                    const message = (e as Error)?.message ?? 'error';
+                    results.push({ address: input.address ?? '', ok: false, code, message });
+                }
+            }
+            return { results };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Patch(':id/rental-hint')
+    async updateRentalHint(
+        @Param('id') groupId: string,
+        @Body() body: UpdateRentalHintDto,
+        @Headers(ADMIN_TOKEN_HEADER) token: string | undefined,
+    ) {
+        try {
+            const group = await this.blockpartyService.updateRentalProviderHint(groupId, body.hint ?? null, token);
+            return { rentalProviderHint: group.rentalProviderHint };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Post('invite/:token/decline')
+    async declineInvitation(@Param('token') token: string) {
+        try {
+            await this.invitationService.decline(token);
+            return { ok: true };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    @Delete(':id/invitations/:token')
+    async revokeInvitation(
+        @Param('id') groupId: string,
+        @Param('token') token: string,
+        @Headers(ADMIN_TOKEN_HEADER) adminToken: string | undefined,
+    ) {
+        try {
+            await this.blockpartyService.requireAdminToken(groupId, adminToken);
+            await this.invitationService.revoke(groupId, token);
+            return { ok: true };
+        } catch (e) {
+            throw this.toHttpError(e);
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────
+
+    private publicView(group: { id: string; name: string; adminAddress: string; status: string; lastShareAt: number | null; createdAt: number; dissolvedAt: number | null; rentalProviderHint?: string | null }) {
+        return {
+            id: group.id,
+            name: group.name,
+            adminAddress: group.adminAddress,
+            status: group.status,
+            lastShareAt: group.lastShareAt,
+            createdAt: group.createdAt,
+            dissolvedAt: group.dissolvedAt,
+            rentalProviderHint: group.rentalProviderHint ?? null,
+        };
+    }
+
+    private toHttpError(e: unknown): HttpException {
+        if (e instanceof HttpException) return e;
+        if (e instanceof BlockpartyServiceError) {
+            const status = {
+                'missing-token': HttpStatus.UNAUTHORIZED,
+                'invalid-token': HttpStatus.UNAUTHORIZED,
+                'missing-member-token': HttpStatus.UNAUTHORIZED,
+                'invalid-member-token': HttpStatus.UNAUTHORIZED,
+                'member-not-confirmed': HttpStatus.FORBIDDEN,
+                'not-found': HttpStatus.NOT_FOUND,
+                'not-member': HttpStatus.NOT_FOUND,
+                'invalid-name': HttpStatus.BAD_REQUEST,
+                'invalid-address': HttpStatus.BAD_REQUEST,
+                'invalid-email': HttpStatus.BAD_REQUEST,
+                'invalid-percent': HttpStatus.BAD_REQUEST,
+                'invalid-splits-sum': HttpStatus.BAD_REQUEST,
+                'invalid-state': HttpStatus.CONFLICT,
+                'name-taken': HttpStatus.CONFLICT,
+                'admin-address-taken': HttpStatus.CONFLICT,
+                'address-in-blockparty': HttpStatus.CONFLICT,
+                'address-in-pplns-group': HttpStatus.CONFLICT,
+                'email-not-verified': HttpStatus.FAILED_DEPENDENCY,
+                'admin-cannot-rejoin': HttpStatus.CONFLICT,
+                'admin-cannot-be-removed': HttpStatus.CONFLICT,
+                'not-editable': HttpStatus.CONFLICT,
+                'no-members': HttpStatus.BAD_REQUEST,
+                'dissolve-cooldown': HttpStatus.FORBIDDEN,
+            }[e.code] ?? HttpStatus.BAD_REQUEST;
+            return new HttpException({ code: e.code, message: e.message }, status);
+        }
+        if (e instanceof InvitationServiceError) {
+            const status = {
+                'invitation-not-found': HttpStatus.NOT_FOUND,
+                'invitation-not-pending': HttpStatus.CONFLICT,
+                'invitation-pending': HttpStatus.CONFLICT,
+                'invalid-address': HttpStatus.BAD_REQUEST,
+                'not-found': HttpStatus.NOT_FOUND,
+                'not-editable': HttpStatus.CONFLICT,
+                'not-member': HttpStatus.NOT_FOUND,
+                // Operational misconfiguration (POOL_BASE_URL unset) —
+                // honest 500 so monitoring + UI surface it as a server
+                // problem, not a user input issue.
+                'config-missing': HttpStatus.INTERNAL_SERVER_ERROR,
+                // SMTP-layer failure — temporary, transient. Surfacing
+                // as 502 lets the UI distinguish "your input is fine,
+                // the email gateway is sad" from generic 500s.
+                'email-send-failed': HttpStatus.BAD_GATEWAY,
+            }[e.code] ?? HttpStatus.BAD_REQUEST;
+            return new HttpException({ code: e.code, message: e.message }, status);
+        }
+        return new HttpException(
+            { code: 'internal-error', message: (e as Error)?.message ?? 'Internal error' },
+            HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+    }
+}

--- a/src/migrations/1782000000000-AddBlockpartyTables.ts
+++ b/src/migrations/1782000000000-AddBlockpartyTables.ts
@@ -1,0 +1,153 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex, TableUnique } from 'typeorm';
+
+/**
+ * Creates the three Blockparty tables:
+ *   - blockparty_group         (party state machine + admin auth)
+ *   - blockparty_member        (per-member percentBp split + confirmation)
+ *   - blockparty_block_history (per-block payout snapshot, no balance ledger)
+ *
+ * No pending/balance table because Blockparty pays out entirely in the
+ * coinbase — sub-dust amounts roll into the pool-fee output per
+ * project decision, not into a carry-forward balance.
+ */
+export class AddBlockpartyTables1782000000000 implements MigrationInterface {
+    name = 'AddBlockpartyTables1782000000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const BIGINT_NOW_MS = `(EXTRACT(EPOCH FROM NOW()) * 1000)::bigint`;
+
+        // ── blockparty_group ────────────────────────────────────────────
+        await queryRunner.createTable(new Table({
+            name: 'blockparty_group',
+            columns: [
+                { name: 'id', type: 'uuid', isPrimary: true, default: 'gen_random_uuid()' },
+                { name: 'name', type: 'varchar', length: '64', isNullable: false },
+                { name: 'adminAddress', type: 'varchar', length: '62', isNullable: false },
+                { name: 'adminTokenHash', type: 'varchar', length: '64', isNullable: false },
+                { name: 'status', type: 'varchar', length: '16', default: `'draft'`, isNullable: false },
+                { name: 'lastShareAt', type: 'bigint', isNullable: true },
+                // Optional admin-set display hint (e.g. "MRR" / "Braiins" /
+                // "Nicehash") — surfaces on the public detail page so members
+                // know where the rental hashpower comes from. No backend
+                // semantics; pure UI metadata.
+                { name: 'rentalProviderHint', type: 'varchar', length: '64', isNullable: true },
+                { name: 'createdAt', type: 'bigint', default: BIGINT_NOW_MS, isNullable: false },
+                { name: 'updatedAt', type: 'bigint', default: BIGINT_NOW_MS, isNullable: false },
+                { name: 'dissolvedAt', type: 'bigint', isNullable: true },
+            ],
+        }), true);
+
+        await queryRunner.createIndex('blockparty_group', new TableIndex({
+            name: 'UQ_blockparty_group_name',
+            columnNames: ['name'],
+            isUnique: true,
+        }));
+
+        await queryRunner.createIndex('blockparty_group', new TableIndex({
+            name: 'UQ_blockparty_group_admin_address',
+            columnNames: ['adminAddress'],
+            isUnique: true,
+        }));
+
+        await queryRunner.createIndex('blockparty_group', new TableIndex({
+            name: 'IDX_blockparty_group_status',
+            columnNames: ['status'],
+        }));
+
+        // ── blockparty_member ───────────────────────────────────────────
+        await queryRunner.createTable(new Table({
+            name: 'blockparty_member',
+            columns: [
+                { name: 'id', type: 'bigserial', isPrimary: true },
+                { name: 'groupId', type: 'uuid', isNullable: false },
+                { name: 'address', type: 'varchar', length: '62', isNullable: false },
+                { name: 'email', type: 'varchar', length: '320', isNullable: false },
+                { name: 'percentBp', type: 'int', isNullable: false },
+                { name: 'role', type: 'varchar', length: '16', default: `'member'`, isNullable: false },
+                { name: 'confirmedAt', type: 'bigint', isNullable: true },
+                // SHA-256 of the member's persistent token, minted on first
+                // accept of an invitation. Used for re-confirmations after
+                // admin %-edits and for gated read access to the admin/detail
+                // page. Null until first accept (members never approved
+                // before the column existed would also stay null).
+                { name: 'memberTokenHash', type: 'varchar', length: '64', isNullable: true },
+                { name: 'createdAt', type: 'bigint', default: BIGINT_NOW_MS, isNullable: false },
+                { name: 'updatedAt', type: 'bigint', default: BIGINT_NOW_MS, isNullable: false },
+            ],
+            uniques: [
+                new TableUnique({
+                    name: 'UQ_blockparty_member_group_address',
+                    columnNames: ['groupId', 'address'],
+                }),
+            ],
+            foreignKeys: [
+                new TableForeignKey({
+                    name: 'FK_blockparty_member_group',
+                    columnNames: ['groupId'],
+                    referencedTableName: 'blockparty_group',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            ],
+        }), true);
+
+        // Globally unique address — an address can only be in one Blockparty.
+        await queryRunner.createIndex('blockparty_member', new TableIndex({
+            name: 'UQ_blockparty_member_address',
+            columnNames: ['address'],
+            isUnique: true,
+        }));
+
+        await queryRunner.createIndex('blockparty_member', new TableIndex({
+            name: 'IDX_blockparty_member_group',
+            columnNames: ['groupId'],
+        }));
+
+        // ── blockparty_block_history ────────────────────────────────────
+        await queryRunner.createTable(new Table({
+            name: 'blockparty_block_history',
+            columns: [
+                { name: 'id', type: 'bigserial', isPrimary: true },
+                { name: 'groupId', type: 'uuid', isNullable: false },
+                { name: 'blockHeight', type: 'int', isNullable: false },
+                { name: 'blockHash', type: 'varchar', length: '64', isNullable: false },
+                { name: 'foundAt', type: 'bigint', isNullable: false },
+                { name: 'coinbaseValueSats', type: 'bigint', isNullable: false },
+                { name: 'poolFeeSats', type: 'bigint', isNullable: false },
+                { name: 'splits', type: 'jsonb', isNullable: false },
+                { name: 'createdAt', type: 'bigint', default: BIGINT_NOW_MS, isNullable: false },
+            ],
+            foreignKeys: [
+                new TableForeignKey({
+                    name: 'FK_blockparty_block_history_group',
+                    columnNames: ['groupId'],
+                    referencedTableName: 'blockparty_group',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            ],
+        }), true);
+
+        await queryRunner.createIndex('blockparty_block_history', new TableIndex({
+            name: 'UQ_blockparty_block_history_group_hash',
+            columnNames: ['groupId', 'blockHash'],
+            isUnique: true,
+        }));
+
+        await queryRunner.createIndex('blockparty_block_history', new TableIndex({
+            name: 'IDX_blockparty_block_history_group',
+            columnNames: ['groupId'],
+        }));
+
+        await queryRunner.createIndex('blockparty_block_history', new TableIndex({
+            name: 'IDX_blockparty_block_history_height',
+            columnNames: ['blockHeight'],
+        }));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('blockparty_block_history', true);
+        await queryRunner.dropTable('blockparty_member', true);
+        await queryRunner.dropTable('blockparty_group', true);
+    }
+}

--- a/src/migrations/1782100000000-AddBlockpartyInvitations.ts
+++ b/src/migrations/1782100000000-AddBlockpartyInvitations.ts
@@ -1,0 +1,61 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Per-member directed invitation table for Blockparty groups. One row
+ * per outstanding invite — token is the primary key (bearer-token model,
+ * same as pplns_group_invitation).
+ */
+export class AddBlockpartyInvitations1782100000000 implements MigrationInterface {
+    name = 'AddBlockpartyInvitations1782100000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const BIGINT_NOW_MS = `(EXTRACT(EPOCH FROM NOW()) * 1000)::bigint`;
+
+        await queryRunner.createTable(new Table({
+            name: 'blockparty_invitation',
+            columns: [
+                { name: 'token', type: 'varchar', length: '64', isPrimary: true },
+                { name: 'groupId', type: 'uuid', isNullable: false },
+                { name: 'address', type: 'varchar', length: '62', isNullable: false },
+                { name: 'email', type: 'varchar', length: '320', isNullable: false },
+                { name: 'status', type: 'varchar', length: '16', default: `'pending'`, isNullable: false },
+                { name: 'createdAt', type: 'bigint', default: BIGINT_NOW_MS, isNullable: false },
+                { name: 'expiresAt', type: 'bigint', isNullable: false },
+                { name: 'respondedAt', type: 'bigint', isNullable: true },
+            ],
+            foreignKeys: [
+                new TableForeignKey({
+                    name: 'FK_blockparty_invitation_group',
+                    columnNames: ['groupId'],
+                    referencedTableName: 'blockparty_group',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            ],
+        }), true);
+
+        await queryRunner.createIndex('blockparty_invitation', new TableIndex({
+            name: 'IDX_blockparty_invitation_group',
+            columnNames: ['groupId'],
+        }));
+
+        await queryRunner.createIndex('blockparty_invitation', new TableIndex({
+            name: 'IDX_blockparty_invitation_address',
+            columnNames: ['address'],
+        }));
+
+        // Partial unique index: at most one pending invitation per (group, address).
+        // Re-issuing a token for the same address requires the prior row to
+        // transition out of 'pending' first (decline/accept/expire/revoke).
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "UQ_blockparty_invitation_group_address_pending"
+            ON "blockparty_invitation" ("groupId", "address")
+            WHERE "status" = 'pending'
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX IF EXISTS "UQ_blockparty_invitation_group_address_pending"`);
+        await queryRunner.dropTable('blockparty_invitation', true);
+    }
+}

--- a/src/models/StratumV1Client.ts
+++ b/src/models/StratumV1Client.ts
@@ -38,6 +38,7 @@ import { ShareTotalsCacheService } from '../services/share-totals-cache.service'
 import { AddressSettingsCacheService } from '../services/address-settings-cache.service';
 import { PplnsService } from '../services/pplns.service';
 import { GroupSoloService } from '../services/group-solo.service';
+import { BlockpartyService } from '../services/blockparty.service';
 import { MinerActiveModeService } from '../services/miner-active-mode.service';
 import { PoolModeHashrateService } from '../ORM/pool-mode-hashrate/pool-mode-hashrate.service';
 import { PayoutMode } from './interfaces/unified-stratum.interfaces';
@@ -169,6 +170,7 @@ export class StratumV1Client {
         private readonly payoutMode: PayoutMode = 'solo',
         private readonly pplnsService?: PplnsService,
         private readonly groupSoloService?: GroupSoloService,
+        private readonly blockpartyService?: BlockpartyService,
         private readonly minerActiveModeService?: MinerActiveModeService,
         private readonly poolModeHashrateService?: PoolModeHashrateService,
         /** VarDiff floor passed through from StratumPortConfig. */
@@ -778,6 +780,18 @@ export class StratumV1Client {
     }
 
     /**
+     * Live lookup of the Blockparty group-id for this session's address,
+     * but only when the party is routable (status confirming / ready /
+     * active). Mirrors `activeGroupId()` for the Group-Solo path.
+     */
+    private activeBlockpartyGroupId(): string | null {
+        if (!this.blockpartyService) return null;
+        const address = this.clientAuthorization?.address;
+        if (!address) return null;
+        return this.blockpartyService.getRoutableGroupIdForAdmin(address) ?? null;
+    }
+
+    /**
      * Dispatch a rejected share to group-solo if the miner is currently in an
      * active group AND not connected on the PPLNS port. A miner who deliberately
      * chose the PPLNS port has opted out of group bookkeeping for this session,
@@ -816,6 +830,7 @@ export class StratumV1Client {
         // Reverse order (group first) kept pre-PR for the Solo port, where
         // address-driven group-solo is the whole point of that feature.
         const jobGroupId = this.activeGroupId();
+        const jobBlockpartyId = this.activeBlockpartyGroupId();
         if (this.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
             // PPLNS: Shared coinbase with proportional payouts
             // Network difficulty is synced centrally via PplnsService's job subscription
@@ -832,6 +847,25 @@ export class StratumV1Client {
                 );
                 return;
             }
+        } else if (jobBlockpartyId) {
+            // Blockparty: rental-driven multi-output coinbase, splits are
+            // fixed per-member basis points. Distribution is purely a
+            // function of current membership — no share snapshot required.
+            // Sub-min-payout members fold into the pool-fee output (no
+            // pending ledger, no carry-forward).
+            const distribution = await this.blockpartyService!.getPayoutDistribution(
+                jobBlockpartyId,
+                jobTemplate.blockData.coinbasevalue,
+            );
+            this.noFee = false;
+            if (distribution.payouts.length === 0) {
+                console.warn(
+                    `[StratumV1Client] Blockparty distribution empty — skipping job for ` +
+                    `${this.clientAuthorization?.address ?? '<unauth>'}`,
+                );
+                return;
+            }
+            payoutInformation = distribution.payouts.map(p => ({ address: p.address, percent: p.percent }));
         } else if (jobGroupId) {
             // Group-solo on non-PPLNS port: per-miner coinbase, PROP-style
             // split + finder-bonus output to THIS connection's address.
@@ -1214,11 +1248,19 @@ export class StratumV1Client {
                     // Route block-found bookkeeping the same way the coinbase
                     // was built — PPLNS port overrides group membership.
                     const foundGroupId = this.activeGroupId();
+                    const foundBlockpartyId = this.activeBlockpartyGroupId();
                     if (this.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
                         await this.pplnsService.onBlockFound(
                             jobTemplate.blockData.height,
                             jobTemplate.blockData.coinbasevalue,
                         );
+                    } else if (foundBlockpartyId) {
+                        await this.blockpartyService!.onBlockFound({
+                            groupId: foundBlockpartyId,
+                            blockHeight: jobTemplate.blockData.height,
+                            blockHash: updatedJobBlock.getId(),
+                            coinbaseValueSats: jobTemplate.blockData.coinbasevalue,
+                        });
                     } else if (foundGroupId) {
                         await this.groupSoloService!.onBlockFound(
                             jobTemplate.blockData.height,
@@ -1253,7 +1295,8 @@ export class StratumV1Client {
                 // every share (no min-diff / warmup configured there).
                 this.acceptedShareCount++;
                 const shareGroupId = this.activeGroupId();
-                let effectiveMode: 'solo' | 'pplns' | 'group-solo';
+                const shareBlockpartyId = this.activeBlockpartyGroupId();
+                let effectiveMode: 'solo' | 'pplns' | 'group-solo' | 'blockparty';
                 if (this.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
                     const warmupCleared = this.acceptedShareCount > this.ledgerWarmupShares;
                     if (warmupCleared) {
@@ -1263,6 +1306,14 @@ export class StratumV1Client {
                         );
                     }
                     effectiveMode = 'pplns';
+                } else if (shareBlockpartyId) {
+                    // No per-share ledger write (Blockparty has no share-
+                    // counting — splits are fixed per percentBp). Still
+                    // notify the service so it can refresh lastShareAt
+                    // and transition READY → ACTIVE on the very first
+                    // share, permanently freezing the splits.
+                    await this.blockpartyService!.onShareAccepted(this.clientAuthorization.address);
+                    effectiveMode = 'blockparty';
                 } else if (shareGroupId) {
                     await this.groupSoloService!.recordShare(
                         this.clientAuthorization.address,

--- a/src/models/StratumV2Client.ts
+++ b/src/models/StratumV2Client.ts
@@ -26,6 +26,7 @@ import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-stat
 import { ShareTotalsCacheService } from '../services/share-totals-cache.service';
 import { PplnsService } from '../services/pplns.service';
 import { GroupSoloService } from '../services/group-solo.service';
+import { BlockpartyService } from '../services/blockparty.service';
 import { MinerActiveModeService } from '../services/miner-active-mode.service';
 import { patchCoinbasePrefixVarint } from '../utils/coinbase-prefix.utils';
 import { PoolModeHashrateService } from '../ORM/pool-mode-hashrate/pool-mode-hashrate.service';
@@ -241,6 +242,7 @@ export class StratumV2Client {
     private readonly templateDistributionService?: TemplateDistributionService,
     private readonly pplnsService?: PplnsService,
     private readonly groupSoloService?: GroupSoloService,
+    private readonly blockpartyService?: BlockpartyService,
     private readonly minerActiveModeService?: MinerActiveModeService,
     private readonly poolModeHashrateService?: PoolModeHashrateService,
   ) {
@@ -1673,11 +1675,19 @@ export class StratumV2Client {
         // Mirror of StratumV1Client — bewusster Port-Wahl des Miners schlägt
         // die Default-Address-Driven-Group-Routing.
         const foundGroupId = this.activeGroupId();
+        const foundBlockpartyId = this.activeBlockpartyGroupId();
         if (this.portConfig.payoutMode === 'pplns' && this.pplnsService?.isEnabled() && jobTemplate) {
           await this.pplnsService.onBlockFound(
             jobTemplate.blockData.height,
             jobTemplate.blockData.coinbasevalue,
           );
+        } else if (foundBlockpartyId && jobTemplate) {
+          await this.blockpartyService!.onBlockFound({
+            groupId: foundBlockpartyId,
+            blockHeight: jobTemplate.blockData.height,
+            blockHash: updatedJobBlock.getId(),
+            coinbaseValueSats: jobTemplate.blockData.coinbasevalue,
+          });
         } else if (foundGroupId && jobTemplate) {
           await this.groupSoloService!.onBlockFound(
             jobTemplate.blockData.height,
@@ -1702,13 +1712,20 @@ export class StratumV2Client {
       // applies to the PPLNS port; group-solo / solo always record.
       this.acceptedShareCount++;
       const shareGroupId = this.activeGroupId();
+      const shareBlockpartyId = this.activeBlockpartyGroupId();
       const warmupThreshold = this.portConfig.ledgerWarmupShares ?? 0;
-      let effectiveMode: 'solo' | 'pplns' | 'group-solo';
+      let effectiveMode: 'solo' | 'pplns' | 'group-solo' | 'blockparty';
       if (this.portConfig.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
         if (this.acceptedShareCount > warmupThreshold) {
           await this.pplnsService.recordShare(this.address!, jobDifficulty);
         }
         effectiveMode = 'pplns';
+      } else if (shareBlockpartyId) {
+        // Notify the service so it can refresh lastShareAt and transition
+        // READY → ACTIVE on the very first share, permanently freezing splits.
+        // No ledger write — Blockparty doesn't count shares.
+        await this.blockpartyService!.onShareAccepted(this.address!);
+        effectiveMode = 'blockparty';
       } else if (shareGroupId) {
         await this.groupSoloService!.recordShare(this.address!, jobDifficulty);
         effectiveMode = 'group-solo';
@@ -1850,10 +1867,18 @@ export class StratumV2Client {
     // group) gets the block accepted on-chain but no payout
     // snapshot is taken — the round / window is never reset and
     // no one is credited. Mirror of the extended-channel routing
-    // (PPLNS port > group-membership > solo).
+    // (PPLNS port > blockparty > group-solo > solo).
     const foundGroupId = this.activeGroupId();
+    const foundBlockpartyId = this.activeBlockpartyGroupId();
     if (this.portConfig.payoutMode === 'pplns' && this.pplnsService?.isEnabled()) {
       await this.pplnsService.onBlockFound(height, coinbasevalue);
+    } else if (foundBlockpartyId) {
+      await this.blockpartyService!.onBlockFound({
+        groupId: foundBlockpartyId,
+        blockHeight: height,
+        blockHash: bitcoinjs.Block.fromHex(blockHex).getId(),
+        coinbaseValueSats: coinbasevalue,
+      });
     } else if (foundGroupId) {
       await this.groupSoloService!.onBlockFound(height, coinbasevalue, this.address!);
     }
@@ -2023,6 +2048,23 @@ export class StratumV2Client {
       );
       return null;
     }
+    const asyncBlockpartyId = this.activeBlockpartyGroupId();
+    if (asyncBlockpartyId) {
+      // Blockparty: fixed-% multi-output coinbase, no shares involved.
+      // Distribution is purely a function of member percentBp values.
+      const distribution = await this.blockpartyService!.getPayoutDistribution(
+        asyncBlockpartyId,
+        blockRewardSats,
+      );
+      if (distribution.payouts.length > 0) {
+        this.noFee = false;
+        return distribution.payouts.map(p => ({ address: p.address, percent: p.percent }));
+      }
+      console.warn(
+        `[StratumV2Client] Blockparty distribution empty — skipping job for ${this.address ?? '<unauth>'}`,
+      );
+      return null;
+    }
     const asyncGroupId = this.activeGroupId();
     if (asyncGroupId) {
       // Per-miner coinbase: pass this session's address as finderAddress
@@ -2064,6 +2106,17 @@ export class StratumV2Client {
     if (!this.address) return null;
     const entry = this.groupSoloService.getGroupForAddress(this.address);
     return entry?.active ? entry.groupId : null;
+  }
+
+  /**
+   * Live lookup of the Blockparty group-id for this session's address,
+   * routable only when status is confirming / ready / active. Mirrors
+   * StratumV1Client.activeBlockpartyGroupId.
+   */
+  private activeBlockpartyGroupId(): string | null {
+    if (!this.blockpartyService) return null;
+    if (!this.address) return null;
+    return this.blockpartyService.getRoutableGroupIdForAdmin(this.address) ?? null;
   }
 
   private async sendNewMiningJob(jobTemplate: IJobTemplate, sendPrevHash: boolean, channelId?: number): Promise<void> {

--- a/src/models/payout-routing-priority.spec.ts
+++ b/src/models/payout-routing-priority.spec.ts
@@ -75,6 +75,7 @@ function makeMiningModeAwareSv1(opts: {
         opts.payoutMode,
         undefined,                // pplnsService — not needed for reject path
         groupSoloService as any,
+        undefined,                // blockpartyService — reject path doesn't touch it
         undefined,                // minerActiveModeService — reject path doesn't mark mode
     );
 

--- a/src/services/blockparty-distribution.spec.ts
+++ b/src/services/blockparty-distribution.spec.ts
@@ -1,0 +1,152 @@
+import { buildBlockpartyDistribution } from './blockparty-distribution';
+import { DUST_LIMIT_SATS } from './coinbase-distribution';
+
+const FEE_ADDR = 'bc1qfeeaddress';
+const A = 'bc1qaaaaa';
+const B = 'bc1qbbbbb';
+const C = 'bc1qccccc';
+
+describe('buildBlockpartyDistribution', () => {
+
+    it('returns empty when reward is 0', () => {
+        const r = buildBlockpartyDistribution({
+            members: [{ address: A, percentBp: 10000 }],
+            blockRewardSats: 0,
+            poolFeeAddress: FEE_ADDR,
+            poolFeePercent: 2,
+            minPayoutSats: 5_000,
+        });
+        expect(r.splits).toEqual([]);
+        expect(r.poolFeeSats).toBe(0);
+        expect(r.payouts).toEqual([]);
+    });
+
+    it('routes the entire reward to pool-fee when there are no members', () => {
+        const reward = 312_500_000;
+        const r = buildBlockpartyDistribution({
+            members: [],
+            blockRewardSats: reward,
+            poolFeeAddress: FEE_ADDR,
+            poolFeePercent: 2,
+            minPayoutSats: 5_000,
+        });
+        expect(r.poolFeeSats).toBe(reward);
+        expect(r.payouts).toHaveLength(1);
+        expect(r.payouts[0]).toMatchObject({ address: FEE_ADDR, sats: reward });
+    });
+
+    it('splits miner cut by basis points and balances against pool fee', () => {
+        const reward = 312_500_000; // 3.125 BTC
+        const r = buildBlockpartyDistribution({
+            members: [
+                { address: A, percentBp: 5000 }, // 50% of miner cut
+                { address: B, percentBp: 3000 }, // 30%
+                { address: C, percentBp: 2000 }, // 20%
+            ],
+            blockRewardSats: reward,
+            poolFeeAddress: FEE_ADDR,
+            poolFeePercent: 2,
+            minPayoutSats: 5_000,
+        });
+
+        const basePoolFee = Math.floor(reward * 0.02);
+        const minerCut = reward - basePoolFee;
+        const expectA = Math.floor(minerCut * 0.5);
+        const expectB = Math.floor(minerCut * 0.3);
+        const expectC = Math.floor(minerCut * 0.2);
+
+        expect(r.splits.map(s => ({ address: s.address, sats: s.sats, trimmed: s.trimmed }))).toEqual([
+            { address: A, sats: expectA, trimmed: false },
+            { address: B, sats: expectB, trimmed: false },
+            { address: C, sats: expectC, trimmed: false },
+        ]);
+
+        // Outputs must sum to exactly reward — rounding leftover goes to pool fee.
+        const totalOut = r.payouts.reduce((acc, p) => acc + p.sats, 0);
+        expect(totalOut).toBe(reward);
+        expect(r.poolFeeSats).toBe(reward - (expectA + expectB + expectC));
+    });
+
+    it('rolls sub-min-payout members into the pool fee with trimmed=true', () => {
+        // 0.01% of 312.5M sats minerCut = 30625 sats — above min — pick a smaller reward.
+        // 1% of 100000 (after 2% fee = 98000 minerCut) = 980 sats < 5000.
+        const reward = 100_000;
+        const r = buildBlockpartyDistribution({
+            members: [
+                { address: A, percentBp: 9900 }, // 99% — well above min
+                { address: B, percentBp: 100 },  // 1% → 980 sats < 5000 → trimmed
+            ],
+            blockRewardSats: reward,
+            poolFeeAddress: FEE_ADDR,
+            poolFeePercent: 2,
+            minPayoutSats: 5_000,
+        });
+
+        expect(r.splits[1]).toMatchObject({ address: B, sats: 0, trimmed: true });
+        expect(r.splits[0].trimmed).toBe(false);
+        // B's 980 sats roll into pool fee — pool fee > base fee of 2000.
+        expect(r.poolFeeSats).toBeGreaterThan(Math.floor(reward * 0.02));
+        // Conservation: outputs sum to exactly reward.
+        const totalOut = r.payouts.reduce((acc, p) => acc + p.sats, 0);
+        expect(totalOut).toBe(reward);
+    });
+
+    it('uses DUST_LIMIT_SATS as the effective floor even when minPayoutSats is lower', () => {
+        // minPayoutSats=100 but DUST_LIMIT_SATS=546. A 500-sat member output
+        // must still be trimmed because Bitcoin core relay-policy would
+        // reject it as dust.
+        // 1% of 50000 minerCut after 2% fee (49000) = 490 sats < 546.
+        const reward = 50_000;
+        const r = buildBlockpartyDistribution({
+            members: [
+                { address: A, percentBp: 9900 },
+                { address: B, percentBp: 100 },
+            ],
+            blockRewardSats: reward,
+            poolFeeAddress: FEE_ADDR,
+            poolFeePercent: 2,
+            minPayoutSats: 100, // intentionally below DUST_LIMIT_SATS
+        });
+        expect(r.splits[1].trimmed).toBe(true);
+        expect(DUST_LIMIT_SATS).toBe(546); // documentation: link this expectation to the constant
+    });
+
+    it('skips the pool-fee output when poolFeeAddress is empty', () => {
+        const reward = 312_500_000;
+        const r = buildBlockpartyDistribution({
+            members: [{ address: A, percentBp: 10000 }],
+            blockRewardSats: reward,
+            poolFeeAddress: '',
+            poolFeePercent: 2,
+            minPayoutSats: 5_000,
+        });
+        // Pool-fee sats are still computed and conserved, but no output is
+        // emitted to an empty address (caller decides how to handle).
+        expect(r.payouts.find(p => p.address === '')).toBeUndefined();
+        expect(r.payouts.map(p => p.address)).toEqual([A]);
+    });
+
+    it('conserves total sats: every output sums to reward', () => {
+        const cases = [
+            { reward: 312_500_000, feePct: 2 },
+            { reward: 156_250_000, feePct: 1.5 },
+            { reward: 78_125_000, feePct: 0 },
+            { reward: 1_000_000_000, feePct: 5 },
+        ];
+        for (const { reward, feePct } of cases) {
+            const r = buildBlockpartyDistribution({
+                members: [
+                    { address: A, percentBp: 3333 },
+                    { address: B, percentBp: 3333 },
+                    { address: C, percentBp: 3334 },
+                ],
+                blockRewardSats: reward,
+                poolFeeAddress: FEE_ADDR,
+                poolFeePercent: feePct,
+                minPayoutSats: 5_000,
+            });
+            const totalOut = r.payouts.reduce((acc, p) => acc + p.sats, 0);
+            expect(totalOut).toBe(reward);
+        }
+    });
+});

--- a/src/services/blockparty-distribution.ts
+++ b/src/services/blockparty-distribution.ts
@@ -1,0 +1,108 @@
+import { CoinbaseDistributionEntry, DUST_LIMIT_SATS } from './coinbase-distribution';
+
+export interface BlockpartyMemberInput {
+    address: string;
+    /** Basis points: 100 = 1%, 10000 = 100%. */
+    percentBp: number;
+}
+
+export interface BlockpartyDistributionInput {
+    members: BlockpartyMemberInput[];
+    blockRewardSats: number;
+    poolFeeAddress: string;
+    /** Decimal percent (e.g. 2 for 2%). */
+    poolFeePercent: number;
+    /** Sub-threshold per-member outputs roll into the pool-fee output. */
+    minPayoutSats: number;
+}
+
+export interface BlockpartyDistributionSplit {
+    address: string;
+    percentBp: number;
+    sats: number;
+    /**
+     * True when this member's nominal share fell below `minPayoutSats`
+     * and was rolled into the pool-fee output instead. `sats` is then 0.
+     */
+    trimmed: boolean;
+}
+
+export interface BlockpartyDistributionResult {
+    /** Per-member breakdown — one entry per input member, same order. */
+    splits: BlockpartyDistributionSplit[];
+    /** Final pool-fee output sats (base fee + rounding remainder + trimmed amounts). */
+    poolFeeSats: number;
+    /** Ready for coinbase output construction — pool fee first, then members. */
+    payouts: CoinbaseDistributionEntry[];
+}
+
+/**
+ * Pure-function payout split for Blockparty groups.
+ *
+ * Construction (no shares, no balance ledger):
+ *   1. basePoolFee  = floor(reward * poolFeePercent / 100)
+ *   2. minerCut     = reward - basePoolFee
+ *   3. per member   = floor(minerCut * percentBp / 10000)
+ *   4. sub-threshold members (memberSats < minPayoutSats) → 0 sats, trimmed flag,
+ *      their nominal sats roll into the pool-fee output (project decision: no
+ *      carry-forward, no dust pending — sub-dust enriches the pool address).
+ *   5. rounding leftover (reward − sum of paid outputs) → also folded into
+ *      the pool-fee output so total outputs == reward exactly.
+ *
+ * Inputs are trusted: percentBp sum is enforced at the service layer
+ * (must equal 10000 = 100% of miner cut). This function tolerates a
+ * mis-summed input by under/overpaying — the service must validate
+ * before calling.
+ */
+export function buildBlockpartyDistribution(input: BlockpartyDistributionInput): BlockpartyDistributionResult {
+    const { members, blockRewardSats, poolFeeAddress, poolFeePercent, minPayoutSats } = input;
+
+    if (blockRewardSats <= 0) {
+        return { splits: [], poolFeeSats: 0, payouts: [] };
+    }
+    if (members.length === 0) {
+        const poolFee = blockRewardSats;
+        return {
+            splits: [],
+            poolFeeSats: poolFee,
+            payouts: poolFeeAddress
+                ? [{ address: poolFeeAddress, percent: 100, sats: poolFee }]
+                : [],
+        };
+    }
+
+    const dustThreshold = Math.max(minPayoutSats, DUST_LIMIT_SATS);
+    const basePoolFeeSats = Math.floor((blockRewardSats * poolFeePercent) / 100);
+    const minerCutSats = blockRewardSats - basePoolFeeSats;
+
+    const splits: BlockpartyDistributionSplit[] = members.map(m => {
+        const nominal = Math.floor((minerCutSats * m.percentBp) / 10000);
+        if (nominal < dustThreshold) {
+            return { address: m.address, percentBp: m.percentBp, sats: 0, trimmed: true };
+        }
+        return { address: m.address, percentBp: m.percentBp, sats: nominal, trimmed: false };
+    });
+
+    const paidToMembers = splits.reduce((acc, s) => acc + s.sats, 0);
+    const poolFeeSats = blockRewardSats - paidToMembers;
+
+    const payouts: CoinbaseDistributionEntry[] = [];
+    if (poolFeeAddress && poolFeeSats > 0) {
+        payouts.push({
+            address: poolFeeAddress,
+            percent: (poolFeeSats / blockRewardSats) * 100,
+            sats: poolFeeSats,
+        });
+    }
+    for (const s of splits) {
+        if (s.sats > 0) {
+            payouts.push({
+                address: s.address,
+                percent: (s.sats / blockRewardSats) * 100,
+                sats: s.sats,
+            });
+        }
+    }
+
+    return { splits, poolFeeSats, payouts };
+}

--- a/src/services/blockparty-invitation.service.ts
+++ b/src/services/blockparty-invitation.service.ts
@@ -1,0 +1,363 @@
+import { Inject, Injectable, forwardRef, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as crypto from 'crypto';
+
+import {
+    BlockpartyInvitationEntity,
+    BlockpartyInvitationStatus,
+} from '../ORM/blockparty/blockparty-invitation.entity';
+import { BlockpartyService, BlockpartyServiceError } from './blockparty.service';
+import { EmailService } from './email.service';
+import { normalizeBtcAddress } from '../utils/btc-address.utils';
+
+const TOKEN_BYTES = 32; // → 43-char base64url
+const DEFAULT_TTL_DAYS = 7;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export class InvitationServiceError extends Error {
+    constructor(public readonly code: string, message: string) {
+        super(message);
+    }
+}
+
+export interface InvitationCreateInput {
+    groupId: string;
+    address: string;
+    email: string;
+    ttlDays?: number;
+}
+
+/**
+ * Read-only invitation view. Includes the FULL splits snapshot of the
+ * party (transparent confirmation) so the recipient sees not only their
+ * own percentage but also what every other member is getting — defends
+ * against an admin telling members "you get 30%" while entering 5%.
+ */
+export interface InvitationView {
+    token: string;
+    groupId: string;
+    groupName: string;
+    address: string;
+    email: string;
+    status: BlockpartyInvitationStatus;
+    expiresAt: number;
+    members: Array<{ address: string; percentBp: number; role: 'admin' | 'member'; confirmed: boolean }>;
+    /** Pool fee percent at invitation time — caller can render "100% breakdown" deterministically. */
+    poolFeePercent: number;
+}
+
+@Injectable()
+export class BlockpartyInvitationService {
+
+    private readonly logger = new Logger(BlockpartyInvitationService.name);
+
+    constructor(
+        @InjectRepository(BlockpartyInvitationEntity)
+        private readonly invitationRepo: Repository<BlockpartyInvitationEntity>,
+        @Inject(forwardRef(() => BlockpartyService))
+        private readonly blockpartyService: BlockpartyService,
+        private readonly emailService: EmailService,
+        private readonly config: ConfigService,
+    ) {}
+
+    private generateToken(): string {
+        return crypto.randomBytes(TOKEN_BYTES).toString('base64url');
+    }
+
+    /**
+     * Mint a directed invitation for the prospective member. Called from
+     * the controller after BlockpartyService.addMember has persisted the
+     * (unconfirmed) member row. Returns the plain token — surface this
+     * to the admin exactly once.
+     */
+    async createInvitation(input: InvitationCreateInput): Promise<{ invitation: BlockpartyInvitationEntity; token: string }> {
+        const normalizedAddress = normalizeBtcAddress(input.address);
+        if (!normalizedAddress) {
+            throw new InvitationServiceError('invalid-address', 'Address required');
+        }
+        const ttlDays = Math.max(1, Math.min(30, input.ttlDays ?? DEFAULT_TTL_DAYS));
+
+        const token = this.generateToken();
+        const now = Date.now();
+        const normalizedEmail = input.email.trim().toLowerCase();
+        // Keep at most one invitation row per (groupId, address) — the
+        // invitation is a per-pair artifact, not a per-attempt log.
+        // Each resend reuses the existing row (flipping status back to
+        // pending with a fresh token + expiry) instead of minting new
+        // rows that pile up in the admin's pending list. Lost-token
+        // recovery is handled by the caller (resendInvitation / admin
+        // batch) which additionally clears the member's onboarding
+        // state so the next accept re-mints a BPM-... token.
+        let invitation = await this.invitationRepo.findOne({
+            where: { groupId: input.groupId, address: normalizedAddress },
+        });
+        if (invitation) {
+            // Active pending row that hasn't expired yet: refuse the
+            // re-mint to surface the duplicate-invite path correctly.
+            // resendInvitation Case 1 handles same-token resend without
+            // touching createInvitation, so this only fires when the
+            // admin tries to fresh-invite an address that's already in
+            // flight.
+            if (invitation.status === 'pending' && invitation.expiresAt > now) {
+                throw new InvitationServiceError(
+                    'invitation-pending',
+                    'A pending invitation for this address already exists — revoke or wait for the response first',
+                );
+            }
+            invitation.token = token;
+            invitation.email = normalizedEmail;
+            invitation.status = 'pending';
+            invitation.expiresAt = now + ttlDays * MS_PER_DAY;
+            invitation.respondedAt = null;
+            await this.invitationRepo.save(invitation);
+        } else {
+            invitation = await this.invitationRepo.save(this.invitationRepo.create({
+                token,
+                groupId: input.groupId,
+                address: normalizedAddress,
+                email: normalizedEmail,
+                status: 'pending',
+                expiresAt: now + ttlDays * MS_PER_DAY,
+                respondedAt: null,
+            }));
+        }
+
+        // Send the invitation email — the link delivery mirror of
+        // pplns-group-invitation. Group context is fetched fresh so the
+        // email shows the current party name + inviter (admin) address.
+        // Errors propagate so the admin's UI flow surfaces SMTP issues
+        // immediately; the invitation row persists either way, so
+        // re-trying just resends from the existing row (admin can
+        // revoke + re-invite if needed).
+        const group = await this.blockpartyService.getGroup(input.groupId);
+        if (group) {
+            const baseUrl = this.poolBaseUrl();
+            try {
+                await this.emailService.sendInvitation({
+                    to: normalizedEmail,
+                    address: normalizedAddress,
+                    groupName: group.name,
+                    inviterAddress: group.adminAddress,
+                    // UI uses HashLocationStrategy — path goes in the
+                    // fragment. /blockparty/invite/:token is the public
+                    // landing page (BlockpartyInviteComponent).
+                    inviteUrl: `${baseUrl}/#/blockparty/invite/${token}`,
+                    expiresAt: new Date(invitation.expiresAt),
+                });
+            } catch (err) {
+                throw new InvitationServiceError(
+                    'email-send-failed',
+                    (err as Error)?.message ?? 'Email send failed',
+                );
+            }
+        }
+
+        return { invitation, token };
+    }
+
+    private poolBaseUrl(): string {
+        const url = this.config.get<string>('POOL_BASE_URL');
+        if (!url) {
+            throw new InvitationServiceError('config-missing', 'POOL_BASE_URL is not set');
+        }
+        return url.replace(/\/+$/, '');
+    }
+
+    async getByToken(token: string): Promise<BlockpartyInvitationEntity | null> {
+        return this.invitationRepo.findOneBy({ token });
+    }
+
+    /** All invitations issued by a party. Used by the admin dashboard. */
+    async listForGroup(groupId: string): Promise<BlockpartyInvitationEntity[]> {
+        return this.invitationRepo.find({ where: { groupId }, order: { createdAt: 'DESC' } });
+    }
+
+    /**
+     * Build the redacted view served at /api/blockparty/invite/:token.
+     * Includes the full splits so the prospective member can verify the
+     * deal they're being invited into before clicking accept.
+     */
+    async getInvitationView(token: string): Promise<InvitationView | null> {
+        const invitation = await this.invitationRepo.findOneBy({ token });
+        if (!invitation) return null;
+
+        const group = await this.blockpartyService.getGroup(invitation.groupId);
+        if (!group) return null;
+
+        const members = await this.blockpartyService.listMembers(invitation.groupId);
+        const poolFeePercent = this.blockpartyService.getPoolFeePercent();
+        return {
+            token: invitation.token,
+            groupId: invitation.groupId,
+            groupName: group.name,
+            address: invitation.address,
+            email: invitation.email,
+            status: this.computeEffectiveStatus(invitation),
+            expiresAt: invitation.expiresAt,
+            members: members.map(m => ({
+                address: m.address,
+                percentBp: m.percentBp,
+                role: m.role,
+                confirmed: m.confirmedAt != null,
+            })),
+            poolFeePercent,
+        };
+    }
+
+    /**
+     * Returns the persistent member token minted on first accept. Surface
+     * to the recipient exactly once — they need it for re-confirmations
+     * (when admin edits splits) and for gated read access on the member
+     * dashboard. Null on idempotent re-accept (token already minted).
+     */
+    async accept(token: string): Promise<{ memberToken: string | null }> {
+        const invitation = await this.requirePending(token);
+
+        // Mark the member confirmed first — if that fails (e.g. party
+        // already ACTIVE or DISSOLVED), the invitation stays 'pending'
+        // and the admin can intervene. If markMemberConfirmed succeeds
+        // but the invitation update below fails, the member is confirmed
+        // anyway, which is the safer side to err on (idempotent retry
+        // will flip the invitation eventually).
+        let memberToken: string | null = null;
+        try {
+            const result = await this.blockpartyService.markMemberConfirmed(invitation.groupId, invitation.address);
+            memberToken = result.memberToken;
+        } catch (err) {
+            if (err instanceof BlockpartyServiceError) {
+                throw new InvitationServiceError(err.code, err.message);
+            }
+            throw err;
+        }
+
+        invitation.status = 'accepted';
+        invitation.respondedAt = Date.now();
+        await this.invitationRepo.save(invitation);
+        return { memberToken };
+    }
+
+    async decline(token: string): Promise<void> {
+        const invitation = await this.requirePending(token);
+        invitation.status = 'declined';
+        invitation.respondedAt = Date.now();
+        await this.invitationRepo.save(invitation);
+    }
+
+    /**
+     * Re-deliver the invitation email for a given (groupId, address).
+     *
+     * Three cases:
+     *   1. A still-pending non-expired invite exists → re-send the same
+     *      token via email (no new row). Recipient can use the URL from
+     *      either email.
+     *   2. A pending-but-expired invite exists → mark it expired, mint a
+     *      fresh token, send email.
+     *   3. No pending invite (e.g. member was declined or revoked) →
+     *      mint a fresh one.
+     *
+     * Admin-token gating happens at the controller layer.
+     */
+    async resendInvitation(
+        groupId: string,
+        address: string,
+        ttlDays?: number,
+    ): Promise<{ token: string; resent: boolean }> {
+        const normalizedAddress = normalizeBtcAddress(address);
+        if (!normalizedAddress) {
+            throw new InvitationServiceError('invalid-address', 'Address required');
+        }
+
+        const existing = await this.invitationRepo.findOne({
+            where: { groupId, address: normalizedAddress, status: 'pending' },
+        });
+
+        // Case 1: still-pending + not expired → re-send same token.
+        if (existing && existing.expiresAt > Date.now()) {
+            const group = await this.blockpartyService.getGroup(groupId);
+            if (!group) throw new InvitationServiceError('not-found', 'Blockparty not found');
+            const baseUrl = this.poolBaseUrl();
+            try {
+                await this.emailService.sendInvitation({
+                    to: existing.email,
+                    address: normalizedAddress,
+                    groupName: group.name,
+                    inviterAddress: group.adminAddress,
+                    inviteUrl: `${baseUrl}/#/blockparty/invite/${existing.token}`,
+                    expiresAt: new Date(existing.expiresAt),
+                });
+            } catch (err) {
+                throw new InvitationServiceError(
+                    'email-send-failed',
+                    (err as Error)?.message ?? 'Email send failed',
+                );
+            }
+            return { token: existing.token, resent: true };
+        }
+
+        // Case 2: pending-but-expired → mark expired and fall through.
+        if (existing && existing.expiresAt <= Date.now()) {
+            existing.status = 'expired';
+            existing.respondedAt = Date.now();
+            await this.invitationRepo.save(existing);
+        }
+
+        // Case 2 cont. / Case 3: mint a fresh invitation. The email
+        // comes from the member's verified binding (createInvitation
+        // re-looks it up internally).
+        const member = await this.blockpartyService.listMembers(groupId);
+        const row = member.find(m => m.address === normalizedAddress);
+        if (!row) {
+            throw new InvitationServiceError('not-member', 'Address is not a member of this Blockparty');
+        }
+        // Lost-token recovery: clear the member's previous onboarding
+        // state so the accept flow re-mints a fresh BPM-... token. Safe
+        // for first-time invites too (no-ops when nothing was set).
+        await this.blockpartyService.resetMemberOnboarding(groupId, normalizedAddress);
+        const { token } = await this.createInvitation({
+            groupId,
+            address: normalizedAddress,
+            email: row.email,
+            ttlDays,
+        });
+        return { token, resent: false };
+    }
+
+    async revoke(groupId: string, token: string): Promise<void> {
+        const invitation = await this.invitationRepo.findOneBy({ token });
+        if (!invitation || invitation.groupId !== groupId) {
+            throw new InvitationServiceError('invitation-not-found', 'Invitation not found for this Blockparty');
+        }
+        if (invitation.status !== 'pending') {
+            throw new InvitationServiceError('invitation-not-pending', `Invitation is ${invitation.status} — cannot revoke`);
+        }
+        // Revoking = letting it expire immediately. No 'revoked' status because
+        // for v1 we only support directed invites; the partial unique index keys
+        // on status='pending', so flipping to 'expired' frees a new pending row.
+        invitation.status = 'expired';
+        invitation.respondedAt = Date.now();
+        await this.invitationRepo.save(invitation);
+    }
+
+    private async requirePending(token: string): Promise<BlockpartyInvitationEntity> {
+        const invitation = await this.invitationRepo.findOneBy({ token });
+        if (!invitation) {
+            throw new InvitationServiceError('invitation-not-found', 'Invitation not found');
+        }
+        const effective = this.computeEffectiveStatus(invitation);
+        if (effective !== 'pending') {
+            throw new InvitationServiceError(
+                'invitation-not-pending',
+                `Invitation is ${effective} — no longer actionable`,
+            );
+        }
+        return invitation;
+    }
+
+    private computeEffectiveStatus(invitation: BlockpartyInvitationEntity): BlockpartyInvitationStatus {
+        if (invitation.status !== 'pending') return invitation.status;
+        if (invitation.expiresAt < Date.now()) return 'expired';
+        return 'pending';
+    }
+}

--- a/src/services/blockparty-regtest-mixed-addresses.spec.ts
+++ b/src/services/blockparty-regtest-mixed-addresses.spec.ts
@@ -1,0 +1,323 @@
+/**
+ * Blockparty Regtest — mixed-address-type coinbase
+ *
+ * Cluster B regression: Blockparty coinbase produces N+1 outputs (pool
+ * fee + N members), where each member address can be any BTC type.
+ * This spec verifies that a 4-address mix (P2WPKH-Admin + P2PKH-Member
+ * + P2TR-Member + P2WPKH-Member) gets encoded with the right
+ * scriptPubKey for each type and that Bitcoin Core 29 accepts the
+ * resulting block.
+ *
+ * Pool fee address stays P2WPKH (the canonical configuration). Member
+ * roster is wallet-generated at test time so we don't hard-code
+ * regtest-network-specific bech32/legacy values.
+ *
+ * Run: npx jest src/services/blockparty-regtest-mixed-addresses.spec.ts --runInBand --no-coverage
+ */
+
+import * as bitcoinjs from 'bitcoinjs-lib';
+
+import { BlockpartyService } from './blockparty.service';
+import { BlockpartyInvitationService } from './blockparty-invitation.service';
+import { rpcCall, assembleWithMiningJobAndTemplate, NETWORK } from './__test-helpers__/regtest-harness';
+
+const ADDR_FEE = 'bcrt1qqj0r5w2ua3pe0sh6gthvfeegvwsa3t4edumqzf'; // P2WPKH pool fee
+const ADDR_ADMIN = 'bcrt1q2jf90sp25mt4pte5swkr4cujpj5d8zzwdt09fq'; // P2WPKH admin
+
+// ── Mock repo factory (mirror of blockparty-regtest.spec.ts) ──────────
+
+function createMockRepo(target: string) {
+    const rows = new Map<any, any>();
+    let nextId = 1;
+
+    function matchesWhere(row: any, where: any): boolean {
+        return Object.entries(where).every(([k, v]) => {
+            if (v && typeof v === 'object' && '_type' in (v as any)) {
+                if ((v as any)._type === 'isNull') return row[k] == null;
+            }
+            return row[k] === v;
+        });
+    }
+
+    return {
+        _rows: rows,
+        target,
+        save: jest.fn(async (row: any) => {
+            if (target === 'invitation') {
+                rows.set(row.token, { ...row });
+                return { ...row };
+            }
+            if (target === 'history' && !row.id) {
+                for (const existing of Array.from(rows.values())) {
+                    if ((existing as any).groupId === row.groupId
+                        && (existing as any).blockHash === row.blockHash) {
+                        const err: any = new Error('duplicate key');
+                        err.code = '23505';
+                        throw err;
+                    }
+                }
+            }
+            if (!row.id) {
+                row.id = target === 'group' ? `uuid-${nextId++}` : nextId++;
+            }
+            rows.set(row.id, { ...row });
+            return { ...row };
+        }),
+        create: jest.fn((partial: any) => ({ ...partial })),
+        find: jest.fn(async (query?: any) => {
+            const all = Array.from(rows.values());
+            let out = all;
+            if (query?.where) {
+                const where = Array.isArray(query.where) ? query.where : [query.where];
+                out = all.filter(r => where.some((w: any) => matchesWhere(r, w)));
+            }
+            if (query?.order) {
+                const [[k, dir]] = Object.entries(query.order);
+                out = [...out].sort((a, b) => a[k] === b[k] ? 0 : (a[k] < b[k] ? (dir === 'DESC' ? 1 : -1) : (dir === 'DESC' ? -1 : 1)));
+            }
+            return out;
+        }),
+        findOne: jest.fn(async (query: any) => {
+            return Array.from(rows.values()).find(r => matchesWhere(r, query?.where ?? {})) ?? null;
+        }),
+        findOneBy: jest.fn(async (where: any) => {
+            return Array.from(rows.values()).find(r => matchesWhere(r, where)) ?? null;
+        }),
+        delete: jest.fn(async (where: any) => {
+            for (const [id, row] of Array.from(rows.entries())) {
+                if (matchesWhere(row, where)) rows.delete(id);
+            }
+        }),
+        update: jest.fn(async (where: any, patch: any) => {
+            let affected = 0;
+            for (const row of Array.from(rows.values())) {
+                if (matchesWhere(row, where)) {
+                    Object.assign(row, patch);
+                    affected++;
+                }
+            }
+            return { affected };
+        }),
+    };
+}
+
+async function buildServices() {
+    const groupRepo = createMockRepo('group');
+    const memberRepo = createMockRepo('member');
+    const historyRepo = createMockRepo('history');
+    const invitationRepo = createMockRepo('invitation');
+
+    const repoByTarget: Record<string, any> = {
+        group: groupRepo, member: memberRepo, history: historyRepo, invitation: invitationRepo,
+    };
+    const manager = {
+        transaction: jest.fn(async (cb: (em: any) => Promise<any>) => cb({
+            getRepository: (target: string) => repoByTarget[target] ?? createMockRepo(target),
+        })),
+    };
+    for (const r of [groupRepo, memberRepo, historyRepo, invitationRepo]) (r as any).manager = manager;
+
+    const config = {
+        get: (k: string) => ({
+            PPLNS_FEE_ADDRESS: ADDR_FEE,
+            PPLNS_FEE_PERCENT: '2',
+            // Keep min-payout low so none of the 4 mid-sized member splits
+            // get trimmed into the pool fee output — this spec is about
+            // address-type encoding, not the dust path.
+            PPLNS_MIN_PAYOUT_SATS: '5000',
+        } as Record<string, string>)[k],
+    };
+    const groupService = { getGroupForAddress: () => undefined };
+    const addressEmailService = {
+        getVerified: async (address: string) => ({
+            address, email: `${address}@verified.local`, verifiedAt: Date.now(),
+            createdAt: Date.now(), updatedAt: Date.now(),
+        }),
+    };
+
+    const blockparty = new BlockpartyService(
+        groupRepo as any, memberRepo as any, historyRepo as any, config as any, groupService as any, addressEmailService as any,
+    );
+    await blockparty.onModuleInit();
+    const emailService = { sendInvitation: jest.fn(async () => undefined) };
+    const invitationConfig = { get: (k: string) => k === 'POOL_BASE_URL' ? 'https://pool.example' : undefined };
+    const invitations = new BlockpartyInvitationService(
+        invitationRepo as any, blockparty, emailService as any, invitationConfig as any,
+    );
+    return { blockparty, invitations, historyRepo };
+}
+
+/**
+ * scriptPubKey-shape classifier for the on-chain coinbase outputs.
+ * Matches Bitcoin's canonical templates as of v29:
+ *   P2WPKH = OP_0 <20 bytes>      (length 22)
+ *   P2WSH  = OP_0 <32 bytes>      (length 34)
+ *   P2TR   = OP_1 <32 bytes>      (length 34)
+ *   P2PKH  = OP_DUP OP_HASH160 <20 bytes> OP_EQUALVERIFY OP_CHECKSIG  (length 25)
+ *   P2SH   = OP_HASH160 <20 bytes> OP_EQUAL  (length 23)
+ *   OP_RETURN witness commit starts with 6a (length 38)
+ */
+function classifyScript(script: Buffer): string {
+    if (script[0] === 0x6a) return 'OP_RETURN';
+    if (script.length === 22 && script[0] === 0x00 && script[1] === 0x14) return 'p2wpkh';
+    if (script.length === 34 && script[0] === 0x00 && script[1] === 0x20) return 'p2wsh';
+    if (script.length === 34 && script[0] === 0x51 && script[1] === 0x20) return 'p2tr';
+    if (script.length === 25 && script[0] === 0x76 && script[1] === 0xa9 && script[2] === 0x14
+        && script[23] === 0x88 && script[24] === 0xac) return 'p2pkh';
+    if (script.length === 23 && script[0] === 0xa9 && script[1] === 0x14 && script[22] === 0x87) return 'p2sh';
+    return `unknown(${script.length})`;
+}
+
+describe('Blockparty Regtest — mixed-address-type coinbase', () => {
+
+    let bobP2pkh = '';
+    let carolP2tr = '';
+    let daveP2wpkh = '';
+
+    beforeAll(async () => {
+        try {
+            const info = await rpcCall('getblockchaininfo');
+            expect(info.chain).toBe('regtest');
+            const wallets: string[] = await rpcCall('listwallets');
+            for (const name of wallets) {
+                if (name !== 'default') {
+                    try { await rpcCall('unloadwallet', [name]); } catch { /* ignore */ }
+                }
+            }
+            if (!wallets.includes('default')) {
+                try { await rpcCall('createwallet', ['default']); } catch { /* already exists */ }
+            }
+            // BIP34 gate: coinbase scriptSig encodes heights 1..16 as OP_N,
+            // which our builder doesn't emit. Mirror of blockparty-regtest.spec.ts.
+            if (info.blocks < 17) {
+                const addr = await rpcCall('getnewaddress');
+                await rpcCall('generatetoaddress', [17 - info.blocks, addr]);
+            }
+            // Wallet-side address generation guarantees regtest-network-valid
+            // bech32 / legacy strings without hard-coding network-specific
+            // prefixes in the spec.
+            bobP2pkh = await rpcCall('getnewaddress', ['', 'legacy']);
+            carolP2tr = await rpcCall('getnewaddress', ['', 'bech32m']);
+            daveP2wpkh = await rpcCall('getnewaddress', ['', 'bech32']);
+        } catch (e: any) {
+            throw new Error(`Bitcoin Core regtest not running at localhost:18443: ${e?.message ?? e}`);
+        }
+    });
+
+    it('mints valid coinbase with P2WPKH-Admin + P2PKH-Bob + P2TR-Carol + P2WPKH-Dave and Core 29 accepts the block', async () => {
+        const { blockparty } = await buildServices();
+
+        // Splits sum to 10000 = 100% of the miner cut:
+        //   admin 4000 (40%) + bob 2500 + carol 2000 + dave 1500
+        // The pool fee (2%) comes off the top before splits are applied.
+        const created = await blockparty.createGroup({
+            name: 'mixed-addr-regtest',
+            adminAddress: ADDR_ADMIN,
+            adminEmail: 'admin@test.local',
+            adminPercentBp: 4000,
+        });
+        await blockparty.addMember(created.group.id, {
+            address: bobP2pkh, email: 'bob@test.local', percentBp: 2500,
+        }, created.adminToken);
+        await blockparty.addMember(created.group.id, {
+            address: carolP2tr, email: 'carol@test.local', percentBp: 2000,
+        }, created.adminToken);
+        await blockparty.addMember(created.group.id, {
+            address: daveP2wpkh, email: 'dave@test.local', percentBp: 1500,
+        }, created.adminToken);
+
+        // Bring the party from CONFIRMING up to ACTIVE so the routing
+        // path would accept it; not strictly required for the coinbase
+        // construction but keeps the spec end-to-end realistic.
+        await blockparty.markMemberConfirmed(created.group.id, bobP2pkh);
+        await blockparty.markMemberConfirmed(created.group.id, carolP2tr);
+        await blockparty.markMemberConfirmed(created.group.id, daveP2wpkh);
+        await blockparty.transitionToConfirming(created.group.id, created.adminToken);
+        await blockparty.onShareAccepted(ADDR_ADMIN);
+
+        const template = await rpcCall('getblocktemplate', [{ rules: ['segwit'] }]);
+        const reward = template.coinbasevalue;
+        const distribution = await blockparty.getPayoutDistribution(created.group.id, reward);
+
+        // Five payout entries: pool fee + 4 members. None trimmed (min-payout = 5000
+        // sats, lowest split is dave at 1500bp of a 9800bp miner-cut on a 5+ BTC reward).
+        expect(distribution.payouts).toHaveLength(5);
+        expect(distribution.splits.every(s => !s.trimmed)).toBe(true);
+        const totalSats = distribution.payouts.reduce((s, p) => s + p.sats, 0);
+        expect(totalSats).toBe(reward);
+
+        // Build + submit the block via the production MiningJob path.
+        const mjDist = distribution.payouts.map(p => ({ address: p.address, percent: p.percent }));
+        const { submitResult, coinbaseTx } = await assembleWithMiningJobAndTemplate(mjDist, template, 'bp-mixed');
+        expect(submitResult).toBeNull(); // Core acceptance
+
+        // Coinbase output sum equals the block reward exactly (rounding
+        // remainder gets folded into outs[0], which for Blockparty is the
+        // pool fee output).
+        const coinbaseTotal = coinbaseTx.outs.reduce((s: number, o: any) => s + o.value, 0);
+        expect(coinbaseTotal).toBe(reward);
+
+        // Per-output scriptPubKey shape — each address type must encode
+        // to its canonical template, NOT the wrong type or an empty
+        // script (which would be the failure mode if MiningJob's
+        // getPaymentScript default branch fired).
+        const shapes = coinbaseTx.outs.map((o: any) => classifyScript(Buffer.from(o.script)));
+        // outs ordering: [pool fee (p2wpkh), admin (p2wpkh), bob (p2pkh),
+        //                 carol (p2tr), dave (p2wpkh), OP_RETURN segwit commit]
+        expect(shapes[0]).toBe('p2wpkh'); // pool fee
+        expect(shapes[1]).toBe('p2wpkh'); // admin
+        expect(shapes[2]).toBe('p2pkh');  // bob
+        expect(shapes[3]).toBe('p2tr');   // carol
+        expect(shapes[4]).toBe('p2wpkh'); // dave
+        expect(shapes[5]).toBe('OP_RETURN'); // segwit commitment
+
+        // Address → scriptPubKey round-trip: derive the expected script
+        // from each address and assert it matches what landed in the
+        // coinbase. Guards against the "right shape, wrong key" failure
+        // where MiningJob picked a default branch or used a stale
+        // network.
+        const expectedScripts: Record<string, Buffer> = {
+            [ADDR_FEE]: bitcoinjs.payments.p2wpkh({ address: ADDR_FEE, network: NETWORK }).output!,
+            [ADDR_ADMIN]: bitcoinjs.payments.p2wpkh({ address: ADDR_ADMIN, network: NETWORK }).output!,
+            [bobP2pkh]: bitcoinjs.payments.p2pkh({ address: bobP2pkh, network: NETWORK }).output!,
+            [carolP2tr]: bitcoinjs.payments.p2tr({ address: carolP2tr, network: NETWORK }).output!,
+            [daveP2wpkh]: bitcoinjs.payments.p2wpkh({ address: daveP2wpkh, network: NETWORK }).output!,
+        };
+        for (let i = 0; i < distribution.payouts.length; i++) {
+            const payout = distribution.payouts[i];
+            const got = Buffer.from(coinbaseTx.outs[i].script);
+            expect(got.equals(expectedScripts[payout.address])).toBe(true);
+        }
+
+        // Per-output sat values — MiningJob computes amount = floor(percent/100 * reward)
+        // and folds the rounding remainder back into outs[0] (= the pool fee
+        // for Blockparty). So member outputs (outs[1..]) must equal their
+        // distribution.payouts[i].sats exactly; outs[0] is allowed to be
+        // ≥ distribution.payouts[0].sats by the rounding remainder.
+        const memberSatsByAddress = new Map<string, number>();
+        for (const p of distribution.payouts) memberSatsByAddress.set(p.address, p.sats);
+        for (let i = 1; i < distribution.payouts.length; i++) {
+            const payout = distribution.payouts[i];
+            expect(coinbaseTx.outs[i].value).toBe(payout.sats);
+        }
+        // outs[0] catches the floor-remainder. Distribution sums to reward, so
+        // the on-chain pool fee output equals the distribution's pool fee output
+        // value (no drift between MiningJob and BlockpartyDistribution at this
+        // reward magnitude on regtest).
+        expect(coinbaseTx.outs[0].value).toBe(distribution.payouts[0].sats);
+
+        const info = await rpcCall('getblockchaininfo');
+        expect(info.blocks).toBe(template.height);
+
+        console.log(`\n=== Blockparty Mixed-Address Regtest ===`);
+        console.log(`Height: ${template.height}, reward: ${reward} sats, pool fee: ${distribution.poolFeeSats} sats`);
+        console.log(`Output shapes: ${shapes.join(' / ')}`);
+        console.log(`Addresses:`);
+        console.log(`  fee   (p2wpkh): ${ADDR_FEE}  → ${distribution.payouts[0].sats} sats`);
+        console.log(`  admin (p2wpkh): ${ADDR_ADMIN} → ${distribution.payouts[1].sats} sats`);
+        console.log(`  bob   (p2pkh):  ${bobP2pkh} → ${distribution.payouts[2].sats} sats`);
+        console.log(`  carol (p2tr):   ${carolP2tr} → ${distribution.payouts[3].sats} sats`);
+        console.log(`  dave  (p2wpkh): ${daveP2wpkh} → ${distribution.payouts[4].sats} sats`);
+        console.log('✅ Mixed-address coinbase accepted by Bitcoin Core 29');
+    }, 60000);
+});

--- a/src/services/blockparty-regtest.spec.ts
+++ b/src/services/blockparty-regtest.spec.ts
@@ -1,0 +1,306 @@
+/**
+ * Blockparty Regtest Integration Test
+ *
+ * End-to-end: BlockpartyService builds a multi-output coinbase from the
+ * configured per-member basis-point splits, MiningJob assembles a real
+ * block via the production path, Bitcoin Core regtest accepts it.
+ * Also exercises the full state machine
+ * (DRAFT → CONFIRMING → READY → ACTIVE) plus the dissolve 7-day cooldown.
+ *
+ * Requires a running regtest node at localhost:18443 (rpcuser=test,
+ * rpcpassword=test). Mirror of group-solo-regtest.spec.ts.
+ *
+ * Run: npx jest blockparty-regtest --runInBand --no-coverage
+ */
+
+import { BlockpartyService } from './blockparty.service';
+import { BlockpartyInvitationService } from './blockparty-invitation.service';
+import { rpcCall, assembleWithMiningJobAndTemplate } from './__test-helpers__/regtest-harness';
+
+const ADDR_FEE = 'bcrt1qqj0r5w2ua3pe0sh6gthvfeegvwsa3t4edumqzf';
+const ADDR_ADMIN = 'bcrt1q2jf90sp25mt4pte5swkr4cujpj5d8zzwdt09fq';
+const ADDR_BOB = 'bcrt1qt2amqww2n3dcz3ckx6nlentvm9e6rpxqrfmvl7';
+
+// ── Mock repo factory (token-keyed for invitations, generic otherwise) ──
+
+function createMockRepo(target: string) {
+    const rows = new Map<any, any>();
+    let nextId = 1;
+
+    function matchesWhere(row: any, where: any): boolean {
+        return Object.entries(where).every(([k, v]) => {
+            if (v && typeof v === 'object' && '_type' in (v as any)) {
+                if ((v as any)._type === 'isNull') return row[k] == null;
+            }
+            return row[k] === v;
+        });
+    }
+
+    return {
+        _rows: rows,
+        target,
+        save: jest.fn(async (row: any) => {
+            if (target === 'invitation') {
+                rows.set(row.token, { ...row });
+                return { ...row };
+            }
+            // Simulate the (groupId, blockHash) unique index on the history table
+            // so the production 23505-catch path is exercised by replays.
+            if (target === 'history' && !row.id) {
+                for (const existing of Array.from(rows.values())) {
+                    if ((existing as any).groupId === row.groupId
+                        && (existing as any).blockHash === row.blockHash) {
+                        const err: any = new Error('duplicate key');
+                        err.code = '23505';
+                        throw err;
+                    }
+                }
+            }
+            if (!row.id) {
+                row.id = target === 'group' ? `uuid-${nextId++}` : nextId++;
+            }
+            rows.set(row.id, { ...row });
+            return { ...row };
+        }),
+        create: jest.fn((partial: any) => ({ ...partial })),
+        find: jest.fn(async (query?: any) => {
+            const all = Array.from(rows.values());
+            let out = all;
+            if (query?.where) {
+                const where = Array.isArray(query.where) ? query.where : [query.where];
+                out = all.filter(r => where.some((w: any) => matchesWhere(r, w)));
+            }
+            if (query?.order) {
+                const [[k, dir]] = Object.entries(query.order);
+                out = [...out].sort((a, b) => a[k] === b[k] ? 0 : (a[k] < b[k] ? (dir === 'DESC' ? 1 : -1) : (dir === 'DESC' ? -1 : 1)));
+            }
+            return out;
+        }),
+        findOne: jest.fn(async (query: any) => {
+            return Array.from(rows.values()).find(r => matchesWhere(r, query?.where ?? {})) ?? null;
+        }),
+        findOneBy: jest.fn(async (where: any) => {
+            return Array.from(rows.values()).find(r => matchesWhere(r, where)) ?? null;
+        }),
+        delete: jest.fn(async (where: any) => {
+            for (const [id, row] of Array.from(rows.entries())) {
+                if (matchesWhere(row, where)) rows.delete(id);
+            }
+        }),
+        update: jest.fn(async (where: any, patch: any) => {
+            let affected = 0;
+            for (const row of Array.from(rows.values())) {
+                if (matchesWhere(row, where)) {
+                    Object.assign(row, patch);
+                    affected++;
+                }
+            }
+            return { affected };
+        }),
+    };
+}
+
+async function buildServices() {
+    const groupRepo = createMockRepo('group');
+    const memberRepo = createMockRepo('member');
+    const historyRepo = createMockRepo('history');
+    const invitationRepo = createMockRepo('invitation');
+
+    const repoByTarget: Record<string, any> = {
+        group: groupRepo, member: memberRepo, history: historyRepo, invitation: invitationRepo,
+    };
+    const manager = {
+        transaction: jest.fn(async (cb: (em: any) => Promise<any>) => cb({
+            getRepository: (target: string) => repoByTarget[target] ?? createMockRepo(target),
+        })),
+    };
+    for (const r of [groupRepo, memberRepo, historyRepo, invitationRepo]) (r as any).manager = manager;
+
+    const config = {
+        get: (k: string) => ({
+            PPLNS_FEE_ADDRESS: ADDR_FEE,
+            PPLNS_FEE_PERCENT: '2',
+            PPLNS_MIN_PAYOUT_SATS: '5000',
+        } as Record<string, string>)[k],
+    };
+    const groupService = { getGroupForAddress: () => undefined };
+    const addressEmailService = {
+        getVerified: async (address: string) => ({
+            address, email: `${address}@verified.local`, verifiedAt: Date.now(),
+            createdAt: Date.now(), updatedAt: Date.now(),
+        }),
+    };
+
+    const blockparty = new BlockpartyService(
+        groupRepo as any, memberRepo as any, historyRepo as any, config as any, groupService as any, addressEmailService as any,
+    );
+    await blockparty.onModuleInit();
+    const emailService = { sendInvitation: jest.fn(async () => undefined) };
+    const invitationConfig = { get: (k: string) => k === 'POOL_BASE_URL' ? 'https://pool.example' : undefined };
+    const invitations = new BlockpartyInvitationService(
+        invitationRepo as any, blockparty, emailService as any, invitationConfig as any,
+    );
+    return { blockparty, invitations, groupRepo, memberRepo, historyRepo, invitationRepo };
+}
+
+describe('Blockparty Regtest — End-to-End with Bitcoin Core', () => {
+
+    beforeAll(async () => {
+        try {
+            const info = await rpcCall('getblockchaininfo');
+            expect(info.chain).toBe('regtest');
+            const wallets: string[] = await rpcCall('listwallets');
+            for (const name of wallets) {
+                if (name !== 'default') {
+                    try { await rpcCall('unloadwallet', [name]); } catch { /* ignore */ }
+                }
+            }
+            if (!wallets.includes('default')) {
+                try { await rpcCall('createwallet', ['default']); } catch { /* already exists */ }
+            }
+            // BIP34 coinbase scriptSig — same reason as the group-solo regtest:
+            // heights 1..16 encode as OP_N, which our coinbase builder doesn't emit.
+            if (info.blocks < 17) {
+                const addr = await rpcCall('getnewaddress');
+                await rpcCall('generatetoaddress', [17 - info.blocks, addr]);
+            }
+        } catch {
+            throw new Error('Bitcoin Core regtest not running at localhost:18443. Start with: bitcoind -regtest -daemon -rpcuser=test -rpcpassword=test -rpcport=18443');
+        }
+    });
+
+    it('full lifecycle: create → invite → confirm → first share activates → block submit accepted by Core → onBlockFound writes history', async () => {
+        const { blockparty, invitations, historyRepo } = await buildServices();
+
+        // 1. Admin creates a draft Blockparty (admin keeps 49 % of the miner cut).
+        const created = await blockparty.createGroup({
+            name: 'rental-regtest', adminAddress: ADDR_ADMIN, adminEmail: 'admin@test.local', adminPercentBp: 5000,
+        });
+        expect(created.group.status).toBe('draft');
+
+        // 2. Admin adds Bob (49 %, sum = 9800 = 100 % − 2 % pool fee).
+        const bob = await blockparty.addMember(created.group.id, {
+            address: ADDR_BOB, email: 'bob@test.local', percentBp: 5000,
+        }, created.adminToken);
+        expect(bob.confirmedAt).toBeNull();
+
+        // 3. Bob gets an invitation token, accepts it via the public invite flow.
+        const invite = await invitations.createInvitation({
+            groupId: created.group.id, address: ADDR_BOB, email: 'bob@test.local',
+        });
+        await invitations.accept(invite.token);
+
+        // 4. Admin transitions to CONFIRMING (validates the splits sum).
+        //    Bob's prior accept means recomputeStatus → 'ready' immediately.
+        await blockparty.transitionToConfirming(created.group.id, created.adminToken);
+        let group = await blockparty.getGroup(created.group.id);
+        expect(group?.status).toBe('ready');
+
+        // 5. First share lands on the admin's treasury address → state → ACTIVE.
+        await blockparty.onShareAccepted(ADDR_ADMIN);
+        group = await blockparty.getGroup(created.group.id);
+        expect(group?.status).toBe('active');
+        expect(group?.lastShareAt).toBeGreaterThan(0);
+
+        // 6. Fetch a real Core block template; compute the on-chain split.
+        const template = await rpcCall('getblocktemplate', [{ rules: ['segwit'] }]);
+        const blockReward = template.coinbasevalue;
+        const height = template.height;
+
+        const distribution = await blockparty.getPayoutDistribution(created.group.id, blockReward);
+
+        // Three outputs expected: pool fee + admin share + Bob share.
+        const addresses = distribution.payouts.map(p => p.address);
+        expect(addresses).toContain(ADDR_FEE);
+        expect(addresses).toContain(ADDR_ADMIN);
+        expect(addresses).toContain(ADDR_BOB);
+        expect(distribution.payouts.length).toBe(3);
+
+        // Sat conservation: pool fee + paid members === blockReward.
+        const totalSats = distribution.payouts.reduce((s, p) => s + p.sats, 0);
+        expect(totalSats).toBe(blockReward);
+
+        console.log(`\n=== Blockparty Regtest ===`);
+        console.log(`Height: ${height}`);
+        console.log(`Block reward: ${blockReward} sats, pool fee: ${distribution.poolFeeSats} sats`);
+        console.log(`Outputs: ${distribution.payouts.map(p => `${p.address.slice(0, 12)}…=${p.sats}`).join(', ')}`);
+
+        // 7. Build + submit a real block via the production MiningJob path.
+        const mjDist = distribution.payouts.map(p => ({ address: p.address, percent: p.percent }));
+        const { submitResult, coinbaseTx } = await assembleWithMiningJobAndTemplate(mjDist, template, 'bp-basic');
+        expect(submitResult).toBeNull(); // null = accepted
+
+        // Coinbase total on-chain must match blockReward exactly.
+        const coinbaseTotal = coinbaseTx.outs.reduce((s: number, o: any) => s + o.value, 0);
+        expect(coinbaseTotal).toBe(blockReward);
+
+        // Chain tip advanced.
+        const info = await rpcCall('getblockchaininfo');
+        expect(info.blocks).toBe(height);
+
+        // 8. onBlockFound writes a history row that mirrors the on-chain split.
+        const blockHash = info.bestblockhash;
+        await blockparty.onBlockFound({
+            groupId: created.group.id,
+            blockHeight: height,
+            blockHash,
+            coinbaseValueSats: blockReward,
+        });
+        const history = await blockparty.getHistory(created.group.id);
+        expect(history).toHaveLength(1);
+        expect(history[0].blockHeight).toBe(height);
+        expect(history[0].blockHash).toBe(blockHash);
+        expect(history[0].coinbaseValueSats).toBe(blockReward);
+        expect(history[0].poolFeeSats).toBe(distribution.poolFeeSats);
+        expect(history[0].splits).toHaveLength(2); // admin + bob (no trimmed)
+        expect(history[0].splits.every((s: any) => !s.trimmed)).toBe(true);
+
+        // Idempotent replay — second call must not write a duplicate row.
+        const replay = await blockparty.onBlockFound({
+            groupId: created.group.id,
+            blockHeight: height,
+            blockHash,
+            coinbaseValueSats: blockReward,
+        });
+        expect(replay).toBeNull();
+        expect((historyRepo as any)._rows.size).toBe(1);
+
+        // Party is still ACTIVE after the block — Blockparty has no per-block
+        // dissolve (the rental runs until admin explicitly tears it down).
+        group = await blockparty.getGroup(created.group.id);
+        expect(group?.status).toBe('active');
+
+        console.log('✅ Lifecycle verified: state machine → on-chain coinbase → history idempotency');
+    }, 60000);
+
+    it('dissolve respects the 7-day post-share cooldown', async () => {
+        const { blockparty, groupRepo } = await buildServices();
+        const created = await blockparty.createGroup({
+            name: 'cooldown-regtest', adminAddress: ADDR_ADMIN, adminEmail: 'admin@test.local', adminPercentBp: 5000,
+        });
+        await blockparty.addMember(created.group.id, {
+            address: ADDR_BOB, email: 'bob@test.local', percentBp: 5000,
+        }, created.adminToken);
+        await blockparty.transitionToConfirming(created.group.id, created.adminToken);
+        await blockparty.markMemberConfirmed(created.group.id, ADDR_BOB);
+
+        // First share — flips status to ACTIVE and sets lastShareAt = now.
+        await blockparty.onShareAccepted(ADDR_ADMIN);
+        let group = await blockparty.getGroup(created.group.id);
+        expect(group?.status).toBe('active');
+
+        // Attempt dissolve during the cooldown → 'dissolve-cooldown'.
+        await expect(
+            blockparty.dissolveGroup(created.group.id, created.adminToken),
+        ).rejects.toMatchObject({ code: 'dissolve-cooldown' });
+
+        // Backdate lastShareAt by 25h on the mocked row, retry — must succeed.
+        const stored = (groupRepo as any)._rows.get(created.group.id);
+        stored.lastShareAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
+
+        await blockparty.dissolveGroup(created.group.id, created.adminToken);
+        group = await blockparty.getGroup(created.group.id);
+        expect(group?.status).toBe('dissolved');
+        expect(group?.dissolvedAt).toBeGreaterThan(0);
+    }, 30000);
+});

--- a/src/services/blockparty.service.spec.ts
+++ b/src/services/blockparty.service.spec.ts
@@ -1,0 +1,507 @@
+import { BlockpartyService, BlockpartyServiceError } from './blockparty.service';
+
+// ── Mock Repos ──────────────────────────────────────────────────
+
+function createMockRepo<T extends { id?: any }>(target: string = 'unknown') {
+    const rows = new Map<any, T>();
+    let nextNumeric = 1;
+    let nextUuid = 1;
+
+    function matchesWhere(row: any, where: any): boolean {
+        return Object.entries(where).every(([k, v]) => {
+            if (v && typeof v === 'object' && '_type' in (v as any)) {
+                if ((v as any)._type === 'isNull') return row[k] == null;
+            }
+            return row[k] === v;
+        });
+    }
+
+    return {
+        _rows: rows,
+        target,
+        save: jest.fn(async (row: T) => {
+            if (!(row as any).id) {
+                (row as any).id = target === 'history' || target === 'member'
+                    ? nextNumeric++
+                    : 'uuid-' + (nextUuid++);
+            }
+            rows.set((row as any).id, { ...(row as any) });
+            return { ...(row as any) };
+        }),
+        create: jest.fn((partial: Partial<T>) => ({ ...partial }) as T),
+        find: jest.fn(async (query?: any) => {
+            const all = Array.from(rows.values());
+            let out = all;
+            if (query?.where) {
+                const where = Array.isArray(query.where) ? query.where : [query.where];
+                out = all.filter((row: any) => where.some((w: any) => matchesWhere(row, w)));
+            }
+            if (query?.order) {
+                const [[k, dir]] = Object.entries(query.order);
+                out = [...out].sort((a: any, b: any) => {
+                    if (a[k] === b[k]) return 0;
+                    const cmp = a[k] < b[k] ? -1 : 1;
+                    return dir === 'DESC' ? -cmp : cmp;
+                });
+            }
+            return out;
+        }),
+        findOne: jest.fn(async (query: any) => {
+            const all = Array.from(rows.values());
+            if (!query?.where) return null;
+            return all.find((row: any) => matchesWhere(row, query.where)) ?? null;
+        }),
+        findOneBy: jest.fn(async (where: any) => {
+            const all = Array.from(rows.values());
+            return all.find((row: any) => matchesWhere(row, where)) ?? null;
+        }),
+        delete: jest.fn(async (where: any) => {
+            for (const [id, row] of Array.from(rows.entries())) {
+                if (matchesWhere(row, where)) rows.delete(id);
+            }
+        }),
+        update: jest.fn(async (where: any, patch: any) => {
+            let affected = 0;
+            for (const row of Array.from(rows.values()) as any[]) {
+                if (matchesWhere(row, where)) {
+                    Object.assign(row, patch);
+                    affected++;
+                }
+            }
+            return { affected };
+        }),
+    };
+}
+
+function createMockConfig(overrides: Record<string, string | undefined> = {}) {
+    return {
+        get: jest.fn((key: string) => overrides[key]),
+    };
+}
+
+const FEE_ADDR = 'bc1qfeeaddress';
+
+async function buildService(envOverrides: Record<string, string | undefined> = {}) {
+    const groupRepo = createMockRepo('group');
+    const memberRepo = createMockRepo('member');
+    const historyRepo = createMockRepo('history');
+
+    const repoByTarget: Record<string, any> = {
+        group: groupRepo,
+        member: memberRepo,
+        history: historyRepo,
+    };
+    const manager = {
+        transaction: jest.fn(async (cb: (em: any) => Promise<any>) => {
+            const em = {
+                getRepository: (target: string) => repoByTarget[target] ?? createMockRepo(target),
+            };
+            return cb(em);
+        }),
+    };
+    (groupRepo as any).manager = manager;
+    (memberRepo as any).manager = manager;
+    (historyRepo as any).manager = manager;
+
+    const config = createMockConfig({
+        PPLNS_FEE_ADDRESS: FEE_ADDR,
+        PPLNS_FEE_PERCENT: '2',
+        PPLNS_MIN_PAYOUT_SATS: '5000',
+        ...envOverrides,
+    });
+
+    const groupService = {
+        // Default: address never in a PPLNS group. Individual tests can override.
+        getGroupForAddress: jest.fn(() => undefined),
+    };
+    const addressEmailService = {
+        // Default: every address has a verified binding. Tests that want
+        // the email-not-verified failure path override this per-call.
+        getVerified: jest.fn(async (address: string) => ({
+            address, email: `${address}@verified.local`, verifiedAt: Date.now(),
+            createdAt: Date.now(), updatedAt: Date.now(),
+        })),
+    };
+    const service = new BlockpartyService(
+        groupRepo as any,
+        memberRepo as any,
+        historyRepo as any,
+        config as any,
+        groupService as any,
+        addressEmailService as any,
+    );
+    await service.onModuleInit();
+    return { service, groupRepo, memberRepo, historyRepo, groupService, addressEmailService };
+}
+
+describe('BlockpartyService', () => {
+
+    // ── Creation ────────────────────────────────────────────────
+
+    it('creates a draft with admin as first member and returns a one-shot admin token', async () => {
+        const { service, memberRepo } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'rental-2026-05',
+            adminAddress: 'bc1qadmin',
+            adminEmail: 'admin@example.com',
+            adminPercentBp: 5000,
+        });
+
+        expect(adminToken).toMatch(/^BP-/);
+        expect(group.adminTokenHash).toBeDefined();
+        expect(group.adminTokenHash).not.toBe(adminToken);
+        expect(group.status).toBe('draft');
+        expect(group.lastShareAt).toBeNull();
+
+        const members = Array.from((memberRepo as any)._rows.values());
+        expect(members).toHaveLength(1);
+        expect(members[0]).toMatchObject({
+            address: 'bc1qadmin',
+            role: 'admin',
+            percentBp: 5000,
+        });
+        expect((members[0] as any).confirmedAt).toBeGreaterThan(0);
+    });
+
+    it('rejects short or control-character names', async () => {
+        const { service } = await buildService();
+        await expect(service.createGroup({
+            name: 'ab', adminAddress: 'bc1qa', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        })).rejects.toThrow(BlockpartyServiceError);
+        await expect(service.createGroup({
+            name: 'has\nnewline', adminAddress: 'bc1qa', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        })).rejects.toThrow(BlockpartyServiceError);
+    });
+
+    it('rejects out-of-range percentBp (< 1% or > 100%)', async () => {
+        const { service } = await buildService();
+        await expect(service.createGroup({
+            name: 'pct-low', adminAddress: 'bc1qa', adminEmail: 'a@b.c', adminPercentBp: 50,
+        })).rejects.toMatchObject({ code: 'invalid-percent' });
+        await expect(service.createGroup({
+            name: 'pct-high', adminAddress: 'bc1qa', adminEmail: 'a@b.c', adminPercentBp: 10001,
+        })).rejects.toMatchObject({ code: 'invalid-percent' });
+    });
+
+    it('rejects duplicate admin address across blockparties', async () => {
+        const { service } = await buildService();
+        await service.createGroup({
+            name: 'first', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await expect(service.createGroup({
+            name: 'second', adminAddress: 'bc1qadmin', adminEmail: 'x@y.z', adminPercentBp: 5000,
+        })).rejects.toMatchObject({ code: 'admin-address-taken' });
+    });
+
+    // ── Member management + state machine ──────────────────────────
+
+    it('adds an unconfirmed member while in DRAFT', async () => {
+        const { service } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        const m = await service.addMember(group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 4800,
+        }, adminToken);
+        expect(m.confirmedAt).toBeNull();
+        expect(m.role).toBe('member');
+    });
+
+    it('requires the admin token to add members', async () => {
+        const { service } = await buildService();
+        const { group } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await expect(service.addMember(group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 4800,
+        }, 'wrong-token')).rejects.toMatchObject({ code: 'invalid-token' });
+    });
+
+    it('refuses to add a member whose address already runs as admin', async () => {
+        const { service } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await expect(service.addMember(group.id, {
+            address: 'bc1qadmin', email: 'a@b.c', percentBp: 4800,
+        }, adminToken)).rejects.toMatchObject({ code: 'admin-cannot-rejoin' });
+    });
+
+    it('refuses to remove the admin member', async () => {
+        const { service } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await expect(service.removeMember(group.id, 'bc1qadmin', adminToken))
+            .rejects.toMatchObject({ code: 'admin-cannot-be-removed' });
+    });
+
+    it('transitions DRAFT → CONFIRMING and READY ← when all members confirm', async () => {
+        const { service, groupRepo, memberRepo } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await service.addMember(group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, adminToken);
+
+        // sum = 4900 + 4900 = 9800 = 10000 - 2% pool fee → valid
+        await service.transitionToConfirming(group.id, adminToken);
+        let saved = await (groupRepo as any).findOneBy({ id: group.id });
+        expect(saved.status).toBe('confirming');
+
+        // After bob confirms, all members confirmed → READY
+        await service.markMemberConfirmed(group.id, 'bc1qbob');
+        saved = await (groupRepo as any).findOneBy({ id: group.id });
+        expect(saved.status).toBe('ready');
+
+        // Spotcheck: bob's confirmedAt is set
+        const bob = Array.from((memberRepo as any)._rows.values())
+            .find((m: any) => m.address === 'bc1qbob') as any;
+        expect(bob.confirmedAt).toBeGreaterThan(0);
+    });
+
+    it('rejects transitionToConfirming when splits do not sum to (10000 - feeBp)', async () => {
+        const { service } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await service.addMember(group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 4000, // sum = 9000, expected 9800
+        }, adminToken);
+        await expect(service.transitionToConfirming(group.id, adminToken))
+            .rejects.toMatchObject({ code: 'invalid-splits-sum' });
+    });
+
+    it('updateSplits resets ALL members confirmation timestamps and drops READY back to CONFIRMING', async () => {
+        const { service, groupRepo, memberRepo } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await service.addMember(group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, adminToken);
+        await service.transitionToConfirming(group.id, adminToken);
+        await service.markMemberConfirmed(group.id, 'bc1qbob');
+
+        let saved = await (groupRepo as any).findOneBy({ id: group.id });
+        expect(saved.status).toBe('ready');
+
+        await service.updateSplits(group.id, [
+            { address: 'bc1qadmin', percentBp: 5800 },
+            { address: 'bc1qbob', percentBp: 4000 },
+        ], adminToken);
+
+        saved = await (groupRepo as any).findOneBy({ id: group.id });
+        expect(saved.status).toBe('confirming');
+
+        // New behavior: admin row keeps confirmedAt (its edit is its
+        // implicit consent); non-admin members get reset and must
+        // re-confirm with their member token.
+        const all = Array.from((memberRepo as any)._rows.values()) as any[];
+        const adminRow = all.find(m => m.address === 'bc1qadmin');
+        const bobRow = all.find(m => m.address === 'bc1qbob');
+        expect(adminRow.confirmedAt).toBeGreaterThan(0);
+        expect(bobRow.confirmedAt).toBeNull();
+    });
+
+    // ── Share + block hooks ──────────────────────────────────────────
+
+    it('onShareAccepted transitions READY → ACTIVE on first share and refreshes lastShareAt', async () => {
+        const { service, groupRepo } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await service.addMember(group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, adminToken);
+        await service.transitionToConfirming(group.id, adminToken);
+        await service.markMemberConfirmed(group.id, 'bc1qbob');
+
+        const t0 = Date.now();
+        await service.onShareAccepted('bc1qadmin');
+        const saved = await (groupRepo as any).findOneBy({ id: group.id });
+        expect(saved.status).toBe('active');
+        expect(saved.lastShareAt).toBeGreaterThanOrEqual(t0);
+    });
+
+    it('onShareAccepted is a no-op for non-admin addresses', async () => {
+        const { service, groupRepo } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await service.addMember(group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, adminToken);
+        await service.transitionToConfirming(group.id, adminToken);
+        await service.markMemberConfirmed(group.id, 'bc1qbob');
+
+        await service.onShareAccepted('bc1qbob');
+        const saved = await (groupRepo as any).findOneBy({ id: group.id });
+        expect(saved.status).toBe('ready');
+        expect(saved.lastShareAt).toBeNull();
+    });
+
+    it('dissolve is blocked during the 7-day post-share cooldown', async () => {
+        const { service, groupRepo } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await service.addMember(group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, adminToken);
+        await service.transitionToConfirming(group.id, adminToken);
+        await service.markMemberConfirmed(group.id, 'bc1qbob');
+        await service.onShareAccepted('bc1qadmin');
+
+        await expect(service.dissolveGroup(group.id, adminToken))
+            .rejects.toMatchObject({ code: 'dissolve-cooldown' });
+
+        // Simulate 25h of silence and try again — should succeed.
+        const saved = await (groupRepo as any).findOneBy({ id: group.id });
+        saved.lastShareAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
+        await (groupRepo as any).save(saved);
+
+        await service.dissolveGroup(group.id, adminToken);
+        const after = await (groupRepo as any).findOneBy({ id: group.id });
+        expect(after.status).toBe('dissolved');
+        expect(after.dissolvedAt).toBeGreaterThan(0);
+    });
+
+    it('dissolve from DRAFT skips the cooldown', async () => {
+        const { service, groupRepo } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await service.dissolveGroup(group.id, adminToken);
+        const saved = await (groupRepo as any).findOneBy({ id: group.id });
+        expect(saved.status).toBe('dissolved');
+    });
+
+    it('rejects edits once the party is ACTIVE (frozen forever)', async () => {
+        const { service } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await service.addMember(group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, adminToken);
+        await service.transitionToConfirming(group.id, adminToken);
+        await service.markMemberConfirmed(group.id, 'bc1qbob');
+        await service.onShareAccepted('bc1qadmin');
+
+        await expect(service.addMember(group.id, {
+            address: 'bc1qcarol', email: 'c@d.e', percentBp: 1000,
+        }, adminToken)).rejects.toMatchObject({ code: 'not-editable' });
+
+        await expect(service.updateSplits(group.id, [
+            { address: 'bc1qadmin', percentBp: 5000 },
+            { address: 'bc1qbob', percentBp: 4800 },
+        ], adminToken)).rejects.toMatchObject({ code: 'not-editable' });
+    });
+
+    // ── Payout distribution ─────────────────────────────────────────
+
+    it('getPayoutDistribution honours the per-member percentBp', async () => {
+        const { service } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await service.addMember(group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, adminToken);
+
+        const reward = 312_500_000;
+        const dist = await service.getPayoutDistribution(group.id, reward);
+
+        const baseFee = Math.floor(reward * 0.02);
+        const minerCut = reward - baseFee;
+        const expectAdmin = Math.floor(minerCut * 0.50);
+        const expectBob = Math.floor(minerCut * 0.50);
+
+        const adminEntry = dist.splits.find(s => s.address === 'bc1qadmin');
+        const bobEntry = dist.splits.find(s => s.address === 'bc1qbob');
+        expect(adminEntry?.sats).toBe(expectAdmin);
+        expect(bobEntry?.sats).toBe(expectBob);
+
+        // Total sats conserved.
+        const totalOut = dist.payouts.reduce((acc, p) => acc + p.sats, 0);
+        expect(totalOut).toBe(reward);
+    });
+
+    it('onBlockFound persists a history row with the splits snapshot', async () => {
+        const { service, historyRepo } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        await service.addMember(group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 5000,
+        }, adminToken);
+
+        const reward = 312_500_000;
+        const dist = await service.getPayoutDistribution(group.id, reward);
+
+        const row = await service.onBlockFound({
+            groupId: group.id,
+            blockHeight: 900_000,
+            blockHash: 'a'.repeat(64),
+            coinbaseValueSats: reward,
+        });
+
+        expect(row).not.toBeNull();
+        expect(row!.splits).toHaveLength(2);
+        expect(row!.poolFeeSats).toBe(dist.poolFeeSats);
+        expect((historyRepo as any)._rows.size).toBe(1);
+    });
+
+    // ── Mode-collision ─────────────────────────────────────────────
+
+    it('refuses createGroup when the admin address is in a PPLNS group', async () => {
+        const { service, groupService } = await buildService();
+        (groupService.getGroupForAddress as jest.Mock).mockImplementation(
+            (addr: string) => addr === 'bc1qadmin' ? { groupId: 'pp-1', active: true } : undefined,
+        );
+        await expect(service.createGroup({
+            name: 'rental', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        })).rejects.toMatchObject({ code: 'address-in-pplns-group' });
+    });
+
+    it('refuses addMember when the candidate address has no verified email', async () => {
+        const { service, addressEmailService } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        (addressEmailService.getVerified as jest.Mock).mockImplementation(
+            async (addr: string) => addr === 'bc1qbob' ? null : { address: addr, email: `${addr}@v.l`, verifiedAt: Date.now(), createdAt: Date.now(), updatedAt: Date.now() },
+        );
+        await expect(service.addMember(group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 4800,
+        }, adminToken)).rejects.toMatchObject({ code: 'email-not-verified' });
+    });
+
+    it('refuses addMember when the candidate address is in a PPLNS group', async () => {
+        const { service, groupService } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        (groupService.getGroupForAddress as jest.Mock).mockImplementation(
+            (addr: string) => addr === 'bc1qbob' ? { groupId: 'pp-1', active: true } : undefined,
+        );
+        await expect(service.addMember(group.id, {
+            address: 'bc1qbob', email: 'bob@b.c', percentBp: 4800,
+        }, adminToken)).rejects.toMatchObject({ code: 'address-in-pplns-group' });
+    });
+
+    // ── Address lookup cache ───────────────────────────────────────
+
+    it('getGroupIdForAdminAddress resolves the right group while live and clears on dissolve', async () => {
+        const { service } = await buildService();
+        const { group, adminToken } = await service.createGroup({
+            name: 'grp', adminAddress: 'bc1qadmin', adminEmail: 'a@b.c', adminPercentBp: 5000,
+        });
+        expect(service.getGroupIdForAdminAddress('bc1qadmin')).toBe(group.id);
+
+        await service.dissolveGroup(group.id, adminToken);
+        expect(service.getGroupIdForAdminAddress('bc1qadmin')).toBeUndefined();
+    });
+});

--- a/src/services/blockparty.service.ts
+++ b/src/services/blockparty.service.ts
@@ -1,0 +1,804 @@
+import { Injectable, OnModuleInit, Inject, forwardRef } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as crypto from 'crypto';
+
+import { BlockpartyGroupEntity, BlockpartyStatus } from '../ORM/blockparty/blockparty-group.entity';
+import { BlockpartyMemberEntity } from '../ORM/blockparty/blockparty-member.entity';
+import {
+    BlockpartyBlockHistoryEntity,
+    BlockpartySplitSnapshot,
+} from '../ORM/blockparty/blockparty-block-history.entity';
+import { normalizeBtcAddress } from '../utils/btc-address.utils';
+import { resolveMinPayoutSats } from './coinbase-distribution';
+import {
+    BlockpartyDistributionResult,
+    buildBlockpartyDistribution,
+} from './blockparty-distribution';
+import { GroupService } from './group.service';
+import { AddressEmailService } from './address-email.service';
+
+const MIN_PERCENT_BP = 100;    // 1 %
+const MAX_PERCENT_BP = 10000;  // 100 % (solo admin = sole member)
+const TOTAL_PERCENT_BP = 10000;
+
+const NAME_MIN_LEN = 3;
+const NAME_MAX_LEN = 64;
+const EMAIL_MAX_LEN = 320;
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+// 7-day post-share lock before the admin can dissolve. A failed rental
+// (provider drops, no-fill) lets the admin take a refund and re-buy
+// hashrate within typical 2-3 day turnarounds — a 24h cooldown wasn't
+// enough headroom for that recovery path. 7 days covers it generously.
+const DISSOLVE_COOLDOWN_MS = 7 * 24 * MS_PER_HOUR;
+
+const EDITABLE_STATES: ReadonlyArray<BlockpartyStatus> = ['draft', 'confirming', 'ready'];
+
+export class BlockpartyServiceError extends Error {
+    constructor(public readonly code: string, message: string) {
+        super(message);
+    }
+}
+
+export interface BlockpartyCreateResult {
+    group: BlockpartyGroupEntity;
+    /** Plain-text admin token — shown to the creator exactly once. */
+    adminToken: string;
+}
+
+export interface BlockpartyMemberInput {
+    address: string;
+    percentBp: number;
+    /**
+     * Optional. When omitted, the verified email binding for the address
+     * is used automatically (mirror of the Group-Solo invite flow).
+     * Pass-through retained so callers that know the email up-front can
+     * still set it explicitly.
+     */
+    email?: string;
+}
+
+@Injectable()
+export class BlockpartyService implements OnModuleInit {
+
+    private readonly feeAddress: string;
+    private readonly feePercent: number;
+    private readonly minPayoutSats: number;
+
+    /** address (lowercased) → groupId, refreshed on every membership change. */
+    private addressCache = new Map<string, string>();
+    /** admin address (lowercased) → { groupId, status } for fast share-path lookup. */
+    private adminAddressCache = new Map<string, { groupId: string; status: BlockpartyStatus }>();
+
+    constructor(
+        @InjectRepository(BlockpartyGroupEntity)
+        private readonly groupRepo: Repository<BlockpartyGroupEntity>,
+        @InjectRepository(BlockpartyMemberEntity)
+        private readonly memberRepo: Repository<BlockpartyMemberEntity>,
+        @InjectRepository(BlockpartyBlockHistoryEntity)
+        private readonly historyRepo: Repository<BlockpartyBlockHistoryEntity>,
+        private readonly configService: ConfigService,
+        @Inject(forwardRef(() => GroupService))
+        private readonly groupService: GroupService,
+        private readonly addressEmailService: AddressEmailService,
+    ) {
+        this.feeAddress = this.configService.get('PPLNS_FEE_ADDRESS') ?? '';
+        this.feePercent = parseFloat(this.configService.get('PPLNS_FEE_PERCENT') ?? '2');
+        this.minPayoutSats = resolveMinPayoutSats(this.configService.get('PPLNS_MIN_PAYOUT_SATS'));
+    }
+
+    async onModuleInit(): Promise<void> {
+        await this.rebuildCache();
+    }
+
+    private async rebuildCache(): Promise<void> {
+        const groups = await this.groupRepo.find();
+        const liveGroupIds = new Set(groups.filter(g => g.status !== 'dissolved').map(g => g.id));
+
+        const members = await this.memberRepo.find();
+        const addrCache = new Map<string, string>();
+        for (const m of members) {
+            if (!liveGroupIds.has(m.groupId)) continue;
+            addrCache.set(m.address, m.groupId);
+        }
+
+        const adminCache = new Map<string, { groupId: string; status: BlockpartyStatus }>();
+        for (const g of groups) {
+            if (g.status === 'dissolved') continue;
+            adminCache.set(g.adminAddress, { groupId: g.id, status: g.status });
+        }
+        this.addressCache = addrCache;
+        this.adminAddressCache = adminCache;
+    }
+
+    // ── Token helpers ─────────────────────────────────────────────
+
+    private generateToken(): string {
+        return 'BP-' + crypto.randomBytes(24).toString('base64url');
+    }
+
+    private generateMemberToken(): string {
+        return 'BPM-' + crypto.randomBytes(24).toString('base64url');
+    }
+
+    private hashToken(token: string): string {
+        return crypto.createHash('sha256').update(token).digest('hex');
+    }
+
+    private verifyToken(providedToken: string, storedHash: string): boolean {
+        const providedHash = this.hashToken(providedToken);
+        if (providedHash.length !== storedHash.length) return false;
+        return crypto.timingSafeEqual(Buffer.from(providedHash), Buffer.from(storedHash));
+    }
+
+    async requireAdminToken(groupId: string, token: string | undefined): Promise<BlockpartyGroupEntity> {
+        if (!token) {
+            throw new BlockpartyServiceError('missing-token', 'Admin token required');
+        }
+        const group = await this.groupRepo.findOneBy({ id: groupId });
+        if (!group) {
+            throw new BlockpartyServiceError('not-found', 'Blockparty not found');
+        }
+        if (!this.verifyToken(token, group.adminTokenHash)) {
+            throw new BlockpartyServiceError('invalid-token', 'Invalid admin token');
+        }
+        return group;
+    }
+
+    // ── Read paths ────────────────────────────────────────────────
+
+    getGroupIdForAddress(address: string): string | undefined {
+        return this.addressCache.get(normalizeBtcAddress(address));
+    }
+
+    getGroupIdForAdminAddress(address: string): string | undefined {
+        return this.adminAddressCache.get(normalizeBtcAddress(address))?.groupId;
+    }
+
+    /**
+     * Wire-level routing helper for the Stratum layer. Returns the active
+     * groupId for the address ONLY if the party status permits coinbase
+     * emission (i.e. confirming, ready, or active). Skips draft (admin
+     * hasn't finalised splits yet) and dissolved (terminal).
+     *
+     * Reading from the in-memory cache keeps this O(1) per share — share
+     * frequency at 1-3 rental proxies/party is moderate but still the
+     * hottest path the Blockparty engine touches.
+     */
+    getRoutableGroupIdForAdmin(address: string): string | undefined {
+        const entry = this.adminAddressCache.get(normalizeBtcAddress(address));
+        if (!entry) return undefined;
+        if (entry.status === 'draft' || entry.status === 'dissolved') return undefined;
+        return entry.groupId;
+    }
+
+    async getGroup(groupId: string): Promise<BlockpartyGroupEntity | null> {
+        return this.groupRepo.findOneBy({ id: groupId });
+    }
+
+    async listMembers(groupId: string): Promise<BlockpartyMemberEntity[]> {
+        return this.memberRepo.find({ where: { groupId }, order: { createdAt: 'ASC' } });
+    }
+
+    async listGroups(): Promise<BlockpartyGroupEntity[]> {
+        return this.groupRepo.find({ order: { createdAt: 'DESC' } });
+    }
+
+    async getHistory(groupId: string): Promise<BlockpartyBlockHistoryEntity[]> {
+        return this.historyRepo.find({ where: { groupId }, order: { foundAt: 'DESC' } });
+    }
+
+    /** Read-only access to the configured pool fee percent (e.g. 2). */
+    getPoolFeePercent(): number {
+        return this.feePercent;
+    }
+
+    // ── Lifecycle ────────────────────────────────────────────────
+
+    /**
+     * Create a draft Blockparty. The creator (treasury-address owner) is
+     * inserted as the first member with `role='admin'`, percentBp from
+     * `adminPercentBp`. Additional members are added with `addMember` —
+     * percentBp must sum to (10000 − feePercent×100) before transition out
+     * of DRAFT.
+     */
+    async createGroup(params: {
+        name: string;
+        adminAddress: string;
+        adminEmail: string;
+        adminPercentBp: number;
+    }): Promise<BlockpartyCreateResult> {
+        const trimmedName = params.name?.trim();
+        if (!trimmedName || trimmedName.length < NAME_MIN_LEN || trimmedName.length > NAME_MAX_LEN) {
+            throw new BlockpartyServiceError('invalid-name', `Name must be ${NAME_MIN_LEN}-${NAME_MAX_LEN} characters`);
+        }
+        if (/[\x00-\x1f\x7f]/.test(trimmedName)) {
+            throw new BlockpartyServiceError('invalid-name', 'Name must not contain control characters');
+        }
+
+        const normalizedAdmin = normalizeBtcAddress(params.adminAddress);
+        if (!normalizedAdmin) {
+            throw new BlockpartyServiceError('invalid-address', 'Admin address required');
+        }
+
+        this.assertEmailShape(params.adminEmail);
+        this.assertPercentBpInRange(params.adminPercentBp);
+
+        const nameClash = await this.groupRepo.findOneBy({ name: trimmedName });
+        if (nameClash) {
+            throw new BlockpartyServiceError('name-taken', 'Blockparty name already in use');
+        }
+        const addrClash = await this.groupRepo.findOneBy({ adminAddress: normalizedAdmin });
+        if (addrClash) {
+            throw new BlockpartyServiceError('admin-address-taken', 'Admin address already runs a Blockparty');
+        }
+        const memberClash = await this.memberRepo.findOneBy({ address: normalizedAdmin });
+        if (memberClash) {
+            throw new BlockpartyServiceError('address-in-blockparty', 'Address is already a member of a Blockparty');
+        }
+        this.assertNotInPplnsGroup(normalizedAdmin);
+
+        const adminToken = this.generateToken();
+        const group = await this.groupRepo.save(this.groupRepo.create({
+            id: crypto.randomUUID(),
+            name: trimmedName,
+            adminAddress: normalizedAdmin,
+            adminTokenHash: this.hashToken(adminToken),
+            status: 'draft',
+            lastShareAt: null,
+            dissolvedAt: null,
+        }));
+
+        await this.memberRepo.save(this.memberRepo.create({
+            groupId: group.id,
+            address: normalizedAdmin,
+            email: params.adminEmail.trim().toLowerCase(),
+            percentBp: params.adminPercentBp,
+            role: 'admin',
+            confirmedAt: Date.now(),
+        }));
+
+        await this.rebuildCache();
+        return { group, adminToken };
+    }
+
+    async addMember(
+        groupId: string,
+        member: BlockpartyMemberInput,
+        token: string | undefined,
+    ): Promise<BlockpartyMemberEntity> {
+        const group = await this.requireAdminToken(groupId, token);
+        this.assertEditable(group);
+
+        const normalized = normalizeBtcAddress(member.address);
+        if (!normalized) {
+            throw new BlockpartyServiceError('invalid-address', 'Address required');
+        }
+        if (normalized === group.adminAddress) {
+            throw new BlockpartyServiceError('admin-cannot-rejoin', 'Admin is already a member');
+        }
+        this.assertPercentBpInRange(member.percentBp);
+
+        const memberClash = await this.memberRepo.findOneBy({ address: normalized });
+        if (memberClash) {
+            throw new BlockpartyServiceError('address-in-blockparty', 'Address is already a member of a Blockparty');
+        }
+        this.assertNotInPplnsGroup(normalized);
+        // Email is ALWAYS pulled from the verified binding — admin input
+        // is ignored even if supplied. This matches Group-Solo's invite
+        // flow and avoids the failure mode where a controller forwards
+        // an empty string and the service treats it as "supplied but
+        // bad". The binding email is the canonical source of truth.
+        const binding = await this.addressEmailService.getVerified(normalized);
+        if (!binding) {
+            throw new BlockpartyServiceError(
+                'email-not-verified',
+                'Address has no verified email. The invitee must bind + verify an email in their settings first.',
+            );
+        }
+        const resolvedEmail = binding.email.toLowerCase();
+
+        let saved: BlockpartyMemberEntity;
+        try {
+            saved = await this.memberRepo.save(this.memberRepo.create({
+                groupId,
+                address: normalized,
+                email: resolvedEmail,
+                percentBp: member.percentBp,
+                role: 'member',
+                confirmedAt: null,
+            }));
+        } catch (err: any) {
+            // Concurrent admin clicks can race past the findOneBy check
+            // above. The unique index on member.address catches it as
+            // 23505 — surface as a typed error so the UI shows the
+            // address-collision toast instead of a generic 500.
+            if (err?.code === '23505' || err?.driverError?.code === '23505') {
+                throw new BlockpartyServiceError('address-in-blockparty', 'Address is already a member of a Blockparty');
+            }
+            throw err;
+        }
+
+        // First member added to a DRAFT party promotes it to CONFIRMING —
+        // the manual "send invitations" button is gone, the act of adding
+        // a member IS the trigger. assertSplitsSumValid is intentionally
+        // NOT called here: the admin can stage the party incrementally
+        // and the splits-save action validates separately. CONFIRMING ↔
+        // READY then auto-transitions via recomputeStatus.
+        if (group.status === 'draft') {
+            group.status = 'confirming';
+            group.updatedAt = Date.now();
+            await this.groupRepo.save(group);
+        }
+        await this.recomputeStatus(groupId);
+        await this.rebuildCache();
+        return saved;
+    }
+
+    async removeMember(groupId: string, address: string, token: string | undefined): Promise<void> {
+        const group = await this.requireAdminToken(groupId, token);
+        this.assertEditable(group);
+
+        const normalized = normalizeBtcAddress(address);
+        if (!normalized) {
+            throw new BlockpartyServiceError('invalid-address', 'Address required');
+        }
+        const member = await this.memberRepo.findOneBy({ groupId, address: normalized });
+        if (!member) {
+            throw new BlockpartyServiceError('not-member', 'Address is not a member of this Blockparty');
+        }
+        if (member.role === 'admin') {
+            throw new BlockpartyServiceError('admin-cannot-be-removed', 'Admin must dissolve the party to leave');
+        }
+
+        await this.memberRepo.delete({ id: member.id });
+        await this.recomputeStatus(groupId);
+        await this.rebuildCache();
+    }
+
+    /**
+     * Set new percentBp values for one or more members. Non-admin members'
+     * confirmations are reset (transparency: any %-change shifts the
+     * deal they agreed to). The ADMIN row keeps its confirmedAt — the
+     * admin authored the edit, so their participation in the new shape
+     * is implicit. The percentBp itself is still written for the admin
+     * row if supplied. Sum check still requires 10000 = 100 % of miner cut.
+     */
+    async updateSplits(
+        groupId: string,
+        updates: Array<{ address: string; percentBp: number }>,
+        token: string | undefined,
+    ): Promise<void> {
+        const group = await this.requireAdminToken(groupId, token);
+        this.assertEditable(group);
+
+        const normalizedUpdates = updates.map(u => {
+            const normalized = normalizeBtcAddress(u.address);
+            if (!normalized) {
+                throw new BlockpartyServiceError('invalid-address', `Invalid address ${u.address}`);
+            }
+            this.assertPercentBpInRange(u.percentBp);
+            return { address: normalized, percentBp: u.percentBp };
+        });
+
+        const adminAddress = group.adminAddress;
+
+        await this.memberRepo.manager.transaction(async em => {
+            const repo = em.getRepository(this.memberRepo.target);
+            // Iterate the full member set so we can apply both edits
+            // and confirmation-reset in a single per-row update —
+            // avoids relying on createQueryBuilder for the WHERE-NOT
+            // case (cleaner to mock + simpler to reason about).
+            const all = await repo.find({ where: { groupId } });
+            const editByAddress = new Map(normalizedUpdates.map(u => [u.address, u.percentBp]));
+            // Defensive: every supplied address must actually be a member.
+            for (const u of normalizedUpdates) {
+                if (!all.some((m: any) => m.address === u.address)) {
+                    throw new BlockpartyServiceError('not-member', `${u.address} is not a member`);
+                }
+            }
+            const now = Date.now();
+            for (const m of all as any[]) {
+                const patch: Record<string, any> = { updatedAt: now };
+                const newPercent = editByAddress.get(m.address);
+                if (newPercent != null) patch['percentBp'] = newPercent;
+                // Admin row: refresh confirmedAt explicitly — the edit IS
+                // the admin's consent to this new splits version. Forcing
+                // the timestamp also self-heals any pre-fix data where
+                // confirmedAt might have been null.
+                // Non-admin rows: reset so members re-acknowledge.
+                if (m.address === adminAddress) {
+                    patch['confirmedAt'] = now;
+                } else {
+                    patch['confirmedAt'] = null;
+                }
+                await repo.update({ id: m.id }, patch);
+            }
+        });
+
+        await this.recomputeStatus(groupId);
+    }
+
+    /**
+     * Mark a single member as confirmed. Used by the invitation-accept
+     * flow (step 4) — the caller has already verified the invitation
+     * token, so no admin-token check here.
+     *
+     * Mints a persistent member-token on first accept (when no
+     * memberTokenHash exists yet) so subsequent re-confirms (after admin
+     * %-edits) and gated read access don't need a fresh invitation cycle.
+     * The plain token is returned exactly once — callers must surface it
+     * to the recipient.
+     */
+    /**
+     * Wipe the member's onboarding state — memberTokenHash + confirmedAt —
+     * so the next markMemberConfirmed re-mints a fresh BPM-... token. The
+     * lost-token recovery path: admin clicks Resend, this clears the
+     * old hash, recipient re-accepts via the new invitation link, and
+     * the accept flow surfaces a new plain token exactly once. Idempotent
+     * on members that haven't onboarded yet (no-op).
+     */
+    async resetMemberOnboarding(groupId: string, address: string): Promise<void> {
+        const normalized = normalizeBtcAddress(address);
+        if (!normalized) {
+            throw new BlockpartyServiceError('invalid-address', 'Address required');
+        }
+        const member = await this.memberRepo.findOneBy({ groupId, address: normalized });
+        if (!member) return; // resend on a non-member is the caller's bug, not ours
+        if (member.memberTokenHash == null && member.confirmedAt == null) return;
+        member.memberTokenHash = null;
+        member.confirmedAt = null;
+        member.updatedAt = Date.now();
+        await this.memberRepo.save(member);
+        await this.recomputeStatus(groupId);
+    }
+
+    async markMemberConfirmed(groupId: string, address: string): Promise<{ memberToken: string | null }> {
+        const normalized = normalizeBtcAddress(address);
+        if (!normalized) {
+            throw new BlockpartyServiceError('invalid-address', 'Address required');
+        }
+        const member = await this.memberRepo.findOneBy({ groupId, address: normalized });
+        if (!member) {
+            throw new BlockpartyServiceError('not-member', 'Address is not a member of this Blockparty');
+        }
+
+        let mintedPlain: string | null = null;
+        if (member.memberTokenHash == null) {
+            mintedPlain = this.generateMemberToken();
+            member.memberTokenHash = this.hashToken(mintedPlain);
+        }
+
+        if (member.confirmedAt == null) {
+            member.confirmedAt = Date.now();
+        }
+        member.updatedAt = Date.now();
+        await this.memberRepo.save(member);
+        await this.recomputeStatus(groupId);
+        return { memberToken: mintedPlain };
+    }
+
+    /**
+     * Re-confirm an existing member after an admin %-edit reset the
+     * confirmation. Authenticated with the persistent member token issued
+     * on first accept — no invitation cycle needed for follow-up confirms.
+     * Idempotent: a second call while already confirmed is a no-op.
+     */
+    async confirmAsMember(groupId: string, address: string, memberToken: string | undefined): Promise<void> {
+        await this.requireMemberToken(groupId, address, memberToken);
+        const normalized = normalizeBtcAddress(address);
+        const member = await this.memberRepo.findOneBy({ groupId, address: normalized });
+        if (!member) {
+            throw new BlockpartyServiceError('not-member', 'Address is not a member of this Blockparty');
+        }
+        if (member.confirmedAt != null) return;
+        member.confirmedAt = Date.now();
+        member.updatedAt = Date.now();
+        await this.memberRepo.save(member);
+        await this.recomputeStatus(groupId);
+    }
+
+    /**
+     * Auth helper for member-scoped operations. Returns the member row
+     * on success; throws on missing/invalid token. Constant-time hash
+     * compare — same pattern as the admin token.
+     */
+    async requireMemberToken(
+        groupId: string,
+        address: string,
+        token: string | undefined,
+    ): Promise<BlockpartyMemberEntity> {
+        if (!token) {
+            throw new BlockpartyServiceError('missing-member-token', 'Member token required');
+        }
+        const normalized = normalizeBtcAddress(address);
+        const member = await this.memberRepo.findOneBy({ groupId, address: normalized });
+        if (!member) {
+            throw new BlockpartyServiceError('not-member', 'Address is not a member of this Blockparty');
+        }
+        if (member.memberTokenHash == null) {
+            throw new BlockpartyServiceError('member-not-confirmed', 'Member has not accepted the invitation yet');
+        }
+        if (!this.verifyToken(token, member.memberTokenHash)) {
+            throw new BlockpartyServiceError('invalid-member-token', 'Invalid member token');
+        }
+        return member;
+    }
+
+    async updateRentalProviderHint(
+        groupId: string,
+        hint: string | null,
+        token: string | undefined,
+    ): Promise<BlockpartyGroupEntity> {
+        const group = await this.requireAdminToken(groupId, token);
+        const cleaned = hint == null ? null : hint.trim().slice(0, 64);
+        group.rentalProviderHint = cleaned && cleaned.length > 0 ? cleaned : null;
+        group.updatedAt = Date.now();
+        return this.groupRepo.save(group);
+    }
+
+
+    /**
+     * Move the group from DRAFT to CONFIRMING. The invitation-send flow
+     * (step 4) calls this after persisting the per-member invitation tokens.
+     * Validates the splits sum is consistent with the configured pool fee
+     * before allowing the transition.
+     */
+    async transitionToConfirming(groupId: string, token: string | undefined): Promise<void> {
+        const group = await this.requireAdminToken(groupId, token);
+        // ACTIVE / DISSOLVED states are terminal — refuse. CONFIRMING /
+        // READY are accepted as no-op (already past the transition; the
+        // new flow auto-flips on first addMember). DRAFT does the
+        // original explicit transition.
+        if (group.status === 'active' || group.status === 'dissolved') {
+            throw new BlockpartyServiceError(
+                'invalid-state',
+                `Cannot transition to CONFIRMING from ${group.status}`,
+            );
+        }
+        await this.assertSplitsSumValid(groupId);
+        if (group.status === 'confirming' || group.status === 'ready') {
+            return;
+        }
+        group.status = 'confirming';
+        group.updatedAt = Date.now();
+        await this.groupRepo.save(group);
+        // Subsequent confirmations may push us straight to READY.
+        await this.recomputeStatus(groupId);
+    }
+
+    async dissolveGroup(groupId: string, token: string | undefined): Promise<void> {
+        const group = await this.requireAdminToken(groupId, token);
+        if (group.status === 'dissolved') return; // idempotent
+
+        if (group.status === 'active') {
+            const last = group.lastShareAt ?? 0;
+            const elapsed = Date.now() - last;
+            if (elapsed < DISSOLVE_COOLDOWN_MS) {
+                const hoursLeft = Math.ceil((DISSOLVE_COOLDOWN_MS - elapsed) / MS_PER_HOUR);
+                const daysLeft = Math.ceil(hoursLeft / 24);
+                throw new BlockpartyServiceError(
+                    'dissolve-cooldown',
+                    `Dissolve allowed only after 7 days of hashrate silence — ~${daysLeft} day(s) remaining`,
+                );
+            }
+        }
+
+        group.status = 'dissolved';
+        group.dissolvedAt = Date.now();
+        group.updatedAt = Date.now();
+        await this.groupRepo.save(group);
+        await this.rebuildCache();
+    }
+
+    // ── Share / Block hooks ──────────────────────────────────────
+
+    /**
+     * Called from the share-accept path. Stratum supplies the miner address
+     * — Blockparty mode is triggered when that equals the admin treasury
+     * address of an active blockparty. Side effects:
+     *   - refresh `lastShareAt` (drives the 7-day dissolve cooldown)
+     *   - first share transitions READY (or CONFIRMING, if admin chose to
+     *     start without all confirmations) → ACTIVE, permanently freezing
+     *     the splits.
+     */
+    async onShareAccepted(adminAddress: string): Promise<void> {
+        const normalized = normalizeBtcAddress(adminAddress);
+        if (!normalized) return;
+        const cached = this.adminAddressCache.get(normalized);
+        if (!cached) return;
+
+        const group = await this.groupRepo.findOneBy({ id: cached.groupId });
+        if (!group || group.status === 'dissolved') return;
+
+        const now = Date.now();
+        const shouldActivate = group.status === 'ready' || group.status === 'confirming' || group.status === 'draft';
+
+        group.lastShareAt = now;
+        if (shouldActivate) {
+            group.status = 'active';
+        }
+        group.updatedAt = now;
+        await this.groupRepo.save(group);
+
+        // Cache the new status so subsequent share-path lookups see it
+        // without re-hitting the DB.
+        this.adminAddressCache.set(normalized, { groupId: group.id, status: group.status });
+    }
+
+    /**
+     * Compute the per-member payout split for a found block. Pure read —
+     * use the result to build coinbase outputs at template time. Cached
+     * in callers if needed; no cache here because the inputs (member list,
+     * percentBp, feePercent) are stable while the group is ACTIVE.
+     */
+    async getPayoutDistribution(
+        groupId: string,
+        blockRewardSats: number,
+    ): Promise<BlockpartyDistributionResult> {
+        const members = await this.listMembers(groupId);
+        return buildBlockpartyDistribution({
+            members: members.map(m => ({ address: m.address, percentBp: m.percentBp })),
+            blockRewardSats,
+            poolFeeAddress: this.feeAddress,
+            poolFeePercent: this.feePercent,
+            minPayoutSats: this.minPayoutSats,
+        });
+    }
+
+    /**
+     * Record a found block. Idempotent — relies on the unique index on
+     * (groupId, blockHash). Returns null when the row already exists.
+     *
+     * Wire-friendly signature: the Stratum layer passes the on-chain
+     * block hash (`bitcoinjs.Block.getId()`); the per-member split is
+     * recomputed internally from current `percentBp` values. No
+     * pre-snapshot needed because Blockparty distribution is purely
+     * function-of-membership (no shares).
+     */
+    async onBlockFound(params: {
+        groupId: string;
+        blockHeight: number;
+        blockHash: string;
+        coinbaseValueSats: number;
+        /** Defaults to Date.now() when omitted. */
+        foundAt?: number;
+    }): Promise<BlockpartyBlockHistoryEntity | null> {
+        const distribution = await this.getPayoutDistribution(params.groupId, params.coinbaseValueSats);
+        const splits: BlockpartySplitSnapshot[] = distribution.splits.map(s => ({
+            address: s.address,
+            percentBp: s.percentBp,
+            sats: s.sats,
+            ...(s.trimmed ? { trimmed: true } : {}),
+        }));
+
+        try {
+            const row = await this.historyRepo.save(this.historyRepo.create({
+                groupId: params.groupId,
+                blockHeight: params.blockHeight,
+                blockHash: params.blockHash,
+                foundAt: params.foundAt ?? Date.now(),
+                coinbaseValueSats: params.coinbaseValueSats,
+                poolFeeSats: distribution.poolFeeSats,
+                splits,
+            }));
+            return row;
+        } catch (err) {
+            if ((err as { code?: string }).code === '23505') {
+                // Race: another caller wrote the same (groupId, blockHash). Idempotent no-op.
+                return null;
+            }
+            throw err;
+        }
+    }
+
+    // ── Validation helpers ──────────────────────────────────────
+
+    /**
+     * Reject the address if there's no verified email binding for it.
+     * Mirrors PPLNS-group invitation policy: invitees must have proved
+     * control of an email address before an admin can pull them into a
+     * payout group — protects against doxxing-by-invitation (an admin
+     * cannot send mail to an arbitrary email pretending to be the
+     * invitee).
+     */
+    private async assertEmailVerified(address: string): Promise<void> {
+        const binding = await this.addressEmailService.getVerified(address);
+        if (!binding) {
+            throw new BlockpartyServiceError(
+                'email-not-verified',
+                'Address has no verified email. The invitee must bind + verify an email in their settings first.',
+            );
+        }
+    }
+
+    /**
+     * Reject the address if it's already a member of any active
+     * PPLNS-group (which covers Group-Solo too). The check uses the
+     * GroupService in-memory cache populated at startup — same source
+     * of truth the stratum routing layer reads. An address can be in
+     * at most one membership-driven mode at a time.
+     */
+    private assertNotInPplnsGroup(address: string): void {
+        const entry = this.groupService.getGroupForAddress(address);
+        if (entry) {
+            throw new BlockpartyServiceError(
+                'address-in-pplns-group',
+                'Address is already a member of a PPLNS group — leave that group first',
+            );
+        }
+    }
+
+    private assertEditable(group: BlockpartyGroupEntity): void {
+        if (!EDITABLE_STATES.includes(group.status)) {
+            throw new BlockpartyServiceError(
+                'not-editable',
+                `Blockparty is ${group.status} — edits are no longer permitted`,
+            );
+        }
+    }
+
+    private assertPercentBpInRange(percentBp: number): void {
+        if (!Number.isInteger(percentBp) || percentBp < MIN_PERCENT_BP || percentBp > MAX_PERCENT_BP) {
+            throw new BlockpartyServiceError(
+                'invalid-percent',
+                `percentBp must be an integer in [${MIN_PERCENT_BP}, ${MAX_PERCENT_BP}] (basis points, 100=1%)`,
+            );
+        }
+    }
+
+    private assertEmailShape(email: string): void {
+        const trimmed = email?.trim().toLowerCase();
+        if (!trimmed || trimmed.length > EMAIL_MAX_LEN) {
+            throw new BlockpartyServiceError('invalid-email', 'Email required');
+        }
+        // Minimal sanity check — full RFC validation lives in EmailService.
+        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+            throw new BlockpartyServiceError('invalid-email', 'Email format invalid');
+        }
+    }
+
+    /**
+     * Members' percentBp represents their share of the *miner cut*
+     * (= block reward minus pool fee). Sum must equal TOTAL_PERCENT_BP
+     * (= 10000 = 100 %). The pool fee is deducted by buildBlockpartyDistribution
+     * before splits are applied; members never see it on the percentage
+     * scale they're configuring. Solo admin → 10000 (sole member).
+     */
+    private async assertSplitsSumValid(groupId: string): Promise<void> {
+        const members = await this.memberRepo.find({ where: { groupId } });
+        if (members.length === 0) {
+            throw new BlockpartyServiceError('no-members', 'Blockparty has no members');
+        }
+        const actual = members.reduce((acc, m) => acc + m.percentBp, 0);
+        if (actual !== TOTAL_PERCENT_BP) {
+            throw new BlockpartyServiceError(
+                'invalid-splits-sum',
+                `Sum of member percentBp must equal ${TOTAL_PERCENT_BP} (100 % of miner cut, current: ${actual})`,
+            );
+        }
+    }
+
+    /**
+     * CONFIRMING vs READY is computed: when every member has confirmedAt,
+     * the group is READY; otherwise CONFIRMING. No automatic transition
+     * back to DRAFT — once invitations have gone out, the editing model
+     * is "edit-with-confirmation-reset", not "back to scratch".
+     */
+    private async recomputeStatus(groupId: string): Promise<void> {
+        const group = await this.groupRepo.findOneBy({ id: groupId });
+        if (!group) return;
+        if (group.status !== 'confirming' && group.status !== 'ready') return;
+
+        const members = await this.memberRepo.find({ where: { groupId } });
+        const allConfirmed = members.length > 0 && members.every(m => m.confirmedAt != null);
+        const target: BlockpartyStatus = allConfirmed ? 'ready' : 'confirming';
+        if (group.status !== target) {
+            group.status = target;
+            group.updatedAt = Date.now();
+            await this.groupRepo.save(group);
+        }
+    }
+}

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -379,6 +379,18 @@ function renderVerificationText(ctx: VerificationEmailContext): string {
     ].join('\n');
 }
 
+/**
+ * Shorten a BTC address for display ("bc1q…3kd9"). Mirrors the UI's
+ * `formatBtcAddress` helper so members see the same shape across
+ * email + dashboard. Pure cosmetic — the canonical full address still
+ * lives in the DB row and on the actual coinbase output.
+ */
+function obfuscateBtcAddress(address: string): string {
+    const trimmed = address?.trim() ?? '';
+    if (trimmed.length <= 9) return trimmed;
+    return `${trimmed.slice(0, 4)}…${trimmed.slice(-5)}`;
+}
+
 function renderInvitationHtml(ctx: InvitationEmailContext): string {
     const expires = ctx.expiresAt.toUTCString();
     const body = `
@@ -394,7 +406,7 @@ function renderInvitationHtml(ctx: InvitationEmailContext): string {
     </p>
     <p style="margin:0 0 8px;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:${COLOR_MUTED};">Invited by</p>
     <p style="margin:0;font-family:'Roboto Mono',monospace;font-size:13px;color:${COLOR_TEXT};word-break:break-all;">
-      ${escapeHtml(ctx.inviterAddress)}
+      ${escapeHtml(obfuscateBtcAddress(ctx.inviterAddress))}
     </p>
   </td></tr>
 </table>
@@ -422,7 +434,7 @@ function renderInvitationText(ctx: InvitationEmailContext): string {
         `You've been invited to join the payout group "${sanitizeHeader(ctx.groupName)}" on Blitz Pool.`,
         ``,
         `Your address: ${ctx.address}`,
-        `Invited by:   ${ctx.inviterAddress}`,
+        `Invited by:   ${obfuscateBtcAddress(ctx.inviterAddress)}`,
         ``,
         `Open the invitation: ${ctx.inviteUrl}`,
         ``,

--- a/src/services/group.service.spec.ts
+++ b/src/services/group.service.spec.ts
@@ -106,6 +106,7 @@ describe('GroupService', () => {
     let memberRepo: ReturnType<typeof createMockRepo>;
     let groupSolo: ReturnType<typeof createMockGroupSolo>;
     let roundReset: { applyConfig: jest.Mock; unschedule: jest.Mock };
+    let blockpartyService: { getGroupIdForAddress: jest.Mock };
     let service: GroupService;
 
     beforeEach(async () => {
@@ -113,6 +114,7 @@ describe('GroupService', () => {
         memberRepo = createMockRepo('member');
         groupSolo = createMockGroupSolo();
         roundReset = { applyConfig: jest.fn(), unschedule: jest.fn() };
+        blockpartyService = { getGroupIdForAddress: jest.fn(() => undefined) };
 
         // Simulated EntityManager: every getRepository(target) hands back
         // the SAME mock instance keyed by `target`, so writes inside the
@@ -139,6 +141,7 @@ describe('GroupService', () => {
             config as any,
             groupSolo as any,
             roundReset as any,
+            blockpartyService as any,
         );
         await service.onModuleInit();
     });
@@ -170,6 +173,23 @@ describe('GroupService', () => {
         await service.createGroup('group-one', 'bc1qalice');
         await expect(service.createGroup('group-two', 'bc1qalice'))
             .rejects.toMatchObject({ code: 'address-in-group' });
+    });
+
+    it('rejects createGroup when the creator address is in a Blockparty', async () => {
+        blockpartyService.getGroupIdForAddress.mockImplementation(
+            (addr: string) => addr === 'bc1qalice' ? 'bp-1' : undefined,
+        );
+        await expect(service.createGroup('group-x', 'bc1qalice'))
+            .rejects.toMatchObject({ code: 'address-in-blockparty' });
+    });
+
+    it('rejects addMember when the candidate address is in a Blockparty', async () => {
+        const { group, adminToken } = await service.createGroup('group-x', 'bc1qalice');
+        blockpartyService.getGroupIdForAddress.mockImplementation(
+            (addr: string) => addr === 'bc1qbob' ? 'bp-1' : undefined,
+        );
+        await expect(service.addMember(group.id, 'bc1qbob', adminToken))
+            .rejects.toMatchObject({ code: 'address-in-blockparty' });
     });
 
     // ── Token auth ──────────────────────────────────────────────

--- a/src/services/group.service.ts
+++ b/src/services/group.service.ts
@@ -7,6 +7,7 @@ import { PplnsGroupEntity } from '../ORM/pplns-group/pplns-group.entity';
 import { PplnsGroupMemberEntity } from '../ORM/pplns-group/pplns-group-member.entity';
 import { GroupSoloService } from './group-solo.service';
 import { GroupRoundResetService } from './group-round-reset.service';
+import { BlockpartyService } from './blockparty.service';
 import { normalizeBtcAddress } from '../utils/btc-address.utils';
 
 /**
@@ -107,6 +108,8 @@ export class GroupService implements OnModuleInit {
         private readonly groupSoloService: GroupSoloService,
         @Inject(forwardRef(() => GroupRoundResetService))
         private readonly roundResetService: GroupRoundResetService,
+        @Inject(forwardRef(() => BlockpartyService))
+        private readonly blockpartyService: BlockpartyService,
     ) {
         const raw = this.configService.get<string>('GROUP_INACTIVITY_KICK_DAYS');
         const parsed = raw ? parseInt(raw, 10) : NaN;
@@ -212,6 +215,7 @@ export class GroupService implements OnModuleInit {
         if (existingMember) {
             throw new GroupServiceError('address-in-group', 'Address is already a member of another group');
         }
+        this.assertNotInBlockparty(normalizedAddress);
 
         const adminToken = this.generateToken();
         const group = await this.groupRepo.save(this.groupRepo.create({
@@ -258,6 +262,7 @@ export class GroupService implements OnModuleInit {
             }
             throw new GroupServiceError('address-in-group', 'Address is already a member of another group');
         }
+        this.assertNotInBlockparty(normalizedAddress);
 
         const member = await this.memberRepo.save(this.memberRepo.create({
             groupId,
@@ -610,6 +615,21 @@ export class GroupService implements OnModuleInit {
             await this.groupRepo.save(group);
         }
         await this.rebuildCache();
+    }
+
+    /**
+     * Reject the address if it's already a member (admin or otherwise)
+     * of any active Blockparty. An address can only be in one
+     * membership-driven mode at a time.
+     */
+    private assertNotInBlockparty(address: string): void {
+        const blockpartyId = this.blockpartyService.getGroupIdForAddress(address);
+        if (blockpartyId) {
+            throw new GroupServiceError(
+                'address-in-blockparty',
+                'Address is already a member of a Blockparty — leave that party first',
+            );
+        }
     }
 
     private async recomputeActive(groupId: string): Promise<void> {

--- a/src/services/miner-active-mode.service.ts
+++ b/src/services/miner-active-mode.service.ts
@@ -98,7 +98,7 @@ export class MinerActiveModeService implements OnModuleInit {
         if (!this.redis || !address) return null;
         try {
             const raw = await this.redis.get(this.key(address));
-            if (raw === 'solo' || raw === 'pplns' || raw === 'group-solo') {
+            if (raw === 'solo' || raw === 'pplns' || raw === 'group-solo' || raw === 'blockparty') {
                 return raw;
             }
             return null;

--- a/src/services/mining-mode.service.spec.ts
+++ b/src/services/mining-mode.service.spec.ts
@@ -7,6 +7,8 @@ describe('MiningModeService.getMode', () => {
     function setup(opts: {
         distribution?: { address: string; difficulty: number; percent: number }[];
         groupForAddress?: Record<string, { groupId: string; active: boolean } | undefined>;
+        /** Admin-address → groupId map for Blockparty lookup. */
+        blockpartyAdmins?: Record<string, string>;
         /** Simulates the Redis port-marker set by the stratum layer. */
         liveMarker?: Record<string, MiningMode>;
     }) {
@@ -16,6 +18,9 @@ describe('MiningModeService.getMode', () => {
         const groupService = {
             getGroupForAddress: jest.fn((address: string) => opts.groupForAddress?.[address]),
         };
+        const blockpartyService = {
+            getGroupIdForAdminAddress: jest.fn((address: string) => opts.blockpartyAdmins?.[address]),
+        };
         const minerActiveModeService = {
             get: jest.fn(async (address: string) => opts.liveMarker?.[address] ?? null),
             mark: jest.fn(),
@@ -23,6 +28,7 @@ describe('MiningModeService.getMode', () => {
         return new MiningModeService(
             pplnsService as any,
             groupService as any,
+            blockpartyService as any,
             minerActiveModeService as any,
         );
     }
@@ -140,6 +146,39 @@ describe('MiningModeService.getMode', () => {
         expect(await svc.getMode('bc1qalice')).toEqual({ mode: 'group-solo', groupId: 'grp-1' });
     });
 
+    // ── Blockparty precedence ─────────────────────────────────────────
+
+    it('blockparty admin address resolves to blockparty mode via live marker', async () => {
+        const svc = setup({
+            blockpartyAdmins: { 'bc1qadmin': 'bp-1' },
+            liveMarker: { 'bc1qadmin': 'blockparty' },
+        });
+        expect(await svc.getMode('bc1qadmin')).toEqual({ mode: 'blockparty', groupId: 'bp-1' });
+    });
+
+    it('blockparty wins over group-solo and pplns in the legacy fallback', async () => {
+        // Same address is somehow listed in all three modes (impossible in
+        // practice with bidirectional collision checks, but the precedence
+        // must be deterministic if it ever happens — e.g. stale state).
+        const svc = setup({
+            blockpartyAdmins: { 'bc1qadmin': 'bp-1' },
+            groupForAddress: { 'bc1qadmin': { groupId: 'gs-1', active: true } },
+            distribution: [{ address: 'bc1qadmin', difficulty: 500, percent: 50 }],
+        });
+        expect(await svc.getMode('bc1qadmin')).toEqual({ mode: 'blockparty', groupId: 'bp-1' });
+    });
+
+    it('blockparty live marker falls through when the party was dissolved', async () => {
+        // Marker still in Redis for 5min but the party is gone — fallback
+        // to whatever the address ALSO matches in the legacy chain.
+        const svc = setup({
+            blockpartyAdmins: {}, // no live blockparty for this admin anymore
+            groupForAddress: { 'bc1qadmin': { groupId: 'gs-1', active: true } },
+            liveMarker: { 'bc1qadmin': 'blockparty' },
+        });
+        expect(await svc.getMode('bc1qadmin')).toEqual({ mode: 'group-solo', groupId: 'gs-1' });
+    });
+
     // ── Per-address result cache ──────────────────────────────────────
     // /api/pplns/mode/:address is uncached and polled per dashboard view.
     // Without the cache, every poll did Redis GET + (on miss) HGETALL over
@@ -153,6 +192,9 @@ describe('MiningModeService.getMode', () => {
         const groupService = {
             getGroupForAddress: jest.fn((address: string) => opts.groupForAddress?.[address]),
         };
+        const blockpartyService = {
+            getGroupIdForAdminAddress: jest.fn((address: string) => opts.blockpartyAdmins?.[address]),
+        };
         const minerActiveModeService = {
             get: jest.fn(async (address: string) => opts.liveMarker?.[address] ?? null),
             mark: jest.fn(),
@@ -160,9 +202,10 @@ describe('MiningModeService.getMode', () => {
         const svc = new MiningModeService(
             pplnsService as any,
             groupService as any,
+            blockpartyService as any,
             minerActiveModeService as any,
         );
-        return { svc, pplnsService, groupService, minerActiveModeService };
+        return { svc, pplnsService, groupService, blockpartyService, minerActiveModeService };
     }
 
     it('caches subsequent calls for the same address within 30s', async () => {

--- a/src/services/mining-mode.service.ts
+++ b/src/services/mining-mode.service.ts
@@ -2,13 +2,14 @@ import { Injectable } from '@nestjs/common';
 
 import { PplnsService } from './pplns.service';
 import { GroupService } from './group.service';
+import { BlockpartyService } from './blockparty.service';
 import { MinerActiveModeService } from './miner-active-mode.service';
 
-export type MiningMode = 'solo' | 'pplns' | 'group-solo';
+export type MiningMode = 'solo' | 'pplns' | 'group-solo' | 'blockparty';
 
 export interface MiningModeResult {
     mode: MiningMode;
-    /** Present only when mode === 'group-solo'. */
+    /** Present when mode === 'group-solo' or mode === 'blockparty'. */
     groupId?: string;
 }
 
@@ -24,9 +25,13 @@ export interface MiningModeResult {
  *
  *   2. Legacy state-based detection — for addresses without a live
  *      marker (offline miner, never mined here, etc.):
- *         a) PPLNS window shares → 'pplns'
+ *         a) Blockparty admin address → 'blockparty' (admin treasury
+ *            is the only address that triggers blockparty mining; regular
+ *            blockparty members aren't mining for the party, they're
+ *            passive payout recipients)
  *         b) Active group membership → 'group-solo'
- *         c) Otherwise → 'solo'
+ *         c) PPLNS window shares → 'pplns'
+ *         d) Otherwise → 'solo'
  *
  * Why the port-marker takes precedence: PPLNS window shares can linger
  * for hours after a miner switches ports, so state-based detection lags
@@ -53,6 +58,7 @@ export class MiningModeService {
     constructor(
         private readonly pplnsService: PplnsService,
         private readonly groupService: GroupService,
+        private readonly blockpartyService: BlockpartyService,
         private readonly minerActiveModeService: MinerActiveModeService,
     ) {}
 
@@ -76,6 +82,13 @@ export class MiningModeService {
     private async computeMode(address: string): Promise<MiningModeResult> {
         // Primary check: live port-marker.
         const liveMode = await this.minerActiveModeService.get(address);
+        if (liveMode === 'blockparty') {
+            const groupId = this.blockpartyService.getGroupIdForAdminAddress(address);
+            if (groupId) {
+                return { mode: 'blockparty', groupId };
+            }
+            // Marker still live but the party was dissolved meanwhile — fall through.
+        }
         if (liveMode === 'pplns') {
             return { mode: 'pplns' };
         }
@@ -93,12 +106,14 @@ export class MiningModeService {
         }
 
         // Fallback: no live marker — legacy state-based detection.
-        // Group-membership wins over residual PPLNS-window shares: group
-        // join is an intentional admin action while PPLNS shares may
-        // linger in the sliding 4× network-diff window from previous
-        // sessions on a PPLNS port. An address that's an active group
-        // member (creator or otherwise) must surface as group-solo so
-        // the UI routes to /payout-group instead of /payout-pplns.
+        // Blockparty wins over group-solo wins over residual PPLNS-window shares:
+        // both blockparty-admin and group membership are explicit opt-in actions
+        // while PPLNS shares may linger in the sliding 4× network-diff window
+        // from previous sessions on a PPLNS port.
+        const blockpartyId = this.blockpartyService.getGroupIdForAdminAddress(address);
+        if (blockpartyId) {
+            return { mode: 'blockparty', groupId: blockpartyId };
+        }
         const group = this.groupService.getGroupForAddress(address);
         if (group && group.active) {
             return { mode: 'group-solo', groupId: group.groupId };

--- a/src/services/stratum-v1.service.spec.ts
+++ b/src/services/stratum-v1.service.spec.ts
@@ -39,6 +39,7 @@ describe('StratumV1Service.onModuleInit', () => {
       { store: {} } as any,
       { isEnabled: () => false } as any,
       { isEnabled: () => false, getGroupForAddress: () => undefined } as any,
+      { getRoutableGroupIdForAdmin: () => undefined } as any,
       { mark: jest.fn(), get: jest.fn() } as any,
       { incrementAccepted: jest.fn(), getChart: jest.fn() } as any,
     );

--- a/src/services/stratum-v1.service.ts
+++ b/src/services/stratum-v1.service.ts
@@ -23,6 +23,7 @@ import { AddressSettingsCacheService } from './address-settings-cache.service';
 import { DifficultyScoresCacheService } from './difficulty-scores-cache.service';
 import { PplnsService } from './pplns.service';
 import { GroupSoloService } from './group-solo.service';
+import { BlockpartyService } from './blockparty.service';
 import { MinerActiveModeService } from './miner-active-mode.service';
 import { PoolModeHashrateService } from '../ORM/pool-mode-hashrate/pool-mode-hashrate.service';
 
@@ -51,6 +52,7 @@ export class StratumV1Service implements OnModuleInit {
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     private readonly pplnsService: PplnsService,
     private readonly groupSoloService: GroupSoloService,
+    private readonly blockpartyService: BlockpartyService,
     private readonly minerActiveModeService: MinerActiveModeService,
     private readonly poolModeHashrateService: PoolModeHashrateService,
   ) {}
@@ -115,6 +117,7 @@ export class StratumV1Service implements OnModuleInit {
       portConfig.payoutMode ?? 'solo',
       this.pplnsService,
       this.groupSoloService,
+      this.blockpartyService,
       this.minerActiveModeService,
       this.poolModeHashrateService,
       portConfig.minimumDifficulty ?? 0,

--- a/src/services/stratum-v2.service.spec.ts
+++ b/src/services/stratum-v2.service.spec.ts
@@ -66,6 +66,7 @@ function createService(envOverrides: Record<string, string> = {}) {
     {} as any, // jobDeclarationService
     { isEnabled: () => false } as any, // pplnsService
     { isEnabled: () => false, getGroupForAddress: () => undefined } as any, // groupSoloService
+    { getRoutableGroupIdForAdmin: () => undefined } as any, // blockpartyService
     { mark: jest.fn(), get: jest.fn() } as any, // minerActiveModeService
     { incrementAccepted: jest.fn(), getChart: jest.fn() } as any, // poolModeHashrateService
   );
@@ -302,6 +303,7 @@ describe('StratumV2Service', () => {
         expect.anything(), // templateDistributionService
         expect.anything(), // pplnsService
         expect.anything(), // groupSoloService
+        expect.anything(), // blockpartyService
         expect.anything(), // minerActiveModeService
         expect.anything(), // poolModeHashrateService
       );

--- a/src/services/stratum-v2.service.ts
+++ b/src/services/stratum-v2.service.ts
@@ -35,6 +35,7 @@ import { ClientDifficultyStatisticsService } from '../ORM/client-difficulty-stat
 import { ShareTotalsCacheService } from './share-totals-cache.service';
 import { PplnsService } from './pplns.service';
 import { GroupSoloService } from './group-solo.service';
+import { BlockpartyService } from './blockparty.service';
 import { MinerActiveModeService } from './miner-active-mode.service';
 import { PoolModeHashrateService } from '../ORM/pool-mode-hashrate/pool-mode-hashrate.service';
 import { DifficultyScoresCacheService } from './difficulty-scores-cache.service';
@@ -87,6 +88,7 @@ export class StratumV2Service implements OnModuleInit, IProtocolHandler {
     private readonly jobDeclarationService: JobDeclarationService,
     private readonly pplnsService: PplnsService,
     private readonly groupSoloService: GroupSoloService,
+    private readonly blockpartyService: BlockpartyService,
     private readonly minerActiveModeService: MinerActiveModeService,
     private readonly poolModeHashrateService: PoolModeHashrateService,
   ) {}
@@ -191,6 +193,7 @@ export class StratumV2Service implements OnModuleInit, IProtocolHandler {
       this.templateDistributionService,
       this.pplnsService,
       this.groupSoloService,
+      this.blockpartyService,
       this.minerActiveModeService,
       this.poolModeHashrateService,
     );


### PR DESCRIPTION
## Summary

Fourth payout mode: a **Blockparty** is a directed group of BTC addresses pooling hashpower (or a hashrate rental) against a single rental-administrator address, splitting every block on-chain by a **fixed percentage** the members agree up front — not pro-rata to work like Group-Solo.

Targets the rent-and-split use case: one admin orders Braiins hashpower, members signed on for known cuts get the coinbase outputs in the block itself.

## What's new

- New entities + migrations (\`blockparty_group\`, \`blockparty_member\` with \`memberTokenHash\`, \`blockparty_invitation\`, \`blockparty_block_history\`)
- State machine: \`DRAFT → CONFIRMING → READY → ACTIVE → DISSOLVED\` (7-day cooldown on dissolve)
- \`BlockpartyDistribution\` 5-phase coinbase math (base fee → miner cut → per-member floor → dust-trim → residual into pool fee). Sum-conservation proven.
- \`BlockpartyInvitationService\`: email-verified directed invites, per-\`(groupId,address)\` invitation reuse, lost-token recovery via \`resetMemberOnboarding\`
- Stratum wiring: SV1 + SV2 standard + extended route shares via \`getActiveBlockpartyGroupId\` ahead of PPLNS / Group-Solo. Address-driven, no separate port.
- \`pool_mode_hashrate\` writes the \`blockparty\` lane for the per-mode splash chart
- \`MiningModeService\` returns \`'blockparty'\` when the address admins an active party
- \`/api/blockparty/*\` controller (15 endpoints), admin-token-gated where appropriate
- Bidirectional mode-collision with \`PplnsGroup\` (an address can be in one or the other, never both)
- Typed errors: \`email-send-failed\` (502), \`config-missing\` (500), \`address-in-blockparty\`, \`invitation-pending\`, …

## Tests

- 49 unit specs (controller + service + distribution) all green
- E2E regtest: 2-member 50/50 split, Bitcoin Core 29 block acceptance + idempotency replay
- Mixed-address regtest: P2WPKH-Admin + P2PKH + P2TR + P2WPKH mix, sat-conservation exact across all five output script types

## Out of scope

- UI changes live in the matching \`feature/blockparty-mining-mode\` branch on \`blitzpool-ui\` (separate PR)
- JDP path is intentionally excluded; Blockparty doesn't extend the SV2 spec

## Test plan

- [x] \`npx jest blockparty --runInBand\` green on test-server PG container
- [x] Existing PPLNS + Group-Solo regtests still green (no shared-coinbase regression)
- [x] Test-server deploy: migration runs cleanly on a real PG instance with existing PPLNS data
- [x] Manual: create party, invite, accept, send shares from rental on admin address, find regtest block, verify coinbase outputs match agreed splits